### PR TITLE
Feature : Afficher toutes les communes pour les sites outdoor 

### DIFF
--- a/frontend/src/modules/outdoorCourse/adapter.ts
+++ b/frontend/src/modules/outdoorCourse/adapter.ts
@@ -37,7 +37,8 @@ export const adaptOutdoorCourses = ({
         ? `${Math.round(rawOutdoorCourse.length)}${dataUnits.distance}`
         : null,
       height: rawOutdoorCourse.height ? `${rawOutdoorCourse.height}${dataUnits.distance}` : null,
-      place: cityDictionnary?.[rawOutdoorCourse?.cities?.[0]]?.name ?? '',
+      place:
+        rawOutdoorCourse?.cities?.map(city => cityDictionnary?.[city]?.name ?? '').join(', ') ?? '',
     };
   });
 };

--- a/frontend/src/modules/outdoorCourse/adapter.ts
+++ b/frontend/src/modules/outdoorCourse/adapter.ts
@@ -37,8 +37,7 @@ export const adaptOutdoorCourses = ({
         ? `${Math.round(rawOutdoorCourse.length)}${dataUnits.distance}`
         : null,
       height: rawOutdoorCourse.height ? `${rawOutdoorCourse.height}${dataUnits.distance}` : null,
-      place:
-        rawOutdoorCourse?.cities?.map(city => cityDictionnary?.[city]?.name ?? '').join(', ') ?? '',
+      place: cityDictionnary?.[rawOutdoorCourse?.cities?.[0]]?.name ?? '',
     };
   });
 };

--- a/frontend/src/modules/outdoorSite/adapter.ts
+++ b/frontend/src/modules/outdoorSite/adapter.ts
@@ -48,7 +48,8 @@ export const adaptOutdoorSites = ({
       period: rawOutdoorSite?.period ? rawOutdoorSite?.period : null,
       wind: rawOutdoorSite?.wind ?? [],
       orientation: rawOutdoorSite?.orientation ?? [],
-      place: cityDictionnary?.[rawOutdoorSite?.cities?.[0]]?.name ?? '',
+      place:
+        rawOutdoorSite?.cities?.map(city => cityDictionnary?.[city]?.name ?? '').join(', ') ?? '',
     };
   });
 
@@ -150,7 +151,11 @@ export const adaptOutdoorSitePopupResults = ({
 }): PopupResult => {
   return {
     title: rawOutdoorSitePopupResult.properties.name,
-    place: cityDictionnary?.[rawOutdoorSitePopupResult?.properties?.cities?.[0]]?.name ?? '',
+    place:
+      rawOutdoorSitePopupResult?.properties?.cities
+        ?.map(city => cityDictionnary?.[city]?.name ?? '')
+        .join(', ') ?? '',
+    //place: cityDictionnary?.[rawOutdoorSitePopupResult?.properties?.cities?.[0]]?.name ?? '',
     imgUrl: getThumbnail(rawOutdoorSitePopupResult.properties.attachments) ?? fallbackImgUri,
   };
 };

--- a/frontend/src/modules/outdoorSite/adapter.ts
+++ b/frontend/src/modules/outdoorSite/adapter.ts
@@ -155,7 +155,6 @@ export const adaptOutdoorSitePopupResults = ({
       rawOutdoorSitePopupResult?.properties?.cities
         ?.map(city => cityDictionnary?.[city]?.name ?? '')
         .join(', ') ?? '',
-    //place: cityDictionnary?.[rawOutdoorSitePopupResult?.properties?.cities?.[0]]?.name ?? '',
     imgUrl: getThumbnail(rawOutdoorSitePopupResult.properties.attachments) ?? fallbackImgUri,
   };
 };


### PR DESCRIPTION
## Détails de la PR (ticket : [https://github.com/GeotrekCE/Geotrek-rando-v3/issues/669](url))

Désormais toutes les communes liées à un site outdoor sont affichées.

## Screenshots

![image](https://user-images.githubusercontent.com/99249234/173102193-fc2b23e9-1647-4439-8a44-b4e51a748927.png)

![image](https://user-images.githubusercontent.com/99249234/173102265-ce2466d7-7c60-402b-834b-74d87ef5dd57.png)

![image](https://user-images.githubusercontent.com/99249234/173102363-d13b36da-b7a2-481a-8504-ce9af9046d3c.png)

![image](https://user-images.githubusercontent.com/99249234/173102438-3471f166-af1e-4508-aa0c-3a98a2c4ca2b.png)

