### PR TITLE
General/fix UI ux

### DIFF
--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -28,19 +28,19 @@ export const Header: React.FC = () => {
         state={headerState}
         className="h-11 bg-primary1 flex flex-row items-center sticky z-header px-3"
       >
-        <div className="flex-shrink-0">
-          <Link href={routes.HOME}>
-            <img className="h-9 desktop:h-18 mr-3" alt="logo" src={config.logo} />
-          </Link>
-        </div>
-        <p
-          className="
-          flex-auto text-white
-          desktop:text-H2 desktop:leading-8
-          font-semibold desktop:font-bold"
-        >
-          <FormattedMessage id={'home.title'} />
-        </p>
+        <Link href={routes.HOME} className="flex items-center">
+          <div className="flex-shrink-0">
+            <img className="h-9 desktop:h-18 mr-3 rounded-md" alt="logo" src={config.logo} />
+          </div>
+          <p
+            className="
+            flex-auto text-white
+            desktop:text-H2 desktop:leading-8
+            font-semibold desktop:font-bold"
+          >
+            <FormattedMessage id={'home.title'} />
+          </p>
+        </Link>
         {(sectionsDesktop || subSections) && (
           <InlineMenu
             className="hidden desktop:flex items-center flex-auto justify-end"

--- a/frontend/src/components/pages/details/Details.tsx
+++ b/frontend/src/components/pages/details/Details.tsx
@@ -176,9 +176,12 @@ export const DetailsUI: React.FC<Props> = ({ detailsId, parentId }) => {
                       />
                     </div>
                   )}
-                  <div className="px-12">
+                  <DetailsSection
+                    titleId="details.altimetricProfile.title"
+                    className={marginDetailsChild}
+                  >
                     <div id="altimetric-profile"></div>
-                  </div>
+                  </DetailsSection>
 
                   {(details.labels.length > 0 ||
                     (details.advice !== null && details.advice.length > 0)) && (

--- a/frontend/src/components/pages/details/components/DetailsSection/DetailsSection.tsx
+++ b/frontend/src/components/pages/details/components/DetailsSection/DetailsSection.tsx
@@ -1,4 +1,7 @@
+import { Separator } from 'components/Separator';
 import { FormattedMessage } from 'react-intl';
+import styled from 'styled-components';
+import { scrollBar } from 'stylesheet';
 
 export interface DetailsSectionProps {
   titleId?: string;
@@ -8,23 +11,38 @@ export interface DetailsSectionProps {
 
 export const DetailsSection: React.FC<DetailsSectionProps> = ({ titleId, children, className }) => {
   return (
-    <div
-      className={`flex flex-col
-      py-6 desktop:py-12
-      border-solid border-greySoft border-b
-      ${className ?? ''}`}
-    >
-      {titleId !== undefined && (
-        <p className="text-Mobile-H1 desktop:text-H2 font-bold">
-          <FormattedMessage id={titleId} />
-        </p>
-      )}
-      <div
-        className="mt-3 desktop:mt-4
-        text-Mobile-C1 desktop:text-P1"
+    <div className={className}>
+      <ScrollContainer
+        className={`flex flex-col
+          pt-6 desktop:pt-12
+          pb-3 desktop:pb-6
+          mb-3 desktop:mb-6
+          `}
       >
-        {children}
-      </div>
+        {titleId !== undefined && (
+          <p className="text-Mobile-H1 desktop:text-H2 font-bold">
+            <FormattedMessage id={titleId} />
+          </p>
+        )}
+        <div
+          className="mt-3 desktop:mt-4
+        text-Mobile-C1 desktop:text-P1"
+        >
+          {children}
+        </div>
+      </ScrollContainer>
+      <Separator />
     </div>
   );
 };
+
+const ScrollContainer = styled.div`
+  &::-webkit-scrollbar {
+    ${scrollBar.root}
+  }
+  &::-webkit-scrollbar-thumb {
+    ${scrollBar.thumb}
+  }
+  max-width: 100%;
+  overflow-x: auto;
+`;

--- a/frontend/src/components/pages/details/useDetails.tsx
+++ b/frontend/src/components/pages/details/useDetails.tsx
@@ -25,6 +25,7 @@ interface SectionPosition {
 
 export interface DetailsSectionsPosition {
   preview?: SectionPosition;
+  children?: SectionPosition;
   poi?: SectionPosition;
   description?: SectionPosition;
   practicalInformations?: SectionPosition;

--- a/frontend/src/components/pages/touristicContent/TouristicContentUI.tsx
+++ b/frontend/src/components/pages/touristicContent/TouristicContentUI.tsx
@@ -144,7 +144,7 @@ export const TouristicContentUI: React.FC<TouristicContentUIProps> = ({ touristi
             </div>
             <div
               className="hidden desktop:flex desktop:z-content desktop:w-2/5
-            desktop:bottom-0 desktop:fixed desktop:right-0 desktop:top-0"
+              desktop:bottom-0 desktop:fixed desktop:right-0 desktop:top-desktopHeader"
             >
               <TouristicContentMapDynamicComponent
                 type="DESKTOP"

--- a/frontend/src/modules/touristicContent/adapter.ts
+++ b/frontend/src/modules/touristicContent/adapter.ts
@@ -118,7 +118,7 @@ export const adaptTouristicContentDetails = ({
   types: Object.entries(rawTCD.properties.types).reduce<TouristicContentDetailsType[]>(
     (adaptedTypes, typeEntry) => {
       const adaptedType = adaptTouristicType(typeEntry, touristicContentCategory);
-      if (adaptedType) {
+      if (adaptedType && adaptedType.values.length > 0) {
         adaptedTypes.push(adaptedType);
       }
       return adaptedTypes;

--- a/frontend/src/stylesheet.ts
+++ b/frontend/src/stylesheet.ts
@@ -80,7 +80,7 @@ export const colorPalette = {
     shadowOnImages: '#27041970',
   },
   map: {
-    touristicContentLines: 'orange',
+    touristicContentLines: '#D65600',
   },
 } as const;
 

--- a/frontend/src/translations/fr.json
+++ b/frontend/src/translations/fr.json
@@ -83,6 +83,7 @@
     "stationnement": "Stationnement",
     "access_parking": "Accès routiers et parkings",
     "altimetricProfile": {
+      "title":"Profil altimétrique",
       "totalLength": "Longueur totale",
       "minElevation": "Elevation min",
       "maxElevation": "Elevation max"


### PR DESCRIPTION
## Check before merging

- [x] Ticket : [Plusieurs fix UI/UX](https://trello.com/c/fBAQ7iZ0/371-plusieurs-fix-ui-ux)
  - ETQU, je peux revenir sur la page d'accueil en cliquant sur le titre dans le header
  - ETQU, je vois les lignes et les tracés géométriques des contenus touristiques dans un orange plus foncé
  - ETQU, je ne vois jamais de scrollbar horizontale globale sur une page
  - ETQU, je suis redirigé vers la bonne section de la page détail quand je clique dans le header
  - ETQU, si les types d'un contenu touristique sont vides je ne vois pas apparaitre les labels sur la page
  - ETQU web, sur la carte d'un contenu touristique, j'ai accès aux boutons de zoom
  - ETQU je vois un titre et des marges au design au dessus du profil altimétrique
- [x] I made sure that all displayed texts are imported from translation files.
- [x] I made sure ticket is up to date on Trello.

## Screenshots

### Mobile
![image](https://user-images.githubusercontent.com/67843879/108094482-20e57c00-707f-11eb-8755-9541c9462d43.png)
![image](https://user-images.githubusercontent.com/67843879/108094519-2f339800-707f-11eb-825c-cabfd1c09421.png)
![image](https://user-images.githubusercontent.com/67843879/108094543-38246980-707f-11eb-8a25-2223b8dcdbeb.png)
![image](https://user-images.githubusercontent.com/67843879/108094599-44a8c200-707f-11eb-8f39-20bb3248ea23.png)
![image](https://user-images.githubusercontent.com/67843879/108094759-73bf3380-707f-11eb-836e-660bd975eeda.png)

### Desktop
![image](https://user-images.githubusercontent.com/67843879/108094453-188d4100-707f-11eb-9a23-c8330a0f51d8.png)
![image](https://user-images.githubusercontent.com/67843879/108094643-525e4780-707f-11eb-9731-31c8943ff88e.png)
![image](https://user-images.githubusercontent.com/67843879/108094743-6bff8f00-707f-11eb-8994-9292a11c7901.png)
