### PR TITLE
fix (header/inlineMenu) section title does not change when select value

### DIFF
--- a/frontend/src/components/InlineMenu/InlineMenu.tsx
+++ b/frontend/src/components/InlineMenu/InlineMenu.tsx
@@ -1,6 +1,5 @@
-import { ChevronDown } from 'components/Icons/ChevronDown';
 import { Heart } from 'components/Icons/Heart';
-import Dropdown, { Option } from 'react-dropdown';
+import Dropdown from 'react-dropdown';
 import ReactCountryFlag from 'react-country-flag';
 import { useIntl } from 'react-intl';
 import { MenuItem } from 'modules/header/interface';
@@ -42,12 +41,13 @@ const InlineMenu: React.FC<InlineMenuProps> = ({
           }))}
           controlClassName={controlClassName}
           menuClassName={menuClassName}
-          arrowClosed={<ArrowMenu />}
-          arrowOpen={<ArrowMenu />}
-          value={{
-            label: intl.formatMessage({ id: 'header.seeMore' }),
-            value: '',
-          }}
+          placeholderClassName="hidden"
+          arrowClosed={
+            <div className={sectionClassName}>{intl.formatMessage({ id: 'header.seeMore' })}</div>
+          }
+          arrowOpen={
+            <div className={sectionClassName}>{intl.formatMessage({ id: 'header.seeMore' })}</div>
+          }
           onChange={option =>
             isInternalFlatPageUrl(option.value)
               ? openInCurrentTab(option.value)
@@ -70,11 +70,13 @@ const InlineMenu: React.FC<InlineMenuProps> = ({
             label: language.toUpperCase(),
             className: optionClassName,
           }))}
-          value={supportedLanguages[0]}
           controlClassName={controlClassName}
           menuClassName={menuClassName}
-          arrowClosed={<ArrowMenu />}
-          arrowOpen={<ArrowMenu />}
+          placeholderClassName="hidden"
+          arrowClosed={
+            <div className={sectionClassName}>{supportedLanguages[0].toUpperCase()}</div>
+          }
+          arrowOpen={<div className={sectionClassName}>{supportedLanguages[0].toUpperCase()}</div>}
         />
       </div>
     </div>
@@ -82,19 +84,17 @@ const InlineMenu: React.FC<InlineMenuProps> = ({
 };
 
 const menuClassName =
-  'bg-white text-greyDarkColored rounded-2xl border border-solid border-greySoft overflow-hidden absolute py-2';
+  'bg-white text-greyDarkColored rounded-2xl border border-solid border-greySoft overflow-hidden absolute py-2 -ml-2 top-18';
 
 const controlClassName = 'pt-4 pb-2 mb-2 mr-4 text-white cursor-pointer flex items-center';
 
 const optionClassName = 'hover:bg-greySoft-light focus:bg-greySoft cursor-pointer px-5 py-2';
 
-const ArrowMenu: React.FC = () => <ChevronDown className="ml-1" size={24} />;
+const sectionClassName = 'pt-3 pb-2 mr-6 text-white cursor-pointer';
 
 const Section: React.FC<{ name: string; url?: string }> = ({ name, url }) => (
   <div
-    className="pt-3 pb-2 mr-6 text-white
-    border-b-4 hover:border-white border-transparent border-solid
-    cursor-pointer duration-500 transition-all"
+    className={`${sectionClassName} duration-500 transition-all border-b-4 hover:border-white border-transparent border-solid`}
   >
     {url !== undefined ? <a href={url}>{name}</a> : name}
   </div>


### PR DESCRIPTION
## Check before merging

- [x] Ticket : [(1) ETQU, je vois le titre de la section "En savoir plus" qui reste identique quand je navigue entre les pages satellites](https://trello.com/c/z7m7EO4B/341-1-etqu-je-vois-le-titre-de-la-section-en-savoir-plus-qui-reste-identique-quand-je-navigue-entre-les-pages-satellites)
- [x] I made sure that all displayed texts are imported from translation files.
- [x] I made sure ticket is up to date on Trello.

## Screenshots

### Desktop
![image](https://user-images.githubusercontent.com/67843879/107668378-e780cb00-6c90-11eb-885c-753a6cf5502d.png)
