### PR TITLE
Increase clusteringMaxZoom - Fix #367

### DIFF
--- a/frontend/src/components/Map/components/ClusterContainer/index.tsx
+++ b/frontend/src/components/Map/components/ClusterContainer/index.tsx
@@ -15,7 +15,7 @@ const clusterRadiusThreshold = 13;
 const lowZoomClusterRadius = 40;
 const highZoomClusterRadius = 20;
 /** Above this zoom level there won't be clustering, the user better sees its trek course on the map when clicking on the marker */
-const clusteringMaxZoom = 15;
+const clusteringMaxZoom = 18;
 
 /**
  * Wraps MarkerClusterGroup to enable/disable it easily


### PR DESCRIPTION
Increase ``clusteringMaxZoom`` to zoom level 18, so that we can still custer near objects on map, when zooming to max on map.