### PR TITLE
:bento: (github) Add PR template in .github folder

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## Check before merging
+
+- [ ] Ticket : [Name]()
+- [ ] I made sure that all displayed texts are imported from translation files.
+- [ ] I made sure ticket is up to date on Trello.
+
+## Screenshots
+
+| Device | Screenshot |
+| ------ | ---------- |
+| Web    |            |
+| Mobile |            |


### PR DESCRIPTION
[ETQD, j'ai accès à un template quand je fais une PR sur github](https://trello.com/c/JaJkqhAF/53-etqd-jai-acc%C3%A8s-%C3%A0-un-template-quand-je-fais-une-pr-sur-github)

A basic template has been in a gihub folder for the project. Further improvements can be made. 

