### PR TITLE
Improve anchor system in detail page

### DIFF
--- a/frontend/src/components/pages/details/Details.tsx
+++ b/frontend/src/components/pages/details/Details.tsx
@@ -597,7 +597,7 @@ export const DetailsUIWithoutContext: React.FC<Props> = ({ detailsId, parentId, 
         )}
       </>
     ),
-    [details, isLoading, mobileMapState, sectionsPositions],
+    [details, isLoading, mobileMapState],
   );
 };
 

--- a/frontend/src/components/pages/details/utils.tsx
+++ b/frontend/src/components/pages/details/utils.tsx
@@ -105,11 +105,11 @@ export const getDimensions = (htmlElement: HTMLElement | null): { top: number; b
   if (htmlElement === null) return { top: 0, bottom: 0 };
   const { height } = htmlElement.getBoundingClientRect();
   const elementTopPosition = htmlElement.offsetTop;
-  const elementBotttomPosition = elementTopPosition + height;
+  const elementBottomPosition = elementTopPosition + height;
 
   return {
     top: elementTopPosition,
-    bottom: elementBotttomPosition,
+    bottom: elementBottomPosition,
   };
 };
 


### PR DESCRIPTION
When an element of the details page changes dimensions (asynchronous loading, accordion, etc...), the anchors are desynchronized with the content.

This PR recalculates the dimensions of each section when scrolling and resizing windows so that everything fits correctly.
This PR also corrects the flickering of the map when loading the details page.