### PR TITLE
Display MultiPolygon geometries on SensitiveAreas Map

### DIFF
--- a/frontend/src/modules/sensitiveArea/adapter.ts
+++ b/frontend/src/modules/sensitiveArea/adapter.ts
@@ -1,5 +1,5 @@
 import { SensitiveAreaPracticeDictionnary } from 'modules/sensitiveAreaPractice/interface';
-import { adaptPolygonGeometry } from 'modules/utils/geometry';
+import { adaptMultiPolygonGeometry, adaptPolygonGeometry } from 'modules/utils/geometry';
 import { getListOfColorsInPalette } from 'stylesheet';
 import { RawSensitiveArea, SensitiveArea } from './interface';
 
@@ -19,6 +19,9 @@ export const adaptSensitiveAreas = ({
     practices:
       rawSensitiveArea.practices?.map(practiceId => sensitiveAreaPracticeDictionnary[practiceId]) ??
       [],
-    geometry: adaptPolygonGeometry(rawSensitiveArea.geometry),
+    geometry:
+      rawSensitiveArea.geometry.type === 'MultiPolygon'
+        ? adaptMultiPolygonGeometry(rawSensitiveArea.geometry)
+        : adaptPolygonGeometry(rawSensitiveArea.geometry),
     color: getListOfColorsInPalette[i % getListOfColorsInPalette.length],
   }));

--- a/frontend/src/modules/sensitiveArea/interface.ts
+++ b/frontend/src/modules/sensitiveArea/interface.ts
@@ -1,4 +1,9 @@
-import { PolygonGeometry, RawPolygonGeometry } from 'modules/interface';
+import {
+  MultiPolygonGeometry,
+  PolygonGeometry,
+  RawMultiPolygonGeometry,
+  RawPolygonGeometry,
+} from 'modules/interface';
 import { SensitiveAreaPractice } from 'modules/sensitiveAreaPractice/interface';
 
 // This type is an array of 12 booleans, one for each calendar month, each indicating if the sensitive area is active during the month
@@ -22,7 +27,7 @@ export interface RawSensitiveArea {
   contact: string;
   description: string;
   elevation: string | null;
-  geometry: RawPolygonGeometry;
+  geometry: RawPolygonGeometry | RawMultiPolygonGeometry;
   info_url: string;
   kml_url: string;
   name: string;
@@ -43,5 +48,5 @@ export interface SensitiveArea {
   period: MonthlyValidity | null;
   practices: SensitiveAreaPractice[];
   color: string;
-  geometry: PolygonGeometry;
+  geometry: PolygonGeometry | MultiPolygonGeometry;
 }


### PR DESCRIPTION
## Check before merging

- [x] Ticket : [Les multi geométries des zones sensibles ne s'affichént pas sur la carte](https://github.com/GeotrekCE/Geotrek-rando-v3/issues/655)
- [x] I made sure that all displayed texts are imported from translation files.
