### PR TITLE
ETQUMobile, lorsqu'un filtre d'une catégorie est sélectionné, je vois la catégorie en couleur avec en sous texte les filtres choisis

### DIFF
--- a/frontend/src/components/MobileFilterMenu/MobileFilterMenu.tsx
+++ b/frontend/src/components/MobileFilterMenu/MobileFilterMenu.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { slide as Slide } from 'react-burger-menu';
 
-import BurgerMenuSection from 'components/BurgerMenuSection/BurgerMenuSection';
 import { Cross } from 'components/Icons/Cross';
+
 import { CloseButton } from './CloseButton';
+import { MobileFilterMenuSection } from './MobileFilterMenuSection';
 
 interface Props {
   menuState: 'DISPLAYED' | 'HIDDEN';
@@ -41,7 +42,7 @@ export const MobileFilterMenu: React.FC<Props> = ({
         <span>{title}</span>
       </div>
       {filtersList.map(filter => (
-        <BurgerMenuSection title={filter.label} key={filter.id} onClick={filter.onSelect} />
+        <MobileFilterMenuSection title={filter.label} key={filter.id} onClick={filter.onSelect} />
       ))}
     </Slide>
   );

--- a/frontend/src/components/MobileFilterMenu/MobileFilterMenu.tsx
+++ b/frontend/src/components/MobileFilterMenu/MobileFilterMenu.tsx
@@ -10,7 +10,12 @@ interface Props {
   menuState: 'DISPLAYED' | 'HIDDEN';
   handleClose: () => void;
   title: React.ReactNode;
-  filtersList: { id: string; label: string; onSelect: () => void }[];
+  filtersList: {
+    id: string;
+    label: string;
+    onSelect: () => void;
+    selectedFiltersLabels: string[];
+  }[];
   closeMenu: () => void;
 }
 
@@ -42,7 +47,12 @@ export const MobileFilterMenu: React.FC<Props> = ({
         <span>{title}</span>
       </div>
       {filtersList.map(filter => (
-        <MobileFilterMenuSection title={filter.label} key={filter.id} onClick={filter.onSelect} />
+        <MobileFilterMenuSection
+          title={filter.label}
+          key={filter.id}
+          onClick={filter.onSelect}
+          selectedFiltersLabels={filter.selectedFiltersLabels}
+        />
       ))}
     </Slide>
   );

--- a/frontend/src/components/MobileFilterMenu/MobileFilterMenuSection/index.tsx
+++ b/frontend/src/components/MobileFilterMenu/MobileFilterMenuSection/index.tsx
@@ -11,27 +11,20 @@ export const MobileFilterMenuSection: React.FC<Props> = ({
   onClick,
   selectedFiltersLabels,
 }) => {
-  const classNameTitle = 'pt-4 pb-4 outline-none';
-  const classNameBorder = 'border-b pb-2 border-solid border-greySoft';
-
   const hasSelectedValues = selectedFiltersLabels.length > 0;
 
+  const classNameContainer = 'pt-4 pb-4 outline-none border-b border-solid border-greySoft';
+  const classNameSectionName = `font-bold text-Mobile-C1 ${
+    hasSelectedValues ? 'text-primary1' : 'text-greyDarkColored'
+  }`;
+  const classNameSelectedFiltersLabels = `text-Mobile-C3 overflow-ellipsis whitespace-nowrap overflow-hidden ${
+    hasSelectedValues ? 'mt-2' : ''
+  }`;
+
   return (
-    <div onClick={onClick} className={`${classNameTitle} ${classNameBorder}`}>
-      <div
-        className={`font-bold text-Mobile-C1 ${
-          hasSelectedValues ? 'text-primary1' : 'text-greyDarkColored'
-        }`}
-      >
-        {title}
-      </div>
-      <div
-        className={`text-Mobile-C3 overflow-ellipsis whitespace-nowrap overflow-hidden ${
-          hasSelectedValues ? 'mt-2' : ''
-        }`}
-      >
-        {selectedFiltersLabels.join(', ')}
-      </div>
+    <div onClick={onClick} className={`${classNameContainer}`}>
+      <div className={classNameSectionName}>{title}</div>
+      <div className={classNameSelectedFiltersLabels}>{selectedFiltersLabels.join(', ')}</div>
     </div>
   );
 };

--- a/frontend/src/components/MobileFilterMenu/MobileFilterMenuSection/index.tsx
+++ b/frontend/src/components/MobileFilterMenu/MobileFilterMenuSection/index.tsx
@@ -25,7 +25,13 @@ export const MobileFilterMenuSection: React.FC<Props> = ({
       >
         {title}
       </div>
-      <div className="mt-2 text-Mobile-C3">{selectedFiltersLabels?.[0]}</div>
+      <div
+        className={`text-Mobile-C3 overflow-ellipsis whitespace-nowrap overflow-hidden ${
+          hasSelectedValues ? 'mt-2' : ''
+        }`}
+      >
+        {selectedFiltersLabels.join(', ')}
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/MobileFilterMenu/MobileFilterMenuSection/index.tsx
+++ b/frontend/src/components/MobileFilterMenu/MobileFilterMenuSection/index.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export interface Props {
+  title: string;
+  onClick?: () => void;
+}
+
+export const MobileFilterMenuSection: React.FC<Props> = ({ title, onClick }) => {
+  const classNameTitle = 'flex items-center pt-4 pb-4 font-bold outline-none';
+  const classNameBorder = 'border-b pb-2 border-solid border-greySoft';
+
+  return (
+    <span onClick={onClick} className={`${classNameTitle} ${classNameBorder}`}>
+      {title}
+    </span>
+  );
+};

--- a/frontend/src/components/MobileFilterMenu/MobileFilterMenuSection/index.tsx
+++ b/frontend/src/components/MobileFilterMenu/MobileFilterMenuSection/index.tsx
@@ -11,15 +11,21 @@ export const MobileFilterMenuSection: React.FC<Props> = ({
   onClick,
   selectedFiltersLabels,
 }) => {
-  const classNameTitle = 'flex items-center pt-4 pb-4 font-bold outline-none';
+  const classNameTitle = 'pt-4 pb-4 outline-none';
   const classNameBorder = 'border-b pb-2 border-solid border-greySoft';
 
+  const hasSelectedValues = selectedFiltersLabels.length > 0;
+
   return (
-    <div>
-      <span onClick={onClick} className={`${classNameTitle} ${classNameBorder}`}>
+    <div onClick={onClick} className={`${classNameTitle} ${classNameBorder}`}>
+      <div
+        className={`font-bold text-Mobile-C1 ${
+          hasSelectedValues ? 'text-primary1' : 'text-greyDarkColored'
+        }`}
+      >
         {title}
-      </span>
-      <span>{selectedFiltersLabels?.[0]}</span>
+      </div>
+      <div className="mt-2 text-Mobile-C3">{selectedFiltersLabels?.[0]}</div>
     </div>
   );
 };

--- a/frontend/src/components/MobileFilterMenu/MobileFilterMenuSection/index.tsx
+++ b/frontend/src/components/MobileFilterMenu/MobileFilterMenuSection/index.tsx
@@ -3,15 +3,23 @@ import React from 'react';
 export interface Props {
   title: string;
   onClick?: () => void;
+  selectedFiltersLabels: string[];
 }
 
-export const MobileFilterMenuSection: React.FC<Props> = ({ title, onClick }) => {
+export const MobileFilterMenuSection: React.FC<Props> = ({
+  title,
+  onClick,
+  selectedFiltersLabels,
+}) => {
   const classNameTitle = 'flex items-center pt-4 pb-4 font-bold outline-none';
   const classNameBorder = 'border-b pb-2 border-solid border-greySoft';
 
   return (
-    <span onClick={onClick} className={`${classNameTitle} ${classNameBorder}`}>
-      {title}
-    </span>
+    <div>
+      <span onClick={onClick} className={`${classNameTitle} ${classNameBorder}`}>
+        {title}
+      </span>
+      <span>{selectedFiltersLabels?.[0]}</span>
+    </div>
   );
 };

--- a/frontend/src/components/MobileFilterMenu/useFilterMenu.ts
+++ b/frontend/src/components/MobileFilterMenu/useFilterMenu.ts
@@ -9,7 +9,12 @@ export const useFilterMenu = (
   menuState: 'DISPLAYED' | 'HIDDEN';
   displayMenu: () => void;
   hideMenu: () => void;
-  filtersList: { id: string; label: string; onSelect: () => void }[];
+  filtersList: {
+    id: string;
+    label: string;
+    onSelect: () => void;
+    selectedFiltersLabels: string[];
+  }[];
   activeFiltersNumber: number;
 } => {
   const [menuState, setMenuState] = useState<'DISPLAYED' | 'HIDDEN'>('HIDDEN');
@@ -21,6 +26,7 @@ export const useFilterMenu = (
     id: filterState.id,
     label: intl.formatMessage({ id: filterState.label }),
     onSelect: () => selectFilter(filterState.id),
+    selectedFiltersLabels: filterState.selectedOptions.map(option => option.label),
   }));
 
   const activeFiltersNumber = filtersState.reduce((selectedFiltersNb, currentFilter) => {


### PR DESCRIPTION
## Check before merging

- [x] Ticket : [ETQUMobile, lorsqu'un filtre d'une catégorie est sélectionné, je vois la catégorie en couleur avec en sous texte les filtres choisis](https://trello.com/c/KfqFdwhl/71-3-etqumobile-lorsquun-filtre-dune-cat%C3%A9gorie-est-s%C3%A9lectionn%C3%A9-je-vois-la-cat%C3%A9gorie-en-couleur-avec-en-sous-texte-les-filtres-chois)
- [x] I made sure that all displayed texts are imported from translation files.
- [x] I made sure ticket is up to date on Trello.

## Screenshots

### Mobile
![image](https://user-images.githubusercontent.com/48312749/105202415-421b8100-5b42-11eb-8681-f669f9223fca.png)


