### PR TITLE
ETQU mobile sur la page Résultats, lorsque je scroll vers le bas le bouton flottant disparait puis réapparait au scroll vers le haut

### DIFF
--- a/frontend/src/components/OpenMapButton/OpenMapButton.tsx
+++ b/frontend/src/components/OpenMapButton/OpenMapButton.tsx
@@ -1,22 +1,35 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { borderRadius, colorPalette, getSpacing, typography, zIndex } from 'stylesheet';
 import { buttonCssResets } from 'services/cssHelpers';
 import { Map } from 'components/Icons/Map';
 import { FormattedMessage } from 'react-intl';
+import { useScrollDirection } from 'hooks/useScrollDirection';
 
 export const OpenMapButton: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement>> = ({
   ...nativeButtonProps
 }) => {
+  const scrollDirection = useScrollDirection();
+  const [buttonDisplayState, setButtonDisplayState] = useState<'SHOWN' | 'HIDDEN'>('SHOWN');
+
+  useEffect(() => {
+    setButtonDisplayState(scrollDirection === 'DOWN' ? 'HIDDEN' : 'SHOWN');
+  }, [scrollDirection]);
+
   return (
-    <MapButton type="button" {...nativeButtonProps} className="flex desktop:hidden">
+    <MapButton
+      type="button"
+      displayState={buttonDisplayState}
+      className="flex desktop:hidden"
+      {...nativeButtonProps}
+    >
       <FormattedMessage id="search.seeMap" />
       <Map size={24} className="ml-1" />
     </MapButton>
   );
 };
 
-const MapButton = styled.button`
+const MapButton = styled.button<{ displayState: 'SHOWN' | 'HIDDEN' }>`
   ${buttonCssResets}
 
   padding: ${getSpacing(3)} ${getSpacing(4)};
@@ -29,14 +42,17 @@ const MapButton = styled.button`
 
   position: fixed;
   z-index: ${zIndex.floatingButton};
-  bottom: ${getSpacing(6)};
+  bottom: ${({ displayState: showState }) => (showState === 'HIDDEN' ? '-100px' : getSpacing(6))};
 
   /* Horizontally center the button */
   left: 50%;
   transform: translateX(-50%);
 
   background-color: ${colorPalette.white};
-  transition: background-color 0.3s ease-in-out;
+
+  transition-property: background-color bottom;
+  transition-duration: 0.3s;
+  transition-timing-function: ease-in-out;
 
   &:hover {
     background-color: ${colorPalette.primary2};

--- a/frontend/src/hooks/useScrollDirection.ts
+++ b/frontend/src/hooks/useScrollDirection.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+
+export type ScrollDirections = 'UP' | 'DOWN' | null;
+
+const computeScrollDirection = (
+  currentPosition: number,
+  previousPosition: number,
+  scrollDetectionThreshold: number,
+): ScrollDirections => {
+  if (currentPosition <= scrollDetectionThreshold) return null;
+  if (currentPosition > previousPosition) return 'DOWN';
+  return 'UP';
+};
+
+/**
+ * Returns the direction of the last scrolling action of the user
+ */
+export const useScrollDirection = (
+  /** Scroll value below which the scroll direction will be null */
+  scrollDetectionThreshold = 0,
+): ScrollDirections => {
+  const [scrollDirection, setScrollDirection] = useState<ScrollDirections>(null);
+  let previousPosition: number;
+
+  // Necessary to avoid errors with Nextjs
+  if (typeof window !== 'undefined') {
+    previousPosition = window.scrollY;
+  }
+
+  const handleScrolling = () => {
+    const currentPosition = window.scrollY;
+    setScrollDirection(
+      computeScrollDirection(currentPosition, previousPosition, scrollDetectionThreshold),
+    );
+    previousPosition = currentPosition;
+  };
+
+  useEffect(() => {
+    window.addEventListener('scroll', handleScrolling);
+    return () => {
+      window.removeEventListener('scroll', handleScrolling);
+    };
+  }, []);
+
+  return scrollDirection;
+};


### PR DESCRIPTION
## Check before merging

- [x] Ticket : [ETQU mobile sur la page Résultats, lorsque je scroll vers le bas le bouton flottant disparait puis réapparait au scroll vers le haut](https://trello.com/c/F1C4IWHZ/83-1-etqu-mobile-sur-la-page-r%C3%A9sultats-lorsque-je-scroll-vers-le-bas-le-bouton-flottant-disparait-puis-r%C3%A9apparait-au-scroll-vers-le)
- [x] I made sure that all displayed texts are imported from translation files.
- [x] I made sure ticket is up to date on Trello.

## Screenshots

| Device | Screenshot |
| ------ | ---------- |
| Mobile | https://user-images.githubusercontent.com/48312749/103913863-53f43180-5109-11eb-99aa-47b17a396f9f.mov|
