### PR TITLE
:sparkles: (google analytics) disable google analytics by default

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -29,6 +29,7 @@ You can override all settings default values in files from `customization/config
 
 _Warning:_
 When setting up Google Analytics, you have to setup a flow. When setting up the flow, be careful to enter the corresponding url (the url of your website), otherwise the data will not be received.
+By default Google analytics is disabled (googleAnalyticsId set to null) you will have to override it in the global.json file of your customization folder.
 
 ## Colors
 

--- a/frontend/config/global.json
+++ b/frontend/config/global.json
@@ -3,7 +3,7 @@
   "mapResultsPageSize": 250,
   "portalIds": [],
   "apiUrl": "https://geotrekdemo.ecrins-parcnational.fr/api/v2",
-  "googleAnalyticsId": "G-8FSV2N4FXN",
+  "googleAnalyticsId": null,
   "baseUrl": "https://geotrek-rando-v3-pi.vercel.app",
   "fallbackImageUri": "https://upload.wikimedia.org/wikipedia/fr/d/df/Logo_ecrins.png",
   "fallbackTouristicContentUri": "https://upload.wikimedia.org/wikipedia/fr/d/df/Logo_ecrins.png",

--- a/frontend/src/modules/interface.ts
+++ b/frontend/src/modules/interface.ts
@@ -44,7 +44,7 @@ export interface APICallsConfig {
   mapResultsPageSize: number;
   portalIds: number[];
   apiUrl: string;
-  googleAnalyticsId: string;
+  googleAnalyticsId: string | null;
   baseUrl: string;
   fallbackImageUri: string;
   fallbackTouristicContentUri: string;

--- a/frontend/src/pages/_document.tsx
+++ b/frontend/src/pages/_document.tsx
@@ -33,20 +33,24 @@ export default class MyDocument extends Document {
     return (
       <Html>
         <Head>
-          <script
-            async
-            src={`https://www.googletagmanager.com/gtag/js?id=${googleAnalyticsId}`}
-          ></script>
-          <script
-            async
-            dangerouslySetInnerHTML={{
-              __html: `window.dataLayer = window.dataLayer || [];
-              function gtag(){dataLayer.push(arguments);}
-              gtag('js', new Date());
+          {!!googleAnalyticsId && (
+            <>
+              <script
+                async
+                src={`https://www.googletagmanager.com/gtag/js?id=${googleAnalyticsId}`}
+              ></script>
+              <script
+                async
+                dangerouslySetInnerHTML={{
+                  __html: `window.dataLayer = window.dataLayer || [];
+                  function gtag(){dataLayer.push(arguments);}
+                  gtag('js', new Date());
 
-              gtag('config', '${googleAnalyticsId}');`,
-            }}
-          />
+                  gtag('config', '${googleAnalyticsId}');`,
+                }}
+              />
+            </>
+          )}
         </Head>
         <body>
           <Main />


### PR DESCRIPTION
## Check before merging

- [x] Ticket : [[1] (2) ETQGestionnaire de Parc, si je n'ajoute pas d'id de google analytics, je ne peux pas trouver l'id par défaut lorsque j'ouvre la console et que j'inspecte le DOM sur la page home](https://trello.com/c/stTR5g62/433-2-etqgestionnaire-de-parc-si-je-najoute-pas-did-de-google-analytics-je-ne-peux-pas-trouver-lid-par-d%C3%A9faut-lorsque-jouvre-la-cons)
- [x] I made sure that all displayed texts are imported from translation files.
- [x] I made sure ticket is up to date on Trello.

## ~~Screenshots~~

### ~~Mobile~~

### ~~Desktop~~
