### PR TITLE
Display Multi* geometries in details page

### DIFF
--- a/frontend/src/components/Map/DetailsMap/TouristicContent.tsx
+++ b/frontend/src/components/Map/DetailsMap/TouristicContent.tsx
@@ -21,37 +21,62 @@ export const TouristicContent: React.FC<PropsType> = ({ contents, type = 'TOURIS
 
           switch (geometry.type) {
             case 'Point':
-              return pictogramUri ? (
-                <HoverableMarker
-                  id={id}
-                  position={[geometry.coordinates.y, geometry.coordinates.x]}
-                  pictogramUri={pictogramUri}
-                  type={type}
-                >
-                  <Popup id={Number(idContent)} type={type} />
-                </HoverableMarker>
-              ) : null;
+            case 'MultiPoint':
+              return (
+                <>
+                  {(geometry.type === 'Point' ? [geometry.coordinates] : geometry.coordinates).map(
+                    coordinates =>
+                      pictogramUri ? (
+                        <HoverableMarker
+                          id={`${id}${JSON.stringify(coordinates)}`}
+                          position={[coordinates.y, coordinates.x]}
+                          pictogramUri={pictogramUri}
+                          type={type}
+                        >
+                          <Popup id={Number(idContent)} type={type} />
+                        </HoverableMarker>
+                      ) : null,
+                  )}
+                </>
+              );
 
             case 'LineString':
+            case 'MultiLineString':
               return (
-                <HoverablePolyline
-                  id={id}
-                  positions={geometry.coordinates.map(point => [point.y, point.x])}
-                />
+                <>
+                  {(geometry.type === 'LineString'
+                    ? [geometry.coordinates]
+                    : geometry.coordinates
+                  ).map(group => (
+                    <HoverablePolyline
+                      key={`${id}${JSON.stringify(group)}`}
+                      id={id}
+                      positions={group.map(point => [point.y, point.x])}
+                    />
+                  ))}
+                </>
               );
 
             case 'Polygon':
+            case 'MultiPolygon':
               return (
-                <HoverablePolygon
-                  id={id}
-                  positions={geometry.coordinates.map(line =>
-                    line.map<[number, number]>(point => [point.y, point.x]),
-                  )}
-                />
+                <>
+                  {(geometry.type === 'Polygon'
+                    ? [geometry.coordinates]
+                    : geometry.coordinates
+                  ).map(group => (
+                    <HoverablePolygon
+                      key={`${id}${JSON.stringify(group)}`}
+                      id={id}
+                      positions={group.map(line =>
+                        line.map<[number, number]>(point => [point.y, point.x]),
+                      )}
+                    />
+                  ))}
+                </>
               );
 
             default:
-              // TODO Multi*
               return null;
           }
         })}


### PR DESCRIPTION
Following this [PR](https://github.com/GeotrekCE/Geotrek-rando-v3/pull/616) to avoid that the application crashes when there are multiple geometries, it displays the multiple geometries on the map.