### PR TITLE
Front/feat texte accueil

### DIFF
--- a/frontend/src/components/pages/_app/Root.tsx
+++ b/frontend/src/components/pages/_app/Root.tsx
@@ -25,7 +25,7 @@ export const Root: FunctionComponent<RootProps> = props => (
     hasError={props.hasError}
     eventId={props.errorEventId}
   >
-    <IntlProvider locale="en" messages={locales.en}>
+    <IntlProvider locale="fr" messages={locales.fr}>
       <Head>
         <link rel="manifest" href="/manifest.json" />
 

--- a/frontend/src/components/pages/home/Home.style.tsx
+++ b/frontend/src/components/pages/home/Home.style.tsx
@@ -1,13 +1,28 @@
 import styled from 'styled-components';
-import { borderRadius, getSpacing, typography, zIndex } from 'stylesheet';
+import { borderRadius, colorPalette, getSpacing, typography, zIndex } from 'stylesheet';
 
 export const HomeContainer = styled.div`
   display: flex;
   flex-direction: column;
-  align-items: center;
-  padding: ${getSpacing(10)};
+  align-items: stretch;
 `;
 HomeContainer.displayName = 'HomeContainer';
+
+export const TopContainer = styled.div`
+  text-align: center;
+  height: ${getSpacing(150)};
+  padding-top: ${getSpacing(80)};
+  padding-left: ${getSpacing(20)};
+  padding-right: ${getSpacing(20)};
+  background-color: ${colorPalette.amberDark};
+`;
+TopContainer.displayName = 'TopContainer';
+
+export const WelcomeText = styled.h1`
+  ${typography.h1};
+  font-size: 44px;
+  color: ${colorPalette.white};
+`;
 
 export const Logo = styled.img`
   width: ${getSpacing(32)};

--- a/frontend/src/components/pages/home/Home.style.tsx
+++ b/frontend/src/components/pages/home/Home.style.tsx
@@ -19,7 +19,7 @@ export const TopContainer = styled.div`
 TopContainer.displayName = 'TopContainer';
 
 export const WelcomeText = styled.h1`
-  ${typography.h1};
+  ${typography.h1}
   font-size: 44px;
   color: ${colorPalette.white};
 `;

--- a/frontend/src/components/pages/home/Home.tsx
+++ b/frontend/src/components/pages/home/Home.tsx
@@ -1,4 +1,5 @@
 import { FunctionComponent } from 'react';
+import { FormattedMessage } from 'react-intl';
 
 import { Layout } from 'components/Layout/Layout';
 import Button from 'components/Button';
@@ -15,6 +16,8 @@ import {
   Logo,
   MapContainer,
   Title,
+  TopContainer,
+  WelcomeText,
 } from './Home.style';
 
 const HomeUI: FunctionComponent<WrapperProps> = ({
@@ -25,6 +28,11 @@ const HomeUI: FunctionComponent<WrapperProps> = ({
 }) => (
   <Layout>
     <HomeContainer>
+      <TopContainer>
+        <WelcomeText>
+          <FormattedMessage id="home.welcome-text" />
+        </WelcomeText>
+      </TopContainer>
       <Logo alt="logo" src="/logo.png" />
       <Title>Welcome to Geotrek</Title>
       <HowTo>

--- a/frontend/src/translations/en.json
+++ b/frontend/src/translations/en.json
@@ -1,5 +1,6 @@
 {
   "home": {
+    "welcome-text": "L’écoguide numérique et local qui fabrique mes découvertes au Parc national des Ecrins.",
     "use-a-link": "Or use a link",
     "get-started": "To get started, edit",
     "save-to-reload": "and save to reload.",

--- a/frontend/src/translations/fr.json
+++ b/frontend/src/translations/fr.json
@@ -1,5 +1,6 @@
 {
   "home": {
+    "welcome-text": "L’écoguide numérique et local qui fabrique mes découvertes au Parc national des Ecrins.",
     "use-a-link": "Ou utilise un lien",
     "get-started": "Pour commencer, modifie",
     "save-to-reload": "et sauvegarde pour recharger.",


### PR DESCRIPTION
Ticket : [ETQU, sur la page Home, sur l'image de couverture, je vois un texte d'accueil](https://trello.com/c/1q8eQqqq/40-etqu-sur-la-page-home-sur-limage-de-couverture-je-vois-un-texte-daccueil)

- Ajout d'un TopContainer dans le dom de la vue Home
  -  Hauteur et marge fixées (non responsive pour le moment)
  - Contient le texte d'accueil
  - Arrière-plan uni en attendant l'image
- Modification du Home container (display stretch, retrait du padding) pour qu'il soit compatible avec le top container
- Ajout du message d'accueil dans les fichiers de traduction

![image](https://user-images.githubusercontent.com/67843879/103543383-b7c6f200-4e9e-11eb-80d7-a231c2dac589.png)
