### PR TITLE
Add filter portal on filter

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "lint": "eslint --ext=jsx,ts,tsx src",
     "lint:fix": "eslint --ext=jsx,ts,tsx src --fix",
     "lint-style": "stylelint 'src/**/*.style.{ts,tsx}' 'src/**/style.{ts,tsx}'",
+    "prepush": "yarn lint && yarn tsc && yarn test",
     "type-check": "tsc -p src/tsconfig.json"
   },
   "stylelint": {

--- a/frontend/src/modules/accessibility/api.ts
+++ b/frontend/src/modules/accessibility/api.ts
@@ -1,3 +1,4 @@
+import { portalsFilter } from 'modules/utils/api.config';
 import { GeotrekAPI } from 'services/api/client';
 import { APIQuery, APIResponseForList } from 'services/api/interface';
 import { RawAccessibility } from './interface';
@@ -5,4 +6,7 @@ import { RawAccessibility } from './interface';
 export const fetchAccessibilities = (
   query: APIQuery,
 ): Promise<APIResponseForList<RawAccessibility>> =>
-  GeotrekAPI.url(`/trek_accessibility`).query(query).get().json();
+  GeotrekAPI.url(`/trek_accessibility`)
+    .query({ ...query, ...portalsFilter })
+    .get()
+    .json();

--- a/frontend/src/modules/activities/api.ts
+++ b/frontend/src/modules/activities/api.ts
@@ -1,3 +1,4 @@
+import { portalsFilter } from 'modules/utils/api.config';
 import { GeotrekAPI } from 'services/api/client';
 import { APIQuery, APIResponseForList } from 'services/api/interface';
 import { RawListActivity } from './interface';
@@ -9,5 +10,8 @@ export const fetchActivity = (query: APIQuery, id: number): Promise<RawListActiv
 export const fetchActivities = (
   query: APIQuery,
 ): Promise<APIResponseForList<Partial<RawListActivity>>> => {
-  return GeotrekAPI.url('/trek_practice').query(query).get().json();
+  return GeotrekAPI.url('/trek_practice')
+    .query({ ...query, ...portalsFilter })
+    .get()
+    .json();
 };

--- a/frontend/src/modules/details/connector.ts
+++ b/frontend/src/modules/details/connector.ts
@@ -74,6 +74,7 @@ export const getDetails = async (id: string, language: string): Promise<Details>
 };
 
 export const getTrekChildren = async (parentId: string, language: string): Promise<TrekChild[]> => {
+  if (parentId.length === 0) return [];
   try {
     const childrenIdsResult = await fetchTrekChildren({ language }, parentId);
     const childrenNames = await Promise.all(

--- a/frontend/src/modules/filters/accessibility/api.ts
+++ b/frontend/src/modules/filters/accessibility/api.ts
@@ -1,3 +1,4 @@
+import { portalsFilter } from 'modules/utils/api.config';
 import { GeotrekAPI } from 'services/api/client';
 import { APIQuery, APIResponseForList } from 'services/api/interface';
 import { RawAccessibilty } from './interface';
@@ -5,4 +6,7 @@ import { RawAccessibilty } from './interface';
 export const fetchAccessibilities = (
   query: APIQuery,
 ): Promise<APIResponseForList<RawAccessibilty>> =>
-  GeotrekAPI.url('/trek_accessibility').query(query).get().json();
+  GeotrekAPI.url('/trek_accessibility')
+    .query({ ...query, ...portalsFilter })
+    .get()
+    .json();

--- a/frontend/src/modules/filters/courseType/api.ts
+++ b/frontend/src/modules/filters/courseType/api.ts
@@ -1,9 +1,13 @@
+import { portalsFilter } from 'modules/utils/api.config';
 import { GeotrekAPI } from 'services/api/client';
 import { APIQuery, APIResponseForList } from 'services/api/interface';
 import { RawCourseType } from './interface';
 
 export const fetchCourseTypes = (query: APIQuery): Promise<APIResponseForList<RawCourseType>> =>
-  GeotrekAPI.url('/trek_route').query(query).get().json();
+  GeotrekAPI.url('/trek_route')
+    .query({ ...query, ...portalsFilter })
+    .get()
+    .json();
 
 export const fetchCourseType = (query: APIQuery, id: number): Promise<RawCourseType> =>
   GeotrekAPI.url(`/trek_route/${id}/`).query(query).get().json();

--- a/frontend/src/modules/filters/difficulties/api.ts
+++ b/frontend/src/modules/filters/difficulties/api.ts
@@ -1,3 +1,4 @@
+import { portalsFilter } from 'modules/utils/api.config';
 import { GeotrekAPI } from 'services/api/client';
 import { APIQuery, APIResponseForList } from 'services/api/interface';
 import { RawDifficulty } from '../interface';
@@ -5,7 +6,10 @@ import { RawDifficulty } from '../interface';
 export const fetchDifficulties = (
   query: APIQuery,
 ): Promise<APIResponseForList<Partial<RawDifficulty>>> =>
-  GeotrekAPI.url('/trek_difficulty').query(query).get().json();
+  GeotrekAPI.url('/trek_difficulty')
+    .query({ ...query, ...portalsFilter })
+    .get()
+    .json();
 
 export const fetchDifficulty = (query: APIQuery, id: number): Promise<RawDifficulty> =>
   GeotrekAPI.url(`/trek_difficulty/${id}/`).query(query).get().json();

--- a/frontend/src/modules/touristicContentCategory/api.ts
+++ b/frontend/src/modules/touristicContentCategory/api.ts
@@ -1,3 +1,4 @@
+import { portalsFilter } from 'modules/utils/api.config';
 import { GeotrekAPI } from 'services/api/client';
 import { APIQuery, APIResponseForList } from 'services/api/interface';
 import { RawTouristicContentCategory } from './interface';
@@ -5,7 +6,10 @@ import { RawTouristicContentCategory } from './interface';
 export const fetchTouristicContentCategories = (
   query: APIQuery,
 ): Promise<APIResponseForList<RawTouristicContentCategory>> =>
-  GeotrekAPI.url(`/touristiccontent_category`).query(query).get().json();
+  GeotrekAPI.url(`/touristiccontent_category`)
+    .query({ ...query, ...portalsFilter })
+    .get()
+    .json();
 
 export const fetchTouristicContentCategory = (
   query: APIQuery,


### PR DESCRIPTION
## Check before merging

- [x] Ticket : [(3) ETQU, je vois les valeurs des filtres correspondants au portail présent dans la config](https://trello.com/c/r8F6yRVo/413-3-etqu-je-vois-les-valeurs-des-filtres-correspondants-au-portail-pr%C3%A9sent-dans-la-config)
- [x] I made sure ticket is up to date on Trello.

## Screenshots
Exemple avec les types d'activité.
Filtre sur portail 1 : que 3 types d'activité :
<img width="1099" alt="Capture d’écran 2021-04-06 à 15 47 19" src="https://user-images.githubusercontent.com/67843879/113722869-1ba4c500-96f1-11eb-9218-77dfafa455ae.png">

Filtre sur portail 2 : un seul type d'activité : 
<img width="548" alt="Capture d’écran 2021-04-06 à 16 00 22" src="https://user-images.githubusercontent.com/67843879/113723003-38d99380-96f1-11eb-9b12-374fcc39b9a4.png">

Autre exemple, sur les niveaux de difficultés du portail 1 : 3 au lieu de 5 disponibles
<img width="1146" alt="Capture d’écran 2021-04-06 à 15 40 32" src="https://user-images.githubusercontent.com/67843879/113723096-4d1d9080-96f1-11eb-948d-1d6ba882c22b.png">



