### PR TITLE
Barre d'activité desktop

### DIFF
--- a/frontend/src/components/ActivitySearchFilter/ActivityButton/ActivityButton.style.ts
+++ b/frontend/src/components/ActivitySearchFilter/ActivityButton/ActivityButton.style.ts
@@ -8,11 +8,7 @@ export const ActivityButtonContainer = styled.button`
   display: flex;
   flex-direction: column;
   align-items: center;
-
-  /* We do a mix of padding and margin to have a pretty hover, padding + margin should add up to 6 */
-  padding: ${getSpacing(2)} ${getSpacing(5)};
-  margin: ${getSpacing(4)} ${getSpacing(1)};
-
+  margin-top: ${getSpacing(6)};
   color: ${colorPalette.greyDarkColored};
 
   background-color: ${colorPalette.white};

--- a/frontend/src/components/ActivitySearchFilter/ActivitySearchFilter.tsx
+++ b/frontend/src/components/ActivitySearchFilter/ActivitySearchFilter.tsx
@@ -113,10 +113,7 @@ interface Props {
 const MAX_VISIBLE_ACTIVITIES = 8;
 
 export const ActivitySearchFilter: React.FC<Props> = ({ className }) => {
-  const { activities, expandedState, setExpandedState } = useActivitySearchFilter();
-
-  const toggleExpandedState = () =>
-    setExpandedState(expandedState === 'EXPANDED' ? 'COLLAPSED' : 'EXPANDED');
+  const { activities, expandedState, toggleExpandedState } = useActivitySearchFilter();
 
   const collapseIsNeeded: boolean =
     activities !== undefined && activities.length > MAX_VISIBLE_ACTIVITIES;
@@ -163,7 +160,7 @@ const ControlCollapseButton: React.FC<{ expandedState: 'EXPANDED' | 'COLLAPSED' 
     return <ChevronDown size={48} className="transform rotate-180" />;
   }
   return (
-    <div className="flex flex-col items-center mr-5">
+    <div className="flex flex-col items-center mr-4">
       <MoreHorizontal size={48} />
       <FormattedMessage id="home.seeMore" />
     </div>

--- a/frontend/src/components/ActivitySearchFilter/ActivitySearchFilter.tsx
+++ b/frontend/src/components/ActivitySearchFilter/ActivitySearchFilter.tsx
@@ -113,8 +113,8 @@ interface Props {
 export const ActivitySearchFilter: React.FC<Props> = ({ className }) => {
   const { activities, expandedState, setExpandedState } = useActivitySearchFilter();
 
-  const setExpandOrCollapse = (): void =>
-    expandedState === 'EXPANDED' ? setExpandedState('COLLAPSED') : setExpandedState('EXPANDED');
+  const toggleExpandedState = () =>
+    setExpandedState(expandedState === 'EXPANDED' ? 'COLLAPSED' : 'EXPANDED');
 
   const collapseIsNeeded: boolean = activities !== undefined && activities.length > 8;
 
@@ -139,7 +139,7 @@ export const ActivitySearchFilter: React.FC<Props> = ({ className }) => {
           ))}
         </div>
         {collapseIsNeeded && (
-          <div className="self-end cursor-pointer" onClick={setExpandOrCollapse}>
+          <div className="self-end cursor-pointer" onClick={toggleExpandedState}>
             <ControlCollapseButton expandedState={expandedState} />
           </div>
         )}

--- a/frontend/src/components/ActivitySearchFilter/ActivitySearchFilter.tsx
+++ b/frontend/src/components/ActivitySearchFilter/ActivitySearchFilter.tsx
@@ -110,16 +110,21 @@ interface Props {
   className?: string;
 }
 
+const MAX_VISIBLE_ACTIVITIES = 8;
+
 export const ActivitySearchFilter: React.FC<Props> = ({ className }) => {
   const { activities, expandedState, setExpandedState } = useActivitySearchFilter();
 
   const toggleExpandedState = () =>
     setExpandedState(expandedState === 'EXPANDED' ? 'COLLAPSED' : 'EXPANDED');
 
-  const collapseIsNeeded: boolean = activities !== undefined && activities.length > 8;
+  const collapseIsNeeded: boolean =
+    activities !== undefined && activities.length > MAX_VISIBLE_ACTIVITIES;
 
   const visibleActivities: Activity[] | undefined =
-    collapseIsNeeded && expandedState === 'COLLAPSED' ? activities?.slice(0, 8) : activities;
+    collapseIsNeeded && expandedState === 'COLLAPSED'
+      ? activities?.slice(0, MAX_VISIBLE_ACTIVITIES)
+      : activities;
 
   return (
     <>

--- a/frontend/src/components/ActivitySearchFilter/ActivitySearchFilter.tsx
+++ b/frontend/src/components/ActivitySearchFilter/ActivitySearchFilter.tsx
@@ -1,4 +1,6 @@
 import { Arrow } from 'components/Icons/Arrow';
+import { ChevronDown } from 'components/Icons/ChevronDown';
+import { MoreHorizontal } from 'components/Icons/MoreHorizontal';
 import { Link } from 'components/Link';
 import { Activity } from 'modules/activities/interface';
 import React from 'react';
@@ -109,26 +111,56 @@ interface Props {
 }
 
 export const ActivitySearchFilter: React.FC<Props> = ({ className }) => {
-  const { activities } = useActivitySearchFilter();
+  const { activities, expandedState, setExpandedState } = useActivitySearchFilter();
+
+  const setExpandOrCollapse = (): void =>
+    expandedState === 'EXPANDED' ? setExpandedState('COLLAPSED') : setExpandedState('EXPANDED');
+
+  const collapseIsNeeded: boolean = activities !== undefined && activities.length > 8;
+
+  const visibleActivities: Activity[] | undefined =
+    collapseIsNeeded && expandedState === 'COLLAPSED' ? activities?.slice(0, 8) : activities;
 
   return (
     <>
       <div
-        className={`py-7 bg-white shadow-lg rounded-2xl overflow-scroll hidden desktop:inline-flex ${
+        className={`px-3 pb-6 bg-white shadow-lg rounded-2xl hidden self-center desktop:flex${
           className ?? ''
         }`}
+        style={{ maxWidth: '865px' }}
       >
-        {activities?.map(activity => (
-          <Link href={routes.SEARCH} key={activity.id}>
-            <ActivityButton iconUrl={activity.pictogram} key={activity.id}>
-              <span>{activity.name}</span>
-            </ActivityButton>
-          </Link>
-        ))}
+        <div className="flex content-evenly flex-wrap flex-1">
+          {visibleActivities?.map(activity => (
+            <Link href={routes.SEARCH} key={activity.id}>
+              <ActivityButton iconUrl={activity.pictogram} key={activity.id}>
+                <span>{activity.name}</span>
+              </ActivityButton>
+            </Link>
+          ))}
+        </div>
+        {collapseIsNeeded && (
+          <div className="self-end cursor-pointer" onClick={setExpandOrCollapse}>
+            <ControlCollapseButton expandedState={expandedState} />
+          </div>
+        )}
       </div>
       <div className="block desktop:hidden">
         <ActivitySearchFilterMobile activities={activities ?? []} />
       </div>
     </>
+  );
+};
+
+const ControlCollapseButton: React.FC<{ expandedState: 'EXPANDED' | 'COLLAPSED' }> = ({
+  expandedState,
+}) => {
+  if (expandedState === 'EXPANDED') {
+    return <ChevronDown size={48} className="transform rotate-180" />;
+  }
+  return (
+    <div className="flex flex-col items-center mr-5">
+      <MoreHorizontal size={48} />
+      <FormattedMessage id="home.seeMore" />
+    </div>
   );
 };

