### PR TITLE
:bug: (activitySearchFilter) use id AND type in mobile

### DIFF
--- a/frontend/src/components/ActivitySearchFilter/ActivitySearchFilter.tsx
+++ b/frontend/src/components/ActivitySearchFilter/ActivitySearchFilter.tsx
@@ -57,7 +57,7 @@ export const ActivitySearchFilter: React.FC<Props> = ({ className }) => {
             )}
           </div>
           <div className="block desktop:hidden">
-            <ActivitySearchFilterMobile activities={activities ?? {}} />
+            <ActivitySearchFilterMobile activities={activities ?? []} />
           </div>
         </>
       )}

--- a/frontend/src/components/ActivitySearchFilter/ActivitySearchFilterMobile/index.tsx
+++ b/frontend/src/components/ActivitySearchFilter/ActivitySearchFilterMobile/index.tsx
@@ -18,14 +18,16 @@ export const ActivitySearchFilterMobile: React.FC<{
 }> = ({ className, activities }) => {
   const { selectedActivityId, updateSelectedActivityId } = useActivitySearchFilterMobile();
 
-  const selectedActivity = activities.find(({ id }) => id === selectedActivityId);
+  const selectedActivity = activities.find(
+    ({ id, type }) => `${type}-${id}` === selectedActivityId,
+  );
 
   return (
     <div className={`${className ?? ''} flex space-x-4 items-center`}>
       <Select
         className="flex-1"
-        options={activities.map(({ id, name }) => ({
-          value: id,
+        options={activities.map(({ id, name, type }) => ({
+          value: `${type}-${id}`,
           label: name,
         }))}
         styles={selectStyles}

--- a/frontend/src/components/Map/index.tsx
+++ b/frontend/src/components/Map/index.tsx
@@ -1,14 +1,17 @@
+import { memo } from 'react';
 import dynamic from 'next/dynamic';
 import { PropsType as SearchMapProps } from './SearchMap';
 import { PropsType as DetailsMapProps } from './DetailsMap/DetailsMap';
 import { PropsType as TouristicContentMapProps } from './TouristicContentMap/TouristicContentMap';
 
-export const SearchMapDynamicComponent: React.FC<SearchMapProps> = props => {
+const SearchMapDynamicComponentWithoutMemo: React.FC<SearchMapProps> = props => {
   const SearchMap = dynamic(() => import('./SearchMap'), {
     ssr: false,
   });
   return <SearchMap {...props} />;
 };
+
+export const SearchMapDynamicComponent = memo(SearchMapDynamicComponentWithoutMemo);
 
 export const DetailsMapDynamicComponent: React.FC<DetailsMapProps> = props => {
   const DetailsMap = dynamic(() => import('./DetailsMap/DetailsMap'), {


### PR DESCRIPTION
PR to :
- fix ActivitySearchFilter behaviour in mobile
- prevent rerendering from the search page map