### PR TITLE
ETQUWeb, lorsque je clique sur le bouton voir plus, je vois l'ensemble des filtres et la flèche de rétractation

### DIFF
--- a/frontend/src/components/pages/search/components/FilterBar/FilterBar.tsx
+++ b/frontend/src/components/pages/search/components/FilterBar/FilterBar.tsx
@@ -30,13 +30,11 @@ export const FilterBar: React.FC<Props> = props => {
 
   const filterBarDisplayedState = useHideOnScrollDown(sizes.desktopHeader);
 
-  const filterBarContainerClassName = `w-full py-3 pl-6 pr-2 hidden desktop:block fixed shadow bg-white z-floatingButton ${
-    filterBarExpansionState === 'COLLAPSED' ? 'h-filterBar' : ''
-  }`;
+  const filterBarContainerClassName = `w-full py-3 pl-6 pr-2 hidden desktop:block fixed shadow bg-white z-floatingButton`;
 
   return (
     <Container className={filterBarContainerClassName} displayedState={filterBarDisplayedState}>
-      <div className={`${filterBarExpansionState === 'EXPANDED' ? 'mb-4' : 'h-filterBar'}`}>
+      <div className={`${filterBarExpansionState === 'EXPANDED' ? 'mb-4' : ''}`}>
         <FiltersLayout>
           {props.availableFilters &&
             props.availableFilters[TrekFilters.DIFFICULTY].options.length > 0 && (


### PR DESCRIPTION
It should be auto to correctly adjust to the flex-wrap when the user
selects many filters

## Check before merging

- [ ] Ticket : [ETQUWeb, lorsque je clique sur le bouton voir plus, je vois l'ensemble des filtres et la flèche de rétractation](https://trello.com/c/2iUej3fI/76-3-etquweb-lorsque-je-clique-sur-le-bouton-voir-plus-je-vois-lensemble-des-filtres-et-la-fl%C3%A8che-de-r%C3%A9tractation)
- [ ] I made sure that all displayed texts are imported from translation files.
- [ ] I made sure ticket is up to date on Trello.

## Screenshots

### Desktop
![image](https://user-images.githubusercontent.com/48312749/104429762-4665fe00-5586-11eb-9386-e3cf34b56498.png)

