### PR TITLE
Allow user to override manifest json props

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -170,6 +170,11 @@ See examples in https://github.com/GeotrekCE/Geotrek-rando-v3/tree/main/frontend
 
 Icons are provided by Geotrek-admin API. See [icons documentation](icons.md) to know how they have to be designed.
 
+## Manifest.json
+
+There is a default `manifest.json` generated using the `applicationName` parameters of `global.json` and icons/images detailed in the next section below (See: https://github.com/GeotrekCE/Geotrek-rando-v3/blob/main/frontend/src/pages/manifest.json.tsx#L20).
+You can complete it by creating `manifest.json` file in the `customization/config/` folder and filling it with the props to add and/or override.
+
 ## Images, favicon, mobile phone icons and splashscreens
 
 These files need to be in the correct folder during the build process and therefore, we created a specific `medias` folder in the customization repository.

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -78,5 +78,6 @@ module.exports = withPlugins(plugins, {
     map: getConfig('map.json', true),
     filter: getConfig('filter.json', true),
     footer: getConfig('footer.json', true),
+    manifest: getConfig('manifest.json', true),
   },
 });

--- a/frontend/src/pages/manifest.json.tsx
+++ b/frontend/src/pages/manifest.json.tsx
@@ -1,16 +1,25 @@
+import { NextPageContext } from 'next';
 import { default as getNextConfig } from 'next/config';
-import React from 'react';
 
-class ManifestJson extends React.Component {
-  public static getInitialProps({ res }: { res: any }) {
-    const {
-      publicRuntimeConfig: { global },
-    } = getNextConfig();
+const ManifestJson = (): null => {
+  return null;
+};
 
-    const appName = String(global.applicationName);
+ManifestJson.getInitialProps = (props: NextPageContext) => {
+  const {
+    publicRuntimeConfig: { global },
+  } = getNextConfig();
 
-    const content = `{
-  "name": "${appName}",
+  const { res } = props;
+
+  if (!res) {
+    return null;
+  }
+
+  const name = String(global.applicationName);
+
+  const content = `{
+  "name": "${name}",
   "theme_color": "#ffffff",
   "background_color": "#ffffff",
   "display": "standalone",
@@ -25,11 +34,9 @@ class ManifestJson extends React.Component {
   "scope": ".",
   "start_url": "./"
 }`;
-
-    res.setHeader('Content-Type', 'text/plain');
-    res.write(content);
-    res.end();
-  }
-}
+  res.setHeader('Content-Type', 'text/plain');
+  res.write(content);
+  res.end();
+};
 
 export default ManifestJson;

--- a/frontend/src/pages/manifest.json.tsx
+++ b/frontend/src/pages/manifest.json.tsx
@@ -7,7 +7,7 @@ const ManifestJson = (): null => {
 
 ManifestJson.getInitialProps = (props: NextPageContext) => {
   const {
-    publicRuntimeConfig: { global },
+    publicRuntimeConfig: { global, manifest = {} },
   } = getNextConfig();
 
   const { res } = props;
@@ -17,25 +17,34 @@ ManifestJson.getInitialProps = (props: NextPageContext) => {
   }
 
   const name = String(global.applicationName);
+  const defaultManifest = {
+    theme_color: '#ffffff',
+    background_color: '#ffffff',
+    display: 'standalone',
+    orientation: 'portrait',
+    icons: [
+      {
+        src: '/medias/maskable-icon.png',
+        sizes: '200x200',
+        purpose: 'maskable',
+        type: 'image/png',
+      },
+      { src: '/medias/apple-icon.png', sizes: '144x144', type: 'image/png' },
+      { src: '/medias/android-icon.png', sizes: '144x144', type: 'image/png' },
+      { src: '/medias/apple-splashscreen.png', sizes: '512x512', type: 'image/png' },
+      { src: '/medias/android-splashscreen.png', sizes: '512x512', type: 'image/png' },
+    ],
+    scope: '.',
+    start_url: './',
+  };
 
-  const content = `{
-  "name": "${name}",
-  "theme_color": "#ffffff",
-  "background_color": "#ffffff",
-  "display": "standalone",
-  "orientation": "portrait",
-  "icons": [
-    { "src": "/medias/maskable-icon.png", "sizes": "200x200", "purpose": "maskable", "type": "image/png" },
-    { "src": "/medias/apple-icon.png", "sizes": "144x144", "type": "image/png" },
-    { "src": "/medias/android-icon.png", "sizes": "144x144", "type": "image/png" },
-    { "src": "/medias/apple-splashscreen.png", "sizes": "512x512", "type": "image/png" },
-    { "src": "/medias/android-splashscreen.png", "sizes": "512x512", "type": "image/png" }
-  ],
-  "scope": ".",
-  "start_url": "./"
-}`;
+  const content = {
+    name,
+    ...defaultManifest,
+    ...manifest,
+  };
   res.setHeader('Content-Type', 'text/plain');
-  res.write(content);
+  res.write(JSON.stringify(content, null, 2));
   res.end();
 };
 


### PR DESCRIPTION
As the title said, by creating a `manifest.json` file you can enhance the default one.

For example in `customization/config/manifest.json` :
```json
{
  "background_url": "red",
  "related_applications": [{
    "platform": "web"
  }, {
    "platform" : "play",
    "url" : "https://play.google.com/store/apps/details?id=MyCustomApp"
  }]
}
```
- The `background_url` replaces the default `#ffffff` in `red`.
- The `related_applications` element is added.