### PR TITLE
Display type of use and labels information values separated by commas

### DIFF
--- a/frontend/src/components/pages/search/components/ResultCard/ResultCard.tsx
+++ b/frontend/src/components/pages/search/components/ResultCard/ResultCard.tsx
@@ -139,9 +139,7 @@ export const ResultCard: React.FC<TrekProps | TouristicContentProps> = props => 
                     values.length > 0 && (
                       <div key={label} className="text-greyDarkColored">
                         <span className="font-bold">{`${label} : `}</span>
-                        {values.map(value => (
-                          <span key={value}>{value}</span>
-                        ))}
+                        {values.join(', ')}
                       </div>
                     ),
                 )}


### PR DESCRIPTION
The values of the "label" and "type of use" informations are displayed without separations (not even a space).
This PR adds a comma between each value.

## Screenshots
![image](https://user-images.githubusercontent.com/1926041/137759938-36c4c7a9-069f-46ed-baaf-d5645857158f.png)
Left: GTR3 / Right: admin
