### PR TITLE
:building_construction: (customization) move ecrin specific config fr…

### DIFF
--- a/frontend/config/footer.json
+++ b/frontend/config/footer.json
@@ -1,29 +1,10 @@
 {
-  "socialNetworks": [
-    { "id": "facebook", "url": "https://www.facebook.com/parcnationaldesecrins/" },
-    { "id": "twitter", "url": "https://twitter.com/pnecrins" }
-  ],
+  "socialNetworks": [],
   "links": [
-    { "label": "footer.links", "url": "https://www.ecrins-parcnational.fr/liens-internet" },
-    { "label": "footer.access", "url": "https://www.ecrins-parcnational.fr/venir-dans-les-ecrins" },
-    {
-      "label": "footer.legalMentions",
-      "url": "https://www.ecrins-parcnational.fr/mentions-legales"
-    },
-    {
-      "label": "footer.accessibility",
-      "url": "https://www.ecrins-parcnational.fr/regles-daccessibilite"
-    },
     {
       "label": "footer.geotrek",
       "url": "https://geotrek.fr/"
     }
   ],
-  "contact": {
-    "name": "Parc National des Écrins",
-    "addressLine1": "Domaine de Charance",
-    "addressLine2": "05000 Gap",
-    "number": "04 92 40 20 10",
-    "mail": "info@ecrins-parcnational.fr"
-  }
+  "contact": {}
 }

--- a/frontend/config/home.json
+++ b/frontend/config/home.json
@@ -10,16 +10,5 @@
   "activityBar": {
     "shouldDisplay": true
   },
-  "suggestions": [
-    {
-      "titleTranslationId": "home.territoryTreks",
-      "iconUrl": "/icons/practice-pedestrian.svg",
-      "ids": ["2", "582", "586", "501", "771", "596", "604"]
-    },
-    {
-      "titleTranslationId": "home.itinerantTreks",
-      "iconUrl": "/icons/practice-pedestrian.svg",
-      "ids": ["501", "771"]
-    }
-  ]
+  "suggestions": []
 }

--- a/frontend/customization/config/footer.json
+++ b/frontend/customization/config/footer.json
@@ -1,1 +1,29 @@
-{}
+{
+  "socialNetworks": [
+    { "id": "facebook", "url": "https://www.facebook.com/parcnationaldesecrins/" },
+    { "id": "twitter", "url": "https://twitter.com/pnecrins" }
+  ],
+  "links": [
+    { "label": "footer.links", "url": "https://www.ecrins-parcnational.fr/liens-internet" },
+    { "label": "footer.access", "url": "https://www.ecrins-parcnational.fr/venir-dans-les-ecrins" },
+    {
+      "label": "footer.legalMentions",
+      "url": "https://www.ecrins-parcnational.fr/mentions-legales"
+    },
+    {
+      "label": "footer.accessibility",
+      "url": "https://www.ecrins-parcnational.fr/regles-daccessibilite"
+    },
+    {
+      "label": "footer.geotrek",
+      "url": "https://geotrek.fr/"
+    }
+  ],
+  "contact": {
+    "name": "Parc National des Écrins",
+    "addressLine1": "Domaine de Charance",
+    "addressLine2": "05000 Gap",
+    "number": "04 92 40 20 10",
+    "mail": "info@ecrins-parcnational.fr"
+  }
+}

--- a/frontend/customization/config/global.json
+++ b/frontend/customization/config/global.json
@@ -1,3 +1,11 @@
 {
+  "searchResultsPageSize": 10,
+  "mapResultsPageSize": 250,
+  "portalIds": [],
+  "apiUrl": "https://geotrekdemo.ecrins-parcnational.fr/api/v2",
+  "googleAnalyticsId": "G-8FSV2N4FXN",
+  "baseUrl": "https://geotrek-rando-v3-pi.vercel.app",
+  "fallbackImageUri": "https://upload.wikimedia.org/wikipedia/fr/d/df/Logo_ecrins.png",
+  "fallbackTouristicContentUri": "https://upload.wikimedia.org/wikipedia/fr/d/df/Logo_ecrins.png",
   "applicationName": "Custom Geotrek"
 }

--- a/frontend/customization/config/header.json
+++ b/frontend/customization/config/header.json
@@ -1,1 +1,9 @@
-{}
+{
+  "menu": {
+    "primaryItemsNumber": 3,
+    "shouldDisplayFavorite": false,
+    "supportedLanguages": ["fr", "en"],
+    "defaultLanguage": "fr"
+  },
+  "logo": "https://geotrek.ecrins-parcnational.fr/PNX-logo.png"
+}

--- a/frontend/customization/config/home.json
+++ b/frontend/customization/config/home.json
@@ -1,1 +1,25 @@
-{}
+{
+  "welcomeBanner": {
+    "carouselUrls": [
+      "https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_1280.jpg",
+      "https://images.pexels.com/photos/869258/pexels-photo-869258.jpeg?auto=compress&cs=tinysrgb&h=750&w=1260",
+      "https://images.pexels.com/photos/4275885/pexels-photo-4275885.jpeg?auto=compress&cs=tinysrgb&h=750&w=1260"
+    ],
+    "shouldDisplayText": true
+  },
+  "activityBar": {
+    "shouldDisplay": true
+  },
+  "suggestions": [
+    {
+      "titleTranslationId": "home.territoryTreks",
+      "iconUrl": "/icons/practice-pedestrian.svg",
+      "ids": ["2", "582", "586", "501", "771", "596", "604"]
+    },
+    {
+      "titleTranslationId": "home.itinerantTreks",
+      "iconUrl": "/icons/practice-pedestrian.svg",
+      "ids": ["501", "771"]
+    }
+  ]
+}

--- a/frontend/customization/config/map.json
+++ b/frontend/customization/config/map.json
@@ -1,1 +1,6 @@
-{}
+{
+  "searchMapCenter": [44.8, 6.3],
+  "searchMapZoom": 10,
+  "mapCredits": "OpenTopoMap",
+  "mapLayerUrl": "https://a.tile.opentopomap.org/{z}/{x}/{y}.png"
+}


### PR DESCRIPTION
…om default config to default c…

## Check before merging

- [x] Ticket : <blockquote class="trello-card"><a href="https://trello.com/c/L0iBDGTS/434-1-etqgestionnaire-de-parc-si-je-ne-renseigne-pas-did-de-randonn%C3%A9e-dans-la-customization-du-composant-de-recommandation-de-randon">(1) ETQGestionnaire de parc si je ne renseigne pas d&#39;id de randonnée dans la customization du composant de recommandation de randonnées sur la home, je ne vois pas les randonnées du parc des écrins</a></blockquote>


