### PR TITLE
Fix truncated icon name

### DIFF
--- a/frontend/src/components/CardIcon/CardIcon.tsx
+++ b/frontend/src/components/CardIcon/CardIcon.tsx
@@ -3,84 +3,56 @@ import SVG from 'react-inlinesvg';
 import styled from 'styled-components';
 
 interface IconProps {
-  iconUri: string;
+  className?: string;
+  iconUri?: string;
   color?: string;
 }
 interface Props extends IconProps {
-  iconName: string;
+  iconName?: string;
 }
 
 const Wrapper = styled.div<{ color?: string }>`
   z-index: 100;
   background: ${props => props.color};
-
-  & > div {
-    max-width: 0;
-    overflow: hidden;
-    white-space: nowrap;
-    transition: max-width 0.6s;
-  }
+  max-width: 32px;
+  transition: max-width 0.6s;
 
   &:hover {
-    & > div {
-      max-width: 150px;
-    }
+    max-width: 300%;
   }
-`;
-
-const Label = styled.div`
-  text-align: center;
-  flex: auto;
-
-  & > div {
-    padding: 0 10px;
-  }
-`;
-
-const StyledSVG = styled(SVG)`
-  height: 28px;
-  width: 28px;
-`;
-
-const Img = styled.img`
-  height: 28px;
-  width: 28px;
 `;
 
 const NoImg = styled.span<{ color?: string }>`
-  display: block;
-  height: 28px;
-  width: 28px;
-  border-radius: 50%;
   background: ${props => props.color};
 `;
 
-const Icon: React.FC<IconProps> = ({ iconUri, color }) => {
+const Icon: React.FC<IconProps> = ({ iconUri = '', className = '', color }) => {
   if (!iconUri) {
-    return <NoImg color={color} />;
+    return <NoImg color={color} className={`block rounded-full ${className}`} />;
   }
   if (RegExp(/(.*).svg/).test(iconUri)) {
     return (
-      <StyledSVG
+      <SVG
         src={iconUri}
-        className="fill-current p-1"
+        className={`fill-current p-1 ${className}`}
         preProcessor={fillSvgWithColor(colorPalette.white)}
       />
     );
   }
-  return <Img src={iconUri} alt="" />;
+  return <img className={className} src={iconUri} alt="" />;
 };
 
-export const CardIcon: React.FC<Props> = ({ iconUri, iconName, color }) => {
+export const CardIcon: React.FC<Props> = ({ iconUri = '', iconName = '', color }) => {
+  if (!iconName && !iconUri) {
+    return null;
+  }
   return (
     <Wrapper
-      className="absolute top-4 left-4 h-8 flex items-center w-auto rounded-full shadow-sm text-white border-2 border-white border-solid"
+      className="absolute top-4 left-4 h-8 flex items-center rounded-full shadow-sm text-white border-2 border-white border-solid overflow-hidden"
       color={color}
     >
-      <Icon color={color} iconUri={iconUri} />
-      <Label>
-        <div>{iconName}</div>
-      </Label>
+      <Icon color={color} iconUri={iconUri} className="w-7 h-7 flex-shrink-0" />
+      {iconName && <div className="pr-3 whitespace-nowrap">{iconName}</div>}
     </Wrapper>
   );
 };

--- a/frontend/src/components/pages/details/components/DetailsCard/DetailsCard.tsx
+++ b/frontend/src/components/pages/details/components/DetailsCard/DetailsCard.tsx
@@ -70,7 +70,7 @@ export const DetailsCard: React.FC<DetailsCardProps> = ({
         setHoveredCardId(null);
       }}
     >
-      {logoUri && (
+      {Boolean(logoUri) && (
         <img
           className="hidden desktop:absolute h-12 object-cover object-center right-6 top-6"
           src={logoUri}
@@ -97,13 +97,7 @@ export const DetailsCard: React.FC<DetailsCardProps> = ({
             </>
           )}
         </Modal>
-        {iconUri && (
-          <CardIcon
-            iconUri={iconUri}
-            iconName={iconName as string}
-            color={getActivityColor(type)}
-          />
-        )}
+        <CardIcon iconUri={iconUri} iconName={iconName} color={getActivityColor(type)} />
       </div>
       <div
         ref={detailsCardRef}
@@ -118,7 +112,7 @@ export const DetailsCard: React.FC<DetailsCardProps> = ({
         <OptionalLink redirectionUrl={redirectionUrl}>
           <p className="text-Mobile-C1 desktop:text-H4 text-primary1 font-bold">{name}</p>
         </OptionalLink>
-        {description && (
+        {Boolean(description) && (
           <div
             className="mt-1 desktop:mt-4
             flex flex-col desktop:flex-row desktop:items-end

--- a/frontend/src/components/pages/details/components/DetailsCard/__tests__/DetailsCard.test.tsx
+++ b/frontend/src/components/pages/details/components/DetailsCard/__tests__/DetailsCard.test.tsx
@@ -14,6 +14,7 @@ describe('DetailsCard', () => {
       ],
       thumbnailUris: ['https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_1280.jpg'],
       iconUri: 'https://geotrekdemo.ecrins-parcnational.fr/media/upload/practice-foot_GpBv9u1.svg',
+      iconName: 'Randonnée pédestre',
       description:
         "<span>Pour esp&eacute;rer apercevoir cet oiseau, partir la nuit au printemps, parcourir un grand d&eacute;nivel&eacute; afin d'arriver sur son terrain de pr&eacute;dilection &agrave; plus de 2000 m voire 3000 m d'altitude avant le lever du jour et l&agrave;, entendre le chant guttural&nbsp;caract&eacute;ristique qui trahit sa pr&eacute;sence. Mais pour le voir, il faudra bien ouvrir les yeux ou se munir d'une paire de jumelles. Et alors l&agrave;, quel bonheur&nbsp;! Le lagop&egrave;de alpin est l'esp&egrave;ce arctique par excellence, menac&eacute;e entre autre par le r&eacute;chauffement climatique. Il fait partie des esp&egrave;ces &agrave; prot&eacute;ger dans le c&oelig;ur du Parc national des Ecrins.</span>",
     };

--- a/frontend/src/components/pages/details/components/DetailsCard/__tests__/__snapshots__/DetailsCard.test.tsx.snap
+++ b/frontend/src/components/pages/details/components/DetailsCard/__tests__/__snapshots__/DetailsCard.test.tsx.snap
@@ -62,13 +62,13 @@ Object {
             </div>
           </div>
           <div
-            class="CardIcon__Wrapper-sc-cv6h96-0 iuMpeF absolute top-4 left-4 h-8 flex items-center w-auto rounded-full shadow-sm text-white border-2 border-white border-solid"
+            class="CardIcon__Wrapper-sc-cv6h96-0 bXmPlv absolute top-4 left-4 h-8 flex items-center rounded-full shadow-sm text-white border-2 border-white border-solid overflow-hidden"
             color="#AA397D"
           >
             <div
-              class="CardIcon__Label-sc-cv6h96-1 ddMeYP"
+              class="pr-3 whitespace-nowrap"
             >
-              <div />
+              Randonnée pédestre
             </div>
           </div>
         </div>
@@ -159,13 +159,13 @@ Object {
           </div>
         </div>
         <div
-          class="CardIcon__Wrapper-sc-cv6h96-0 iuMpeF absolute top-4 left-4 h-8 flex items-center w-auto rounded-full shadow-sm text-white border-2 border-white border-solid"
+          class="CardIcon__Wrapper-sc-cv6h96-0 bXmPlv absolute top-4 left-4 h-8 flex items-center rounded-full shadow-sm text-white border-2 border-white border-solid overflow-hidden"
           color="#AA397D"
         >
           <div
-            class="CardIcon__Label-sc-cv6h96-1 ddMeYP"
+            class="pr-3 whitespace-nowrap"
           >
-            <div />
+            Randonnée pédestre
           </div>
         </div>
       </div>

--- a/frontend/src/components/pages/search/components/ResultCard/ResultCard.tsx
+++ b/frontend/src/components/pages/search/components/ResultCard/ResultCard.tsx
@@ -163,7 +163,7 @@ export const ResultCard: React.FC<
         )}
       </Modal>
 
-      <Link href={redirectionUrl} testId={`Link-ResultCard-${id}`} className="w-full">
+      <Link href={redirectionUrl} testId={`Link-ResultCard-${id}`} className="w-full min-h-0">
         <DetailsContainer>
           <DetailsLayout>
             {place !== null && <Place>{place}</Place>}

--- a/frontend/src/components/pages/search/components/ResultCard/ResultCard.tsx
+++ b/frontend/src/components/pages/search/components/ResultCard/ResultCard.tsx
@@ -141,14 +141,7 @@ export const ResultCard: React.FC<
       }}
       className={className}
       id="result_card"
-      style={
-        asColumn
-          ? {
-              flex: 'auto',
-              flexDirection: 'column',
-            }
-          : { flex: 'auto' }
-      }
+      asColumn={asColumn}
     >
       <Modal>
         {({ isFullscreen, toggleFullscreen }) => (
@@ -295,9 +288,9 @@ export const ResultCard: React.FC<
   );
 };
 
-const Container = styled.div`
+const Container = styled.div<{ asColumn?: boolean }>`
   display: flex;
-  flex: none;
+  flex: auto;
   flex-direction: column;
   cursor: pointer;
   border: 1px solid ${colorPalette.greySoft.DEFAULT};
@@ -313,11 +306,13 @@ const Container = styled.div`
 
   align-items: stretch;
 
-  ${desktopOnly(
-    css`
-      flex-direction: row;
-    `,
-  )}
+  ${({ asColumn }) =>
+    asColumn !== true &&
+    desktopOnly(
+      css`
+        flex-direction: row;
+      `,
+    )}
 `;
 
 const DetailsContainer = styled.div`

--- a/frontend/src/components/pages/search/components/ResultCard/ResultCardCarousel/ResultCardCarousel.tsx
+++ b/frontend/src/components/pages/search/components/ResultCard/ResultCardCarousel/ResultCardCarousel.tsx
@@ -1,6 +1,6 @@
 import { CardIcon } from 'components/CardIcon';
 import { SmallCarousel } from 'components/Carousel';
-import getConfig from 'next/config';
+import styled, { css } from 'styled-components';
 import getActivityColor from '../getActivityColor';
 
 interface ResultCardCarouselProps {
@@ -20,32 +20,30 @@ export const ResultCardCarousel: React.FC<ResultCardCarouselProps> = ({
   onClickImage,
   asColumn,
 }) => {
-  const {
-    publicRuntimeConfig: { colors },
-  } = getConfig();
-
   const files = navigator && navigator?.onLine ? thumbnailUris : thumbnailUris.slice(0, 1);
 
   return (
-    <div
+    <Wrapper
       className={`h-full w-full flex-shrink-0 relative desktop:w-resultCardDesktop`}
-      style={asColumn ? { width: '100%' } : {}}
+      asColumn={asColumn}
     >
       <SmallCarousel>
         {files.map((thumbnailUri, i) => (
           <div key={i} className="relative h-full" onClick={onClickImage}>
-            <img
-              src={thumbnailUri}
-              className="object-cover object-top
-              w-full
-              h-full"
-            />
+            <img src={thumbnailUri} className="object-cover object-top w-full h-full" alt="" />
           </div>
         ))}
       </SmallCarousel>
-      {iconUri !== undefined && (
-        <CardIcon iconUri={iconUri} iconName={iconName} color={getActivityColor(type)} />
-      )}
-    </div>
+      <CardIcon iconUri={iconUri} iconName={iconName} color={getActivityColor(type)} />
+    </Wrapper>
   );
 };
+
+const Wrapper = styled.div<{ asColumn?: boolean }>`
+    ${({ asColumn }) =>
+      asColumn === true &&
+      css`
+        width: 100%;
+      `}
+  }
+`;

--- a/frontend/src/components/pages/search/components/ResultCard/__tests__/__snapshots__/ResultCard.test.tsx.snap
+++ b/frontend/src/components/pages/search/components/ResultCard/__tests__/__snapshots__/ResultCard.test.tsx.snap
@@ -6,9 +6,8 @@ Object {
   "baseElement": <body>
     <div>
       <div
-        class="ResultCard__Container-sc-1bem01n-0 bmgMpp"
+        class="ResultCard__Container-sc-1bem01n-0 jBsKrk"
         id="result_card"
-        style="flex-basis: auto;"
       >
         <div
           style="background-color: white; position: relative;"
@@ -20,7 +19,7 @@ Object {
               style="width: 100%; height: 100%;"
             >
               <div
-                class="h-full w-full flex-shrink-0 relative desktop:w-resultCardDesktop"
+                class="ResultCardCarousel__Wrapper-sc-13vjoai-0 botBuK h-full w-full flex-shrink-0 relative desktop:w-resultCardDesktop"
               >
                 <div
                   class="slick-slider Carousel__StyledSlider-sc-1tck7ng-0 iyRBSY slick-initialized"
@@ -47,6 +46,7 @@ Object {
                             tabindex="-1"
                           >
                             <img
+                              alt=""
                               class="object-cover object-top w-full h-full"
                               src=""
                             />
@@ -57,20 +57,6 @@ Object {
                   </div>
                   
                   
-                </div>
-                <div
-                  class="CardIcon__Wrapper-sc-cv6h96-0 kTmOsX absolute top-4 left-4 h-8 flex items-center w-auto rounded-full shadow-sm text-white border-2 border-white border-solid"
-                  color="#001B84"
-                >
-                  <span
-                    class="CardIcon__NoImg-sc-cv6h96-4 ftTsYP"
-                    color="#001B84"
-                  />
-                  <div
-                    class="CardIcon__Label-sc-cv6h96-1 ddMeYP"
-                  >
-                    <div />
-                  </div>
                 </div>
               </div>
             </div>
@@ -240,9 +226,8 @@ Object {
   </body>,
   "container": <div>
     <div
-      class="ResultCard__Container-sc-1bem01n-0 bmgMpp"
+      class="ResultCard__Container-sc-1bem01n-0 jBsKrk"
       id="result_card"
-      style="flex-basis: auto;"
     >
       <div
         style="background-color: white; position: relative;"
@@ -254,7 +239,7 @@ Object {
             style="width: 100%; height: 100%;"
           >
             <div
-              class="h-full w-full flex-shrink-0 relative desktop:w-resultCardDesktop"
+              class="ResultCardCarousel__Wrapper-sc-13vjoai-0 botBuK h-full w-full flex-shrink-0 relative desktop:w-resultCardDesktop"
             >
               <div
                 class="slick-slider Carousel__StyledSlider-sc-1tck7ng-0 iyRBSY slick-initialized"
@@ -281,6 +266,7 @@ Object {
                           tabindex="-1"
                         >
                           <img
+                            alt=""
                             class="object-cover object-top w-full h-full"
                             src=""
                           />
@@ -291,20 +277,6 @@ Object {
                 </div>
                 
                 
-              </div>
-              <div
-                class="CardIcon__Wrapper-sc-cv6h96-0 kTmOsX absolute top-4 left-4 h-8 flex items-center w-auto rounded-full shadow-sm text-white border-2 border-white border-solid"
-                color="#001B84"
-              >
-                <span
-                  class="CardIcon__NoImg-sc-cv6h96-4 ftTsYP"
-                  color="#001B84"
-                />
-                <div
-                  class="CardIcon__Label-sc-cv6h96-1 ddMeYP"
-                >
-                  <div />
-                </div>
               </div>
             </div>
           </div>

--- a/frontend/src/components/pages/search/components/ResultCard/__tests__/__snapshots__/ResultCard.test.tsx.snap
+++ b/frontend/src/components/pages/search/components/ResultCard/__tests__/__snapshots__/ResultCard.test.tsx.snap
@@ -63,7 +63,7 @@ Object {
           </div>
         </div>
         <a
-          class="Link__StyledLink-sc-oanbk8-0 htOOkH w-full"
+          class="Link__StyledLink-sc-oanbk8-0 htOOkH w-full min-h-0"
           data-testid="Link-ResultCard-2"
           href="/details-2-Balade-au-pays-des-menhirs"
         >
@@ -283,7 +283,7 @@ Object {
         </div>
       </div>
       <a
-        class="Link__StyledLink-sc-oanbk8-0 htOOkH w-full"
+        class="Link__StyledLink-sc-oanbk8-0 htOOkH w-full min-h-0"
         data-testid="Link-ResultCard-2"
         href="/details-2-Balade-au-pays-des-menhirs"
       >


### PR DESCRIPTION
Small refactoring and two bugfixes detailed below.

## Check before merging

- [x] Ticket : [Encarts remontant des fiches de la page d'accueil ne s'affichent pas entièrement sur IOS15+](https://github.com/GeotrekCE/Geotrek-rando-v3/issues/645)
- [x] Fix truncated icon name if the name is too long (see screenshots below).

## Screenshots
Before :
![image](https://user-images.githubusercontent.com/1926041/170286075-fd57f6ce-e917-4ddf-93b0-770524518ced.png)

After :
![image](https://user-images.githubusercontent.com/1926041/170285645-e047c403-31a4-4915-a9b0-47db74879859.png)

