### PR TITLE
ETQU Web, je vois le nom de la section où je suis en surbrillance dans le header - Retour de val

### DIFF
--- a/frontend/src/components/pages/details/Details.tsx
+++ b/frontend/src/components/pages/details/Details.tsx
@@ -5,6 +5,7 @@ import { MapDynamicComponent } from 'components/Map';
 import { useShowOnScrollPosition } from 'hooks/useShowOnScrollPosition';
 import { colorPalette, sizes, zIndex } from 'stylesheet';
 import { RemoteIconInformation } from 'components/Information/RemoteIconInformation';
+import { useRef } from 'react';
 import { DetailsPreview } from './components/DetailsPreview';
 import { DetailsSection } from './components/DetailsSection';
 import { DetailsDescription } from './components/DetailsDescription';
@@ -36,11 +37,20 @@ export const DetailsUI: React.FC<Props> = ({ detailsId }) => {
     sectionsPositions,
   } = useDetails(detailsId);
 
+  /** Ref of the parent of all sections */
+  const sectionsContainerRef = useRef<HTMLDivElement>(null);
+
   const { visibleSection } = useOnScreenSection({
     sectionsPositions,
-    // We add a -200 offset so that the highlighted section doesn't change right as the top of it get out of the screen (it switches when 200 pixel of it got out of the screen)
+    // The scroll offset is the height above the sections' container minus the headers size
+    // (we want the element detection to trigger when an element top reaches the header's bottom not the windows' top)
+    // Note that this scrollOffset is necessary because the sections' container
+    // position is relative, therefore its childrens' boundingClientRect are computed
+    // relative to the relative parent.
     scrollOffset:
-      sizes.detailsHeaderDesktop + sizes.desktopHeader - sizes.scrollOffsetBeforeElement - 200,
+      (sectionsContainerRef.current?.getBoundingClientRect().top ?? 0) -
+      sizes.desktopHeader -
+      sizes.detailsHeaderDesktop,
   });
 
   return (
@@ -83,6 +93,7 @@ export const DetailsUI: React.FC<Props> = ({ detailsId }) => {
                 className="desktop:py-0
                 desktop:relative desktop:-top-9
                 flex flex-col"
+                ref={sectionsContainerRef}
               >
                 <DetailsTopIcons
                   className={marginDetailsChild}

--- a/frontend/src/components/pages/details/hooks/useHighlightedSection.ts
+++ b/frontend/src/components/pages/details/hooks/useHighlightedSection.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { sizes } from 'stylesheet';
 import { DetailsSectionsPosition } from '../useDetails';
 
 /**
@@ -9,16 +10,31 @@ export const useOnScreenSection = ({
   scrollOffset,
 }: {
   sectionsPositions: DetailsSectionsPosition;
-  // Height of the page not taken into account when computing the sections'
-  // bounding clients rect. This happens when the container of the sections
-  // has a position: relative.
+  /**
+   * Height of the page not taken into account when computing the sections'
+   * bounding clients rect. This happens when the container of the sections
+   * has a position: relative.
+   */
   scrollOffset: number;
 }): { visibleSection: string | null } => {
   const [visibleSection, setVisibleSection] = useState<string | null>(null);
 
+  /** Number between 0 and 1, indicates which portion of the screen should the element take to appear on screen */
+  const screenProportionToTriggerElementHighlight = 2 / 3;
+
+  /** Height of the windows minus the headers */
+  let visibleScreenHeight = 0;
+  // Necessary check because we use Nextjs
+  if (typeof window !== 'undefined') {
+    visibleScreenHeight = window.innerHeight - sizes.desktopHeader - sizes.detailsHeaderDesktop;
+  }
+
   useEffect(() => {
     const handleScroll = () => {
-      const scrollPosition = window.scrollY - scrollOffset;
+      const scrollPosition =
+        window.scrollY -
+        scrollOffset +
+        (1 - screenProportionToTriggerElementHighlight) * visibleScreenHeight;
 
       const sectionOnScreen =
         // First check that the scroll position is between the top and bottom of elements

--- a/frontend/src/components/pages/details/hooks/useHighlightedSection.ts
+++ b/frontend/src/components/pages/details/hooks/useHighlightedSection.ts
@@ -9,14 +9,16 @@ export const useOnScreenSection = ({
   scrollOffset,
 }: {
   sectionsPositions: DetailsSectionsPosition;
-  /** If you increase this value the detection of the next element on screen will be triggered earlier in top to bottom scrolling */
+  // Height of the page not taken into account when computing the sections'
+  // bounding clients rect. This happens when the container of the sections
+  // has a position: relative.
   scrollOffset: number;
 }): { visibleSection: string | null } => {
   const [visibleSection, setVisibleSection] = useState<string | null>(null);
 
   useEffect(() => {
     const handleScroll = () => {
-      const scrollPosition = window.scrollY + scrollOffset;
+      const scrollPosition = window.scrollY - scrollOffset;
 
       const sectionOnScreen =
         // First check that the scroll position is between the top and bottom of elements

--- a/frontend/src/translations/fr.json
+++ b/frontend/src/translations/fr.json
@@ -59,11 +59,11 @@
     }
   },
   "details": {
-    "preview": "Aperçu",
+    "preview": "Présentation",
     "download": "Télécharger",
     "poi": "Patrimoines",
     "source": "Source",
-    "touristicContent": "À découvrir à proximité",
+    "touristicContent": "À proximité",
     "readMore": "lire la suite",
     "readLess": "lire moins",
     "description": "Description",


### PR DESCRIPTION
Amélioration de la détection des sections

## Check before merging

- [x] Ticket : [ETQU Web, je vois le nom de la section où je suis en surbrillance dans le header](https://trello.com/c/uwCwenpm/254-2-etqu-web-je-vois-le-nom-de-la-section-o%C3%B9-je-suis-en-surbrillance-dans-le-header)
- [x] I made sure that all displayed texts are imported from translation files.
- [x] I made sure ticket is up to date on Trello.
