### PR TITLE
(home) Make welcome text responsive for mobile

### DIFF
--- a/frontend/src/components/pages/home/Home.style.tsx
+++ b/frontend/src/components/pages/home/Home.style.tsx
@@ -1,7 +1,8 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import {
   borderRadius,
   colorPalette,
+  desktopOnly,
   getSpacing,
   oldGetSpacing,
   typography,
@@ -18,21 +19,26 @@ HomeContainer.displayName = 'HomeContainer';
 
 export const TopContainer = styled.div`
   text-align: center;
-  height: ${oldGetSpacing(150)};
-  padding-top: ${oldGetSpacing(80)};
-  padding-left: ${oldGetSpacing(20)};
-  padding-right: ${oldGetSpacing(20)};
   background-color: ${colorPalette.primary3};
   background-image: url('/images/home-background.jpg');
   background-size: cover;
   background-position: center;
+  padding: ${getSpacing(13)};
+  ${desktopOnly(css`
+    height: ${getSpacing(150)};
+    padding-top: ${getSpacing(85)};
+    padding-left: ${getSpacing(22)};
+    padding-right: ${getSpacing(22)};
+  `)}
 `;
 TopContainer.displayName = 'TopContainer';
 
 export const WelcomeText = styled.h1`
   ${typography.h1}
-  font-size: 44px;
   color: ${colorPalette.white};
+  ${desktopOnly(css`
+    font-size: ${getSpacing(8)};
+  `)}
 `;
 
 export const Logo = styled.img`


### PR DESCRIPTION
## Check before merging

- [x] Ticket : [ETQU mobile, sur la page Home, sur l'image de couverture, je vois un texte d'accueil [RESPONSIVE]](https://trello.com/c/KkWh6qRq/49-etqu-mobile-sur-la-page-home-sur-limage-de-couverture-je-vois-un-texte-daccueil-responsive)
- [x] I made sure that all displayed texts are imported from translation files.
- [x] I made sure ticket is up to date on Trello.

## Screenshots

| Device | Screenshot |
| ------ | ---------- |
| Mobile |       
![image](https://user-images.githubusercontent.com/67843879/103756099-275bef00-500f-11eb-8f03-8a091504cea2.png)
     |
