### PR TITLE
feat ui (DetailsCardSection & ChildrenSection) fix overflow & scroll

### DIFF
--- a/frontend/src/components/pages/details/components/DetailsCardSection/DetailsCardSection.tsx
+++ b/frontend/src/components/pages/details/components/DetailsCardSection/DetailsCardSection.tsx
@@ -1,4 +1,6 @@
 import { Separator } from 'components/Separator';
+import styled from 'styled-components';
+import { colorPalette, getSpacing, sizes } from 'stylesheet';
 import { marginDetailsChild } from '../../Details';
 import { DetailsCard, DetailsCardProps } from '../DetailsCard/DetailsCard';
 
@@ -21,9 +23,10 @@ export const DetailsCardSection: React.FC<DetailsCardSectionProps> = ({
         {title}
         {displayBadge && <Badge label={detailsCards.length} />}
       </div>
-      <div
+      <ScrollContainer
         className="flex desktop:flex-col items-stretch
-        overflow-scroll desktop:max-h-detailsCardSection flex-nowrap
+        overflow-x-scroll desktop:overflow-x-hidden
+        overflow-y-hidden desktop:overflow-y-scroll flex-nowrap
         pb-5 mt-4 mb-2 desktop:mb-0
         px-4 desktop:pl-18 desktop:pr-9 desktop:mr-9"
       >
@@ -38,7 +41,7 @@ export const DetailsCardSection: React.FC<DetailsCardSectionProps> = ({
             logoUri={card.logoUri}
           />
         ))}
-      </div>
+      </ScrollContainer>
       <div className={marginDetailsChild}>
         <Separator />
       </div>
@@ -65,3 +68,19 @@ export const Badge: React.FC<BadgeProps> = ({ label }) => {
     </div>
   );
 };
+
+const offsetTopForTitle = 70;
+
+const ScrollContainer = styled.div`
+  &::-webkit-scrollbar {
+    width: ${getSpacing(2)};
+  }
+  &::-webkit-scrollbar-thumb {
+    background-color: ${colorPalette.greySoft};
+    opacity: 0.5;
+    border-radius: ${getSpacing(2)};
+  }
+  max-height: calc(
+    100vh - ${sizes.desktopHeader + sizes.detailsHeaderDesktop + offsetTopForTitle}px
+  );
+`;

--- a/frontend/src/components/pages/details/components/DetailsCardSection/DetailsCardSection.tsx
+++ b/frontend/src/components/pages/details/components/DetailsCardSection/DetailsCardSection.tsx
@@ -1,6 +1,6 @@
 import { Separator } from 'components/Separator';
 import styled from 'styled-components';
-import { colorPalette, getSpacing, sizes } from 'stylesheet';
+import { scrollBar, sizes } from 'stylesheet';
 import { marginDetailsChild } from '../../Details';
 import { DetailsCard, DetailsCardProps } from '../DetailsCard/DetailsCard';
 
@@ -73,12 +73,10 @@ const offsetTopForTitle = 70;
 
 const ScrollContainer = styled.div`
   &::-webkit-scrollbar {
-    width: ${getSpacing(2)};
+    ${scrollBar.root}
   }
   &::-webkit-scrollbar-thumb {
-    background-color: ${colorPalette.greySoft};
-    opacity: 0.5;
-    border-radius: ${getSpacing(2)};
+    ${scrollBar.thumb}
   }
   max-height: calc(
     100vh - ${sizes.desktopHeader + sizes.detailsHeaderDesktop + offsetTopForTitle}px

--- a/frontend/src/components/pages/details/components/DetailsChildrenSection/DetailsChildrenSection.tsx
+++ b/frontend/src/components/pages/details/components/DetailsChildrenSection/DetailsChildrenSection.tsx
@@ -2,7 +2,7 @@ import { Separator } from 'components/Separator';
 import { TrekResult } from 'modules/results/interface';
 import { ResultCard } from 'components/pages/search/components/ResultCard';
 import styled from 'styled-components';
-import { sizes } from 'stylesheet';
+import { colorPalette, getSpacing, sizes } from 'stylesheet';
 import { Step } from '../DetailsDescription';
 import { marginDetailsChild } from '../../Details';
 import { generateChildrenDetailsUrl } from '../../utils';
@@ -69,6 +69,14 @@ export const DetailsChildrenSection: React.FC<DetailsChildrenSectionProps> = ({
 const offsetTopForTitle = 130;
 
 const ScrollContainer = styled.div`
+  &::-webkit-scrollbar {
+    width: ${getSpacing(2)};
+  }
+  &::-webkit-scrollbar-thumb {
+    background-color: ${colorPalette.greySoft};
+    opacity: 0.5;
+    border-radius: ${getSpacing(2)};
+  }
   max-height: calc(
     100vh - ${sizes.desktopHeader + sizes.detailsHeaderDesktop + offsetTopForTitle}px
   );

--- a/frontend/src/components/pages/details/components/DetailsChildrenSection/DetailsChildrenSection.tsx
+++ b/frontend/src/components/pages/details/components/DetailsChildrenSection/DetailsChildrenSection.tsx
@@ -2,7 +2,7 @@ import { Separator } from 'components/Separator';
 import { TrekResult } from 'modules/results/interface';
 import { ResultCard } from 'components/pages/search/components/ResultCard';
 import styled from 'styled-components';
-import { colorPalette, getSpacing, sizes } from 'stylesheet';
+import { scrollBar, sizes } from 'stylesheet';
 import { Step } from '../DetailsDescription';
 import { marginDetailsChild } from '../../Details';
 import { generateChildrenDetailsUrl } from '../../utils';
@@ -70,12 +70,10 @@ const offsetTopForTitle = 130;
 
 const ScrollContainer = styled.div`
   &::-webkit-scrollbar {
-    width: ${getSpacing(2)};
+    ${scrollBar.root}
   }
   &::-webkit-scrollbar-thumb {
-    background-color: ${colorPalette.greySoft};
-    opacity: 0.5;
-    border-radius: ${getSpacing(2)};
+    ${scrollBar.thumb}
   }
   max-height: calc(
     100vh - ${sizes.desktopHeader + sizes.detailsHeaderDesktop + offsetTopForTitle}px

--- a/frontend/src/stylesheet.ts
+++ b/frontend/src/stylesheet.ts
@@ -157,5 +157,19 @@ export const sizes = {
   scrollOffsetBeforeElement: 36,
 };
 
+export const scrollBar = {
+  root: css`
+    height: ${getSpacing(2)};
+    ${desktopOnly(css`
+      width: ${getSpacing(2)};
+    `)}
+  `,
+  thumb: css`
+    background-color: ${colorPalette.greySoft};
+    opacity: 0.7;
+    border-radius: ${getSpacing(2)};
+  `,
+} as const;
+
 export const fillSvgWithColor = (color: string) => (svg: string): string =>
   svg.replace(/fill:.*?;/g, `fill: ${color};`);


### PR DESCRIPTION
## Check before merging

- [x] Ticket : [(1) ETQU, je vois la section patrimoines à une hauteur max de 100%](https://trello.com/c/u8JjqVTX/235-1-etqu-je-vois-la-section-patrimoines-%C3%A0-une-hauteur-max-de-100)
- [x] I made sure ticket is up to date on Trello.

Testé sous Safari, Chrome et Firefox pour le design des scrollbars 

## Screenshots

### Mobile
![image](https://user-images.githubusercontent.com/67843879/107234150-a5068680-6a23-11eb-886f-f8775f0dd65f.png)

### Desktop
![image](https://user-images.githubusercontent.com/67843879/107233635-1560d800-6a23-11eb-98bd-0d47a646212d.png)
