### PR TITLE
:bug: (details) show touristic content at right moment

### DIFF
--- a/frontend/src/components/pages/details/Details.tsx
+++ b/frontend/src/components/pages/details/Details.tsx
@@ -192,7 +192,7 @@ export const DetailsUIWithoutContext: React.FC<Props> = ({ detailsId, parentId, 
                       titleId="details.altimetricProfile.title"
                       className={marginDetailsChild}
                     >
-                      <div id="altimetric-profile"></div>
+                      <div className="h-90" id="altimetric-profile"></div>
                     </DetailsSection>
 
                     {(details.labels.length > 0 ||


### PR DESCRIPTION
PR to display touristic content at the right position on detail page