### PR TITLE
Fix MobileFilterMenu with enableOutdoor and or enableTouristicEvents are set to false

### DIFF
--- a/frontend/src/components/MobileFilterMenu/MobileFilterMenu.tsx
+++ b/frontend/src/components/MobileFilterMenu/MobileFilterMenu.tsx
@@ -5,6 +5,8 @@ import Slide from 'react-burger-menu/lib/menus/slide';
 
 import { Cross } from 'components/Icons/Cross';
 import getActivityColor from 'components/pages/search/components/ResultCard/getActivityColor';
+import { CATEGORY_ID, EVENT_ID, OUTDOOR_ID, PRACTICE_ID } from 'modules/filters/constant';
+import useCounter from 'components/pages/search/hooks/useCounter';
 import { FilterCategory, FilterState } from '../../modules/filters/interface';
 import { countFiltersSelected } from '../../modules/filters/utils';
 
@@ -18,6 +20,7 @@ interface Props {
   filtersList: FilterCategory[];
   resetFilter: () => void;
   resultsNumber: number;
+  language: string;
 }
 
 export const MobileFilterMenu: React.FC<Props> = ({
@@ -27,7 +30,11 @@ export const MobileFilterMenu: React.FC<Props> = ({
   resetFilter,
   resultsNumber,
   filtersList,
+  language,
 }) => {
+  const { treksCount, touristicContentsCount, outdoorSitesCount, touristicEventsCount } =
+    useCounter({ language });
+
   return (
     /*
      * The library default behaviour is to have a fixed close icon which
@@ -52,8 +59,12 @@ export const MobileFilterMenu: React.FC<Props> = ({
 
       <div>
         {filtersList.map(item => {
-          const numberSelected = countFiltersSelected(filtersState, item.filters, item.subFilters);
+          if (treksCount === 0 && item.id === PRACTICE_ID) return null;
+          if (touristicContentsCount === 0 && item.id === CATEGORY_ID) return null;
+          if (outdoorSitesCount === 0 && item.id === OUTDOOR_ID) return null;
+          if (touristicEventsCount === 0 && item.id === EVENT_ID) return null;
 
+          const numberSelected = countFiltersSelected(filtersState, item.filters, item.subFilters);
           return (
             <MobileFilterMenuSection
               color={getActivityColor(item.id)}

--- a/frontend/src/components/pages/search/Search.tsx
+++ b/frontend/src/components/pages/search/Search.tsx
@@ -111,6 +111,7 @@ export const SearchUI: React.FC<Props> = ({ language }) => {
               filtersList={filtersList}
               resetFilter={onRemoveAllFiltersClick}
               resultsNumber={searchResults?.resultsNumber ?? 0}
+              language={language}
             />
           )}
           {subMenuState === 'DISPLAYED' && (


### PR DESCRIPTION
## Check before merging

- [x] Ticket : [Catégories des filtres en version mobile](https://github.com/GeotrekCE/Geotrek-rando-v3/issues/586)
- [x] I made sure that all displayed texts are imported from translation files.
