### PR TITLE
Fix/ssr-navigator

### DIFF
--- a/frontend/src/components/Map/DetailsMap/PointsSignage.tsx
+++ b/frontend/src/components/Map/DetailsMap/PointsSignage.tsx
@@ -16,7 +16,7 @@ export type PointsSignageProps = {
 type Locations = {
   description: string;
   name: string;
-  imageUrl: string | undefined | null;
+  imageUrl: string | null;
   pictogramUri: string;
   position: RawCoordinate2D;
   type: string;
@@ -52,9 +52,7 @@ export const PointsSignage: React.FC<PointsSignageProps> = ({ signage }) => {
         >
           <StyledTooltip>
             <div className="flex flex-col">
-              {location.imageUrl !== undefined && location.imageUrl !== null && (
-                <CoverImage src={location.imageUrl} alt="" />
-              )}
+              {location.imageUrl !== null && <CoverImage src={location.imageUrl} alt="" />}
               <div className="p-4">
                 <div className="text-P2 mb-1 text-greyDarkColored">{location.type}</div>
                 <Name className="text-Mobile-C1 text-primary1 font-bold desktop:text-H4">

--- a/frontend/src/components/Map/DetailsMap/PointsSignage.tsx
+++ b/frontend/src/components/Map/DetailsMap/PointsSignage.tsx
@@ -16,7 +16,7 @@ export type PointsSignageProps = {
 type Locations = {
   description: string;
   name: string;
-  imageUrl: string | undefined;
+  imageUrl: string | undefined | null;
   pictogramUri: string;
   position: RawCoordinate2D;
   type: string;

--- a/frontend/src/components/Map/DetailsMap/PointsSignage.tsx
+++ b/frontend/src/components/Map/DetailsMap/PointsSignage.tsx
@@ -52,7 +52,9 @@ export const PointsSignage: React.FC<PointsSignageProps> = ({ signage }) => {
         >
           <StyledTooltip>
             <div className="flex flex-col">
-              {location.imageUrl !== undefined && <CoverImage src={location.imageUrl} alt="" />}
+              {location.imageUrl !== undefined && location.imageUrl !== null && (
+                <CoverImage src={location.imageUrl} alt="" />
+              )}
               <div className="p-4">
                 <div className="text-P2 mb-1 text-greyDarkColored">{location.type}</div>
                 <Name className="text-Mobile-C1 text-primary1 font-bold desktop:text-H4">

--- a/frontend/src/components/pages/details/Details.tsx
+++ b/frontend/src/components/pages/details/Details.tsx
@@ -146,7 +146,9 @@ export const DetailsUIWithoutContext: React.FC<Props> = ({ detailsId, parentId, 
                         id="details_cover"
                         className={!isFullscreen ? 'desktop:h-coverDetailsDesktop' : 'h-full'}
                       >
-                        {details.imgs.length > 1 && navigator && navigator?.onLine ? (
+                        {details.imgs.length > 1 &&
+                        typeof navigator !== 'undefined' &&
+                        navigator?.onLine ? (
                           <DetailsCoverCarousel
                             attachments={details.imgs}
                             onClickImage={toggleFullscreen}
@@ -235,6 +237,8 @@ export const DetailsUIWithoutContext: React.FC<Props> = ({ detailsId, parentId, 
                       </div>
                     )}
                     {getGlobalConfig().enableMeteoWidget &&
+                      typeof navigator !== 'undefined' &&
+                      navigator.onLine &&
                       details.cities_raw &&
                       details.cities_raw[0] && (
                         <DetailsSection>
@@ -433,19 +437,22 @@ export const DetailsUIWithoutContext: React.FC<Props> = ({ detailsId, parentId, 
                       </div>
                     )}
 
-                    {details.reservation && details.reservation_id && (
-                      <DetailsSection
-                        className={marginDetailsChild}
-                        htmlId="details_reservation"
-                        titleId="details.reservation"
-                      >
-                        <DetailsReservationWidget
-                          language={language}
-                          reservation={details.reservation}
-                          id={details.reservation_id}
-                        />
-                      </DetailsSection>
-                    )}
+                    {details.reservation &&
+                      details.reservation_id &&
+                      typeof navigator !== 'undefined' &&
+                      navigator.onLine && (
+                        <DetailsSection
+                          className={marginDetailsChild}
+                          htmlId="details_reservation"
+                          titleId="details.reservation"
+                        >
+                          <DetailsReservationWidget
+                            language={language}
+                            reservation={details.reservation}
+                            id={details.reservation_id}
+                          />
+                        </DetailsSection>
+                      )}
                   </div>
                   <Footer />
                 </div>

--- a/frontend/src/components/pages/details/components/DetailsCard/DetailsCard.tsx
+++ b/frontend/src/components/pages/details/components/DetailsCard/DetailsCard.tsx
@@ -83,15 +83,21 @@ export const DetailsCard: React.FC<DetailsCardProps> = ({
               {isFullscreen &&
                 attachments &&
                 attachments.length > 0 &&
-                navigator &&
+                typeof navigator !== 'undefined' &&
                 navigator?.onLine && <DetailsCoverCarousel attachments={attachments} />}
               {!isFullscreen && (
                 <DetailsCardCarousel
                   thumbnailUris={
-                    navigator && navigator?.onLine ? thumbnailUris : thumbnailUris.slice(0, 1)
+                    typeof navigator !== 'undefined' && navigator?.onLine
+                      ? thumbnailUris
+                      : thumbnailUris.slice(0, 1)
                   }
                   height={heightState}
-                  onClickImage={navigator && navigator?.onLine ? toggleFullscreen : undefined}
+                  onClickImage={
+                    typeof navigator !== 'undefined' && navigator?.onLine
+                      ? toggleFullscreen
+                      : undefined
+                  }
                 />
               )}
             </>

--- a/frontend/src/components/pages/details/components/DetailsCoverCarousel/DetailsCoverCarousel.tsx
+++ b/frontend/src/components/pages/details/components/DetailsCoverCarousel/DetailsCoverCarousel.tsx
@@ -10,7 +10,8 @@ export const DetailsCoverCarousel: React.FC<DetailsCoverCarouselProps> = ({
   attachments,
   onClickImage,
 }) => {
-  const files = navigator && navigator?.onLine ? attachments : attachments.slice(0, 1);
+  const files =
+    typeof navigator !== 'undefined' && navigator?.onLine ? attachments : attachments.slice(0, 1);
 
   return (
     <LargeCarousel className="relative h-coverDetailsMobile desktop:h-coverDetailsDesktop">

--- a/frontend/src/components/pages/search/components/ResultCard/ResultCardCarousel/ResultCardCarousel.tsx
+++ b/frontend/src/components/pages/search/components/ResultCard/ResultCardCarousel/ResultCardCarousel.tsx
@@ -20,7 +20,10 @@ export const ResultCardCarousel: React.FC<ResultCardCarouselProps> = ({
   onClickImage,
   asColumn,
 }) => {
-  const files = navigator && navigator?.onLine ? thumbnailUris : thumbnailUris.slice(0, 1);
+  const files =
+    typeof navigator !== 'undefined' && navigator?.onLine
+      ? thumbnailUris
+      : thumbnailUris.slice(0, 1);
 
   return (
     <Wrapper

--- a/frontend/src/components/pages/site/OutdoorCourseUI.tsx
+++ b/frontend/src/components/pages/site/OutdoorCourseUI.tsx
@@ -121,7 +121,7 @@ export const OutdoorCourseUIWithoutContext: React.FC<Props> = ({ outdoorCourseUr
                         className={!isFullscreen ? 'desktop:h-coverDetailsDesktop' : 'h-full'}
                       >
                         {outdoorCourseContent.attachments.length > 1 &&
-                        navigator &&
+                        typeof navigator !== 'undefined' &&
                         navigator?.onLine ? (
                           <DetailsCoverCarousel
                             attachments={outdoorCourseContent.attachments}
@@ -291,6 +291,8 @@ export const OutdoorCourseUIWithoutContext: React.FC<Props> = ({ outdoorCourseUr
                     )}
 
                     {getGlobalConfig().enableMeteoWidget &&
+                      typeof navigator !== 'undefined' &&
+                      navigator.onLine &&
                       outdoorCourseContent.cities_raw &&
                       outdoorCourseContent.cities_raw[0] && (
                         <DetailsSection>

--- a/frontend/src/components/pages/site/OutdoorSiteUI.tsx
+++ b/frontend/src/components/pages/site/OutdoorSiteUI.tsx
@@ -133,7 +133,7 @@ const OutdoorSiteUIWithoutContext: React.FC<Props> = ({ outdoorSiteUrl, language
                         className={!isFullscreen ? 'desktop:h-coverDetailsDesktop' : 'h-full'}
                       >
                         {outdoorSiteContent.attachments.length > 1 &&
-                        navigator &&
+                        typeof navigator !== 'undefined' &&
                         navigator?.onLine ? (
                           <DetailsCoverCarousel
                             attachments={outdoorSiteContent.attachments}
@@ -311,6 +311,8 @@ const OutdoorSiteUIWithoutContext: React.FC<Props> = ({ outdoorSiteUrl, language
                     )}
 
                     {getGlobalConfig().enableMeteoWidget &&
+                      typeof navigator !== 'undefined' &&
+                      navigator.onLine &&
                       outdoorSiteContent.cities_raw &&
                       outdoorSiteContent.cities_raw[0] && (
                         <DetailsSection>

--- a/frontend/src/components/pages/touristicContent/TouristicContentUI.tsx
+++ b/frontend/src/components/pages/touristicContent/TouristicContentUI.tsx
@@ -76,7 +76,9 @@ export const TouristicContentUI: React.FC<TouristicContentUIProps> = ({
               <Modal>
                 {({ toggleFullscreen }) => (
                   <div id="touristicContent_cover">
-                    {touristicContent.attachments.length > 1 && navigator && navigator?.onLine ? (
+                    {touristicContent.attachments.length > 1 &&
+                    typeof navigator !== 'undefined' &&
+                    navigator?.onLine ? (
                       <DetailsCoverCarousel
                         attachments={touristicContent.attachments}
                         onClickImage={toggleFullscreen}
@@ -189,6 +191,8 @@ export const TouristicContentUI: React.FC<TouristicContentUIProps> = ({
                   </DetailsSection>
                 )}
                 {getGlobalConfig().enableMeteoWidget &&
+                  typeof navigator !== 'undefined' &&
+                  navigator.onLine &&
                   touristicContent.cities_raw &&
                   touristicContent.cities_raw[0] && (
                     <DetailsSection>

--- a/frontend/src/components/pages/touristicEvent/TouristicEventUI.tsx
+++ b/frontend/src/components/pages/touristicEvent/TouristicEventUI.tsx
@@ -123,7 +123,7 @@ export const TouristicEventUIWithoutContext: React.FC<Props> = ({
                         className={!isFullscreen ? 'desktop:h-coverDetailsDesktop' : 'h-full'}
                       >
                         {touristicEventContent.attachments.length > 1 &&
-                        navigator &&
+                        typeof navigator !== 'undefined' &&
                         navigator?.onLine ? (
                           <DetailsCoverCarousel
                             attachments={touristicEventContent.attachments}
@@ -262,6 +262,8 @@ export const TouristicEventUIWithoutContext: React.FC<Props> = ({
                       )}
 
                       {getGlobalConfig().enableMeteoWidget &&
+                        typeof navigator !== 'undefined' &&
+                        navigator.onLine &&
                         touristicEventContent.cities_raw &&
                         touristicEventContent.cities_raw[0] && (
                           <DetailsSection>

--- a/frontend/src/modules/signage/adapter.ts
+++ b/frontend/src/modules/signage/adapter.ts
@@ -6,7 +6,7 @@ const adaptSignage = (
   signageTypeDictionary: SignageTypeDictionary,
 ): Signage => ({
   id: rawSignage.id,
-  imageUrl: rawSignage.attachments?.find(({ type }) => type === 'image')?.thumbnail,
+  imageUrl: rawSignage.attachments?.find(({ type }) => type === 'image')?.thumbnail ?? null,
   description: rawSignage.description,
   geometry: rawSignage.geometry,
   name: rawSignage.name,

--- a/frontend/src/modules/signage/interface.ts
+++ b/frontend/src/modules/signage/interface.ts
@@ -25,7 +25,7 @@ export interface Signage {
   description: string;
   geometry: RawPointGeometry3D;
   type: SignageType;
-  imageUrl: string | undefined;
+  imageUrl: string | undefined | null;
 }
 
 export interface SignageDictionary {

--- a/frontend/src/modules/signage/interface.ts
+++ b/frontend/src/modules/signage/interface.ts
@@ -25,7 +25,7 @@ export interface Signage {
   description: string;
   geometry: RawPointGeometry3D;
   type: SignageType;
-  imageUrl: string | undefined | null;
+  imageUrl: string | null;
 }
 
 export interface SignageDictionary {

--- a/frontend/src/pages/trek/[detailsId].tsx
+++ b/frontend/src/pages/trek/[detailsId].tsx
@@ -2,7 +2,7 @@ import { NextPage } from 'next';
 import { useRouter } from 'next/router';
 import { DetailsUI } from 'components/pages/details';
 import { useEffect } from 'react';
-import { QueryClient } from 'react-query';
+import { DehydratedState, QueryClient } from 'react-query';
 import { dehydrate } from 'react-query/hydration';
 import { getDetails, getTrekFamily } from 'modules/details/connector';
 import { isUrlString } from 'modules/utils/string';
@@ -10,6 +10,9 @@ import { getDefaultLanguage } from 'modules/header/utills';
 import { routes } from 'services/routes';
 import { redirectIfWrongUrl } from '../../modules/utils/url';
 import Custom404 from '../404';
+
+const sanitizeState = (unsafeState: DehydratedState): DehydratedState =>
+  JSON.parse(JSON.stringify(unsafeState));
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const getServerSideProps = async (context: {
@@ -44,9 +47,12 @@ export const getServerSideProps = async (context: {
         redirect,
       };
 
+    const unsafeState = dehydrate(queryClient);
+    const safeState = sanitizeState(unsafeState);
+
     return {
       props: {
-        dehydratedState: dehydrate(queryClient),
+        dehydratedState: safeState,
       },
     };
   } catch (error) {

--- a/frontend/src/pages/trek/[detailsId].tsx
+++ b/frontend/src/pages/trek/[detailsId].tsx
@@ -2,7 +2,7 @@ import { NextPage } from 'next';
 import { useRouter } from 'next/router';
 import { DetailsUI } from 'components/pages/details';
 import { useEffect } from 'react';
-import { DehydratedState, QueryClient } from 'react-query';
+import { QueryClient } from 'react-query';
 import { dehydrate } from 'react-query/hydration';
 import { getDetails, getTrekFamily } from 'modules/details/connector';
 import { isUrlString } from 'modules/utils/string';
@@ -10,9 +10,6 @@ import { getDefaultLanguage } from 'modules/header/utills';
 import { routes } from 'services/routes';
 import { redirectIfWrongUrl } from '../../modules/utils/url';
 import Custom404 from '../404';
-
-const sanitizeState = (unsafeState: DehydratedState): DehydratedState =>
-  JSON.parse(JSON.stringify(unsafeState));
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const getServerSideProps = async (context: {
@@ -47,12 +44,9 @@ export const getServerSideProps = async (context: {
         redirect,
       };
 
-    const unsafeState = dehydrate(queryClient);
-    const safeState = sanitizeState(unsafeState);
-
     return {
       props: {
-        dehydratedState: safeState,
+        dehydratedState: dehydrate(queryClient),
       },
     };
   } catch (error) {


### PR DESCRIPTION
## Détails de la PR :
Lors du pull de la branche develop, 2 bugs sont apparus : 

- une erreur "navigator is not defined" apparaissait lors du premier rendu d'une page. Pour éviter cette erreur j'ai ajouté dans les affichages conditionnels `typeof navigator !== "undefined"`
- une erreur de SSR est apparue sur la page de la randonnée (id: 501). L'erreur nous dit qu'il est impossible de serializer une valeur qui est undefined. Et effectivement sur cette rando il apparaît que le signage["703"].imageUrl renvoyé par l'api est undefined : 
![image](https://user-images.githubusercontent.com/99249234/171627567-450a34a8-5f01-4f53-b0fb-cabe55f115b3.png)

L'erreur n'est pas présente sur la démo mais je pense qu'il est quand même important de la régler.
Pour se faire, je suis passée par la méthode `SanitizeState `déjà utilisée sur la page search.tsx afin d'éviter l'erreur de serialization.

## Screenshots
- Erreur du navigator 
![image](https://user-images.githubusercontent.com/99249234/171627183-a999ca1d-331b-4483-8244-610dcd4106ce.png)

- Erreur SSR trek/[detailsId]
![image](https://user-images.githubusercontent.com/99249234/171627359-5685b334-b760-439a-9ba5-c76b97d3c79d.png)
