### PR TITLE
Use lineclamp to cut text after 2 lines in activity cards

### DIFF
--- a/frontend/src/components/pages/home/components/ActivitySuggestionCard/ActivitySuggestionCard.tsx
+++ b/frontend/src/components/pages/home/components/ActivitySuggestionCard/ActivitySuggestionCard.tsx
@@ -3,9 +3,6 @@ export interface ActivitySuggestionCardProps {
   imgUrl: string;
 }
 
-const MAX_VISIBLE_CHARACTERS_DESKTOP = 80;
-const MAX_VISIBLE_CHARACTERS_MOBILE = 35;
-
 export const ActivitySuggestionCard: React.FC<ActivitySuggestionCardProps> = ({
   title,
   imgUrl,
@@ -26,32 +23,17 @@ export const ActivitySuggestionCard: React.FC<ActivitySuggestionCardProps> = ({
       >
         <img src={imgUrl}></img>
       </div>
-      <div
-        className="
-        text-primary1 font-bold
-        h-14 desktop:h-18
-        p-4
-        "
-      >
-        <TruncateTitle title={title} />
+      <div className="p-4">
+        <span
+          className="
+            text-primary1 font-bold
+            h-10 desktop:h-14
+            overflow-hidden"
+          style={{ display: '-webkit-box', WebkitBoxOrient: 'vertical', WebkitLineClamp: 2 }}
+        >
+          {title}
+        </span>
       </div>
     </div>
-  );
-};
-
-const TruncateTitle: React.FC<{ title: string }> = ({ title }) => {
-  const titleDesktop =
-    title.length > MAX_VISIBLE_CHARACTERS_DESKTOP
-      ? title.slice(0, MAX_VISIBLE_CHARACTERS_DESKTOP) + '...'
-      : title;
-  const titleMobile =
-    title.length > MAX_VISIBLE_CHARACTERS_MOBILE
-      ? title.slice(0, MAX_VISIBLE_CHARACTERS_MOBILE) + '...'
-      : title;
-  return (
-    <>
-      <span className="desktop:hidden">{titleMobile}</span>
-      <span className="hidden desktop:block">{titleDesktop}</span>
-    </>
   );
 };


### PR DESCRIPTION
## Check before merging

- [x] Ticket : [(3) ETQU, sur la page home, je vois une section "Randonnées du parc" avec une carte au design](https://trello.com/c/MwU4TKig/90-3-etqu-sur-la-page-home-je-vois-une-section-randonn%C3%A9es-du-parc-avec-une-carte-au-design)
- [x] I made sure ticket is up to date on Trello.

Special PR to test CSS feature on different navigators

## Screenshots

### Mobile Chrome
![image](https://user-images.githubusercontent.com/67843879/104457967-ffd6ca80-55aa-11eb-8955-e4439e165993.png)

### Desktop Chrome
![image](https://user-images.githubusercontent.com/67843879/104457988-06fdd880-55ab-11eb-9f40-b17d3404b5ae.png)

