### PR TITLE
Search/text filter enter and placeholder

### DIFF
--- a/frontend/src/components/pages/search/components/InputWithMagnifier/InputWithMagnifier.tsx
+++ b/frontend/src/components/pages/search/components/InputWithMagnifier/InputWithMagnifier.tsx
@@ -1,5 +1,5 @@
 import { Search } from 'components/Icons/Search';
-import React, { ChangeEvent, FunctionComponent } from 'react';
+import React, { ChangeEvent, FunctionComponent, KeyboardEvent } from 'react';
 import { colorPalette } from 'stylesheet';
 import CustomizedInput from './CustomizedInput.style';
 
@@ -14,9 +14,21 @@ const InputWithMagnifier: FunctionComponent<InputWithMagnifierProps> = ({
   value,
   onButtonClick,
 }) => {
+  const onInputEnterPress = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      onButtonClick();
+    }
+  };
+
   return (
     <div className="flex flex-row w-full desktop:w-auto">
-      <CustomizedInput onChange={onChange} value={value !== null ? value : ''} type="text" />
+      <CustomizedInput
+        onChange={onChange}
+        value={value !== null ? value : ''}
+        type="text"
+        onKeyPress={onInputEnterPress}
+        placeholder="Rechercher"
+      />
       <div
         className="w-10 h-10 desktop:h-12 desktop:w-12 bg-primary1 rounded-r-md
         flex justify-center items-center

--- a/frontend/src/components/pages/search/components/InputWithMagnifier/InputWithMagnifier.tsx
+++ b/frontend/src/components/pages/search/components/InputWithMagnifier/InputWithMagnifier.tsx
@@ -1,5 +1,6 @@
 import { Search } from 'components/Icons/Search';
 import React, { ChangeEvent, FunctionComponent, KeyboardEvent } from 'react';
+import { useIntl } from 'react-intl';
 import { colorPalette } from 'stylesheet';
 import CustomizedInput from './CustomizedInput.style';
 
@@ -14,6 +15,8 @@ const InputWithMagnifier: FunctionComponent<InputWithMagnifierProps> = ({
   value,
   onButtonClick,
 }) => {
+  const intl = useIntl();
+
   const onInputEnterPress = (event: KeyboardEvent<HTMLInputElement>) => {
     if (event.key === 'Enter') {
       onButtonClick();
@@ -27,7 +30,7 @@ const InputWithMagnifier: FunctionComponent<InputWithMagnifierProps> = ({
         value={value !== null ? value : ''}
         type="text"
         onKeyPress={onInputEnterPress}
-        placeholder="Rechercher"
+        placeholder={intl.formatMessage({ id: 'search.textFilter' })}
       />
       <div
         className="w-10 h-10 desktop:h-12 desktop:w-12 bg-primary1 rounded-r-md

--- a/frontend/src/components/pages/search/components/InputWithMagnifier/__snapshots__/InputWithMagnifier.test.tsx.snap
+++ b/frontend/src/components/pages/search/components/InputWithMagnifier/__snapshots__/InputWithMagnifier.test.tsx.snap
@@ -10,6 +10,7 @@ Object {
       >
         <input
           class="Inputstyle__Input-m8ywjr-0 CustomizedInputstyle__CustomizedInput-hiqqyy-0 ftUolv hXCUVP"
+          placeholder="Rechercher..."
           type="text"
           value=""
         />
@@ -48,6 +49,7 @@ Object {
     >
       <input
         class="Inputstyle__Input-m8ywjr-0 CustomizedInputstyle__CustomizedInput-hiqqyy-0 ftUolv hXCUVP"
+        placeholder="Rechercher..."
         type="text"
         value=""
       />

--- a/frontend/src/translations/en.json
+++ b/frontend/src/translations/en.json
@@ -53,6 +53,7 @@
       "structures": "Structure",
       "clearAll": "Clear all"
     },
+    "textFilter": "Search...",
     "map": {
       "seeResult": "Display details"
     }

--- a/frontend/src/translations/fr.json
+++ b/frontend/src/translations/fr.json
@@ -53,6 +53,7 @@
       "structures": "Structure",
       "clearAll": "Tout effacer"
     },
+    "textFilter": "Rechercher...",
     "map": {
       "seeResult": "Afficher le détail"
     }


### PR DESCRIPTION
## Check before merging

- [ ] Ticket : [ETQU, sur la page de recherche, lorsque je clique sur la touche entrée, les treks sont filtrées par texte et je vois un placeholder](https://trello.com/c/tRKqGInZ/448-2-etqu-sur-la-page-de-recherche-lorsque-je-clique-sur-la-touche-entr%C3%A9e-les-treks-sont-filtr%C3%A9es-par-texte-et-je-vois-un-placehold)
- [ ] I made sure that all displayed texts are imported from translation files.
- [ ] I made sure ticket is up to date on Trello.

## Screenshots

### Mobile

### Desktop
<img width="1438" alt="Capture d’écran 2021-04-15 à 10 31 05" src="https://user-images.githubusercontent.com/34058526/114839195-c8f49880-9dd5-11eb-9dfe-95f2e0a41b8f.png">
