### PR TITLE
Pass `pictogramUrl` property to Themes filter items

### DIFF
--- a/frontend/src/modules/filters/theme/adapter.ts
+++ b/frontend/src/modules/filters/theme/adapter.ts
@@ -12,7 +12,11 @@ export const adaptTheme = (rawTheme: RawTheme): Theme => ({
 
 export const adaptThemeFilter = (rawThemes: Partial<RawTheme>[]): FilterWithoutType => ({
   id: THEME_ID,
-  options: rawThemes.filter(isRawThemeComplete).map(adaptTheme),
+  options: rawThemes.filter(isRawThemeComplete).map(rawTheme => ({
+    value: `${rawTheme.id}`,
+    label: rawTheme.label,
+    pictogramUrl: rawTheme.pictogram,
+  })),
 });
 
 export const adaptThemes = (rawThemes: Partial<RawTheme>[]): Choices =>


### PR DESCRIPTION
## Check before merging

- [x] Ticket : [Les picto des Thèmes saisis dans le Geotrek Admin ne sont pas remontés dans les filtres de recherche Geotrek Rando](https://github.com/GeotrekCE/Geotrek-rando-v3/issues/556)

