### PR TITLE
Details/touristic badge

### DIFF
--- a/frontend/src/components/pages/details/Details.tsx
+++ b/frontend/src/components/pages/details/Details.tsx
@@ -257,6 +257,7 @@ export const DetailsUI: React.FC<Props> = ({ detailsId }) => {
                   <div ref={setTouristicContentsRef}>
                     <DetailsCardSection
                       title={intl.formatMessage({ id: 'details.touristicContent' })}
+                      displayBadge
                       detailsCards={details.touristicContents.map(touristicContent => ({
                         name: touristicContent.name ?? '',
                         place: touristicContent.category.label,

--- a/frontend/src/components/pages/details/components/DetailsCardSection/DetailsCardSection.tsx
+++ b/frontend/src/components/pages/details/components/DetailsCardSection/DetailsCardSection.tsx
@@ -3,15 +3,23 @@ import { marginDetailsChild } from '../../Details';
 import { DetailsCard, DetailsCardProps } from '../DetailsCard/DetailsCard';
 
 interface DetailsCardSectionProps {
+  displayBadge?: boolean;
   detailsCards: DetailsCardProps[];
   title: string;
 }
 
-export const DetailsCardSection: React.FC<DetailsCardSectionProps> = ({ detailsCards, title }) => {
+export const DetailsCardSection: React.FC<DetailsCardSectionProps> = ({
+  detailsCards,
+  title,
+  displayBadge = false,
+}) => {
   return (
     <div className="mt-6 desktop:mt-12">
-      <div className={`text-Mobile-H1 desktop:text-H2 font-bold ${marginDetailsChild}`}>
+      <div
+        className={`text-Mobile-H1 desktop:text-H2 font-bold ${marginDetailsChild} flex items-center`}
+      >
         {title}
+        {displayBadge && <Badge label={detailsCards.length} />}
       </div>
       <div
         className="flex desktop:flex-col items-stretch
@@ -34,6 +42,26 @@ export const DetailsCardSection: React.FC<DetailsCardSectionProps> = ({ detailsC
       <div className={marginDetailsChild}>
         <Separator />
       </div>
+    </div>
+  );
+};
+
+interface BadgeProps {
+  label: number;
+}
+
+export const Badge: React.FC<BadgeProps> = ({ label }) => {
+  return (
+    <div
+      className="h-8 w-8
+      ml-3
+      rounded-lg
+      grid place-items-center
+      border-solid border-primary1 border-3 shadow-sm
+      text-P1 desktop:text-H4 font-bold text-primary1
+      "
+    >
+      {label}
     </div>
   );
 };


### PR DESCRIPTION
## Check before merging

- [x] Ticket : [(1) ETQU, sur la page détails, je vois le nombre de contenu touristique à proximité à l'aide d'un badge à droite du titre de section](https://trello.com/c/vhHcH7xO/239-1-etqu-sur-la-page-d%C3%A9tails-je-vois-le-nombre-de-contenu-touristique-%C3%A0-proximit%C3%A9-%C3%A0-laide-dun-badge-%C3%A0-droite-du-titre-de-section)
- [x] I made sure ticket is up to date on Trello.

## Screenshots

### Mobile
![image](https://user-images.githubusercontent.com/67843879/107015218-cb66c080-679c-11eb-86a7-6636f01dd6fb.png)

### Desktop
![image](https://user-images.githubusercontent.com/67843879/107015256-d6b9ec00-679c-11eb-9923-e2d753d3e9be.png)