--- a/frontend/src/components/ActivitySearchFilter/useActivitySearchFilter.ts
+++ b/frontend/src/components/ActivitySearchFilter/useActivitySearchFilter.ts
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Activity } from 'modules/activities/interface';
 import { useQuery } from 'react-query';
 
@@ -6,5 +7,7 @@ import { getActivities } from '../../modules/activities/connector';
 export const useActivitySearchFilter = () => {
   const { data: activities } = useQuery<Activity[], Error>('activities', getActivities);
 
-  return { activities };
+  const [expandedState, setExpandedState] = useState<'EXPANDED' | 'COLLAPSED'>('COLLAPSED');
+
+  return { activities, expandedState, setExpandedState };
 };

--- a/frontend/src/components/ActivitySearchFilter/useActivitySearchFilter.ts
+++ b/frontend/src/components/ActivitySearchFilter/useActivitySearchFilter.ts
@@ -9,5 +9,14 @@ export const useActivitySearchFilter = () => {
 
   const [expandedState, setExpandedState] = useState<'EXPANDED' | 'COLLAPSED'>('COLLAPSED');
 
-  return { activities, expandedState, setExpandedState };
+  const toggleExpandedState = () =>
+    setExpandedState(currentExpandedState =>
+      currentExpandedState === 'EXPANDED' ? 'COLLAPSED' : 'EXPANDED',
+    );
+
+  return {
+    activities,
+    expandedState,
+    toggleExpandedState,
+  };
 };

--- a/frontend/src/components/Icons/MoreHorizontal/index.tsx
+++ b/frontend/src/components/Icons/MoreHorizontal/index.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { GenericIconProps } from '../types';
+
+export const MoreHorizontal: React.FC<GenericIconProps> = ({
+  color = 'currentColor',
+  opacity,
+  className,
+  size,
+}) => {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 48 48"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      opacity={opacity}
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M24 26a2 2 0 100-4 2 2 0 000 4zM38 26a2 2 0 100-4 2 2 0 000 4zM10 26a2 2 0 100-4 2 2 0 000 4z"
+        fill={color}
+        stroke={color}
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+};

--- a/frontend/src/translations/fr.json
+++ b/frontend/src/translations/fr.json
@@ -2,6 +2,7 @@
   "home": {
     "title": "Parc National des Écrins",
     "selectPlaceholder": "Sélectionner une activité",
+    "seeMore": "Voir plus",
     "welcome-text": "L’écoguide numérique et local qui fabrique mes découvertes au Parc national des Ecrins.",
     "use-a-link": "Ou utilise un lien",
     "get-started": "Pour commencer, modifie",


### PR DESCRIPTION
## Check before merging

- [x] Ticket : [(3) ETQU Desktop, je vois la barre d'activité avec plusieurs activités (vraies données)](https://trello.com/c/KoZZl06r/64-3-etqu-desktop-je-vois-la-barre-dactivit%C3%A9-avec-plusieurs-activit%C3%A9s-vraies-donn%C3%A9es)
- [x] I made sure that all displayed texts are imported from translation files.
- [x] I made sure ticket is up to date on Trello.

Only 4 activities are currently available from the back. For the screenshots, they have been duplicated to test with more than 8. This "hack" is not pushed, and if only 4 activities are available, the "see more" button does not appear (see the third image.

## Screenshots)

### Desktop
![image](https://user-images.githubusercontent.com/67843879/104322796-a35da780-54e5-11eb-89a4-ed433b09f531.png)
![image](https://user-images.githubusercontent.com/67843879/104322883-bf614900-54e5-11eb-84ce-6de9151e7bf1.png)
![image](https://user-images.githubusercontent.com/67843879/104324441-bb362b00-54e7-11eb-9d9a-010961b31d41.png)

