### PR TITLE
Display service in map details pages

### DIFF
--- a/frontend/src/components/Map/DetailsMap/DetailsMap.tsx
+++ b/frontend/src/components/Map/DetailsMap/DetailsMap.tsx
@@ -82,6 +82,7 @@ export type PropsType = {
   displayAltimetricProfile?: boolean;
   informationDesks?: InformationDesk[];
   signage?: SignageDictionary | null;
+  service?: PointWithIcon[];
   infrastructure?: InfrastructureDictionary | null;
 };
 export const DetailsMap: React.FC<PropsType> = props => {
@@ -110,7 +111,9 @@ export const DetailsMap: React.FC<PropsType> = props => {
     experiencesVisibility,
     toggleExperiencesVisibility,
     signageVisibility,
+    serviceVisibility,
     toggleSignageVisibility,
+    toggleServiceVisibility,
     infrastructureVisibility,
     toggleInfrastructureVisibility,
   } = useDetailsMap();
@@ -204,6 +207,7 @@ export const DetailsMap: React.FC<PropsType> = props => {
               : null
           }
           signageVisibility={props.signage ? signageVisibility : null}
+          serviceVisibility={props.service && props.service.length > 0 ? serviceVisibility : null}
           infrastructureVisibility={props.infrastructure ? infrastructureVisibility : null}
           toggleTrekChildrenVisibility={toggleTrekChildrenVisibility}
           togglePoiVisibility={togglePoiVisibility}
@@ -213,6 +217,7 @@ export const DetailsMap: React.FC<PropsType> = props => {
           toggleCoursesVisibility={toggleCoursesVisibility}
           toggleExperiencesVisibility={toggleExperiencesVisibility}
           toggleSignageVisibility={toggleSignageVisibility}
+          toggleServiceVisibility={toggleServiceVisibility}
           toggleInfrastructureVisibility={toggleInfrastructureVisibility}
         />
         {props.trekGeometry && (
@@ -238,6 +243,7 @@ export const DetailsMap: React.FC<PropsType> = props => {
           trekChildrenGeometry={props.trekChildrenGeometry}
           sensitiveAreasGeometry={props.sensitiveAreas}
           signage={props.signage}
+          service={props.service}
           infrastructure={props.infrastructure}
           trekChildrenMobileVisibility={trekChildrenMobileVisibility}
           poiMobileVisibility={poiMobileVisibility}
@@ -249,6 +255,7 @@ export const DetailsMap: React.FC<PropsType> = props => {
           experiencesVisibility={experiencesVisibility}
           informationDesks={props.informationDesks}
           signageVisibility={signageVisibility}
+          serviceVisibility={serviceVisibility}
           infrastructureVisibility={infrastructureVisibility}
         />
         {props.displayAltimetricProfile === true && props.trekGeoJSON && (

--- a/frontend/src/components/Map/DetailsMap/MapChildren.tsx
+++ b/frontend/src/components/Map/DetailsMap/MapChildren.tsx
@@ -48,6 +48,8 @@ type Props = {
   informationDesks?: InformationDesk[];
   signageVisibility: Visibility;
   signage?: SignageDictionary | null;
+  serviceVisibility: Visibility;
+  service?: PointWithIcon[];
   infrastructureVisibility: Visibility;
   infrastructure?: InfrastructureDictionary | null;
 };
@@ -116,6 +118,8 @@ export const MapChildren: React.FC<Props> = props => {
       {props.infrastructureVisibility === 'DISPLAYED' && (
         <PointsSecondary dictionary={props.infrastructure} icon={Infrastructure} />
       )}
+
+      {props.serviceVisibility === 'DISPLAYED' && <MarkersWithIcon points={props.service} />}
 
       {(isMobile || visibleSection === 'report') && props.reportVisibility && <PointReport />}
     </>

--- a/frontend/src/components/Map/DetailsMap/useDetailsMap.tsx
+++ b/frontend/src/components/Map/DetailsMap/useDetailsMap.tsx
@@ -19,6 +19,7 @@ export const useDetailsMap = () => {
   const [coursesVisibility, setCoursesVisibility] = useState<Visibility>('HIDDEN');
   const [experiencesVisibility, setExperiencesVisibility] = useState<Visibility>('HIDDEN');
   const [signageVisibility, setSignageVisibility] = useState<Visibility>('HIDDEN');
+  const [serviceVisibility, setServiceVisibility] = useState<Visibility>('HIDDEN');
   const [infrastructureVisibility, setInfrastructureVisibility] = useState<Visibility>('HIDDEN');
 
   const toggleTrekChildrenVisibility = () => setTrekChildrenVisibility(toggleVisibility);
@@ -34,6 +35,7 @@ export const useDetailsMap = () => {
   const toggleExperiencesVisibility = () => setExperiencesVisibility(toggleVisibility);
   const toggleCoursesVisibility = () => setCoursesVisibility(toggleVisibility);
   const toggleSignageVisibility = () => setSignageVisibility(toggleVisibility);
+  const toggleServiceVisibility = () => setServiceVisibility(toggleVisibility);
   const toggleInfrastructureVisibility = () => setInfrastructureVisibility(toggleVisibility);
 
   return {
@@ -53,6 +55,8 @@ export const useDetailsMap = () => {
     toggleExperiencesVisibility,
     signageVisibility,
     toggleSignageVisibility,
+    serviceVisibility,
+    toggleServiceVisibility,
     infrastructureVisibility,
     toggleInfrastructureVisibility,
   };

--- a/frontend/src/components/Map/components/ControlSection/ControlPanel/index.tsx
+++ b/frontend/src/components/Map/components/ControlSection/ControlPanel/index.tsx
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import { Florist } from 'components/Icons/Florist';
 import { Signage } from 'components/Icons/Signage';
 import { Infrastructure } from 'components/Icons/Infrastructure';
+import { MapPin } from 'components/Icons/MapPin';
 import { Line } from './Line';
 import IconLocation from './IconLocation';
 import IconInfo from './IconInfo';
@@ -46,6 +47,8 @@ export const ControlPanel: React.FC<ControlSectionProps> = ({
   toggleExperiencesVisibility,
   signageVisibility,
   toggleSignageVisibility,
+  serviceVisibility,
+  toggleServiceVisibility,
   infrastructureVisibility,
   toggleInfrastructureVisibility,
 }) => {
@@ -121,6 +124,14 @@ export const ControlPanel: React.FC<ControlSectionProps> = ({
           active={infrastructureVisibility === 'DISPLAYED'}
           toggle={toggleInfrastructureVisibility}
           transKey="search.map.panel.infrastructure"
+        />
+      )}
+      {serviceVisibility !== null && (
+        <Line
+          Icon={MapPin}
+          active={serviceVisibility === 'DISPLAYED'}
+          toggle={toggleServiceVisibility}
+          transKey="search.map.panel.service"
         />
       )}
     </Wrapper>

--- a/frontend/src/components/Map/components/ControlSection/ControlSection.tsx
+++ b/frontend/src/components/Map/components/ControlSection/ControlSection.tsx
@@ -24,6 +24,8 @@ export interface ControlSectionProps {
   toggleExperiencesVisibility: () => void;
   signageVisibility: Visibility;
   toggleSignageVisibility: () => void;
+  serviceVisibility: Visibility;
+  toggleServiceVisibility: () => void;
   infrastructureVisibility: Visibility;
   toggleInfrastructureVisibility: () => void;
   className?: string;

--- a/frontend/src/components/pages/details/Details.tsx
+++ b/frontend/src/components/pages/details/Details.tsx
@@ -20,6 +20,8 @@ import { getGlobalConfig } from 'modules/utils/api.config';
 import { Footer } from 'components/Footer';
 import Accessibility, { shouldDisplayAccessibility } from 'components/Accessibility';
 
+import { renderToStaticMarkup } from 'react-dom/server';
+import { MapPin } from 'components/Icons/MapPin';
 import { DetailsPreview } from './components/DetailsPreview';
 import { DetailsSection } from './components/DetailsSection';
 import { DetailsDescription } from './components/DetailsDescription';
@@ -521,6 +523,14 @@ export const DetailsUIWithoutContext: React.FC<Props> = ({ detailsId, parentId, 
                         displayAltimetricProfile={displayAltimetricProfile}
                         informationDesks={details.informationDesks}
                         signage={details.signage}
+                        service={details.service?.map(service => ({
+                          location: { x: service.geometry.x, y: service.geometry.y },
+                          pictogramUri:
+                            service.type.pictogram ??
+                            renderToStaticMarkup(<MapPin color="white" />),
+                          name: service.type.name,
+                          id: `DETAILS-SERVICE-${service.id}`,
+                        }))}
                         infrastructure={details.infrastructure}
                       />
                     </div>
@@ -580,6 +590,13 @@ export const DetailsUIWithoutContext: React.FC<Props> = ({ detailsId, parentId, 
                   displayAltimetricProfile={displayAltimetricProfile}
                   informationDesks={details.informationDesks}
                   signage={details.signage}
+                  service={details.service?.map(service => ({
+                    location: { x: service.geometry.x, y: service.geometry.y },
+                    pictogramUri:
+                      service.type.pictogram ?? renderToStaticMarkup(<MapPin color="white" />),
+                    name: service.type.name,
+                    id: `DETAILS-SERVICE-${service.id}`,
+                  }))}
                   infrastructure={details.infrastructure}
                 />
               </MobileMapContainer>

--- a/frontend/src/components/pages/details/__tests__/Details.test.tsx
+++ b/frontend/src/components/pages/details/__tests__/Details.test.tsx
@@ -19,6 +19,8 @@ import { mockTrekRatingRoute } from 'modules/trekRating/mocks';
 import { mockTrekRatingScaleRoute } from 'modules/trekRatingScale/mocks';
 import { mockSignageRoute } from 'modules/signage/mocks';
 import { mockSignageTypeRoute } from 'modules/signageType/mocks';
+import { mockServiceRoute } from 'modules/service/mocks';
+import { mockServiceTypeRoute } from 'modules/serviceType/mocks';
 import { mockInfrastructureRoute } from 'modules/infrastructure/mocks';
 import { mockInfrastructureTypeRoute } from 'modules/infrastructureType/mocks';
 import { getGlobalConfig } from 'modules/utils/api.config';
@@ -94,6 +96,8 @@ describe('Details', () => {
 
     mockSignageTypeRoute(1);
     mockSignageRoute(1, rawDetailsMock.properties.id);
+    mockServiceTypeRoute(1);
+    mockServiceRoute(1, rawDetailsMock.properties.id);
     mockInfrastructureTypeRoute(1);
     mockInfrastructureRoute(1, rawDetailsMock.properties.id);
 

--- a/frontend/src/components/pages/site/OutdoorCourseUI.tsx
+++ b/frontend/src/components/pages/site/OutdoorCourseUI.tsx
@@ -23,6 +23,8 @@ import { Footer } from 'components/Footer';
 import { OpenMapButton } from 'components/OpenMapButton';
 import { MobileMapContainer } from 'components/pages/search';
 import { getGlobalConfig } from 'modules/utils/api.config';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { MapPin } from 'components/Icons/MapPin';
 import { cleanHTMLElementsFromString } from '../../../modules/utils/string';
 import { DetailsPreview } from '../details/components/DetailsPreview';
 import { ErrorFallback } from '../search/components/ErrorFallback';
@@ -366,6 +368,14 @@ export const OutdoorCourseUIWithoutContext: React.FC<Props> = ({ outdoorCourseUr
                         trekId={Number(id)}
                         title={outdoorCourseContent.name}
                         signage={outdoorCourseContent.signage}
+                        service={outdoorCourseContent.service?.map(service => ({
+                          location: { x: service.geometry.x, y: service.geometry.y },
+                          pictogramUri:
+                            service.type.pictogram ??
+                            renderToStaticMarkup(<MapPin color="white" />),
+                          name: service.type.name,
+                          id: `DETAILS-SERVICE-${service.id}`,
+                        }))}
                         infrastructure={outdoorCourseContent.infrastructure}
                       />
                     </div>
@@ -413,6 +423,13 @@ export const OutdoorCourseUIWithoutContext: React.FC<Props> = ({ outdoorCourseUr
                   trekId={Number(id)}
                   title={outdoorCourseContent.name}
                   signage={outdoorCourseContent.signage}
+                  service={outdoorCourseContent.service?.map(service => ({
+                    location: { x: service.geometry.x, y: service.geometry.y },
+                    pictogramUri:
+                      service.type.pictogram ?? renderToStaticMarkup(<MapPin color="white" />),
+                    name: service.type.name,
+                    id: `DETAILS-SERVICE-${service.id}`,
+                  }))}
                   infrastructure={outdoorCourseContent.infrastructure}
                 />
               </MobileMapContainer>

--- a/frontend/src/components/pages/site/OutdoorSiteUI.tsx
+++ b/frontend/src/components/pages/site/OutdoorSiteUI.tsx
@@ -28,6 +28,8 @@ import { Footer } from 'components/Footer';
 import { OpenMapButton } from 'components/OpenMapButton';
 import { MobileMapContainer } from 'components/pages/search';
 import { getGlobalConfig } from 'modules/utils/api.config';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { MapPin } from 'components/Icons/MapPin';
 import { cleanHTMLElementsFromString } from '../../../modules/utils/string';
 import { useOutdoorSite } from './useOutdoorSite';
 import { DetailsPreview } from '../details/components/DetailsPreview';
@@ -445,6 +447,14 @@ const OutdoorSiteUIWithoutContext: React.FC<Props> = ({ outdoorSiteUrl, language
                         trekId={Number(id)}
                         informationDesks={outdoorSiteContent?.informationDesks}
                         signage={outdoorSiteContent.signage}
+                        service={outdoorSiteContent.service?.map(service => ({
+                          location: { x: service.geometry.x, y: service.geometry.y },
+                          pictogramUri:
+                            service.type.pictogram ??
+                            renderToStaticMarkup(<MapPin color="white" />),
+                          name: service.type.name,
+                          id: `DETAILS-SERVICE-${service.id}`,
+                        }))}
                         infrastructure={outdoorSiteContent.infrastructure}
                       />
                     </div>
@@ -491,6 +501,13 @@ const OutdoorSiteUIWithoutContext: React.FC<Props> = ({ outdoorSiteUrl, language
                   hideMap={hideMobileMap}
                   trekId={Number(id)}
                   signage={outdoorSiteContent.signage}
+                  service={outdoorSiteContent.service?.map(service => ({
+                    location: { x: service.geometry.x, y: service.geometry.y },
+                    pictogramUri:
+                      service.type.pictogram ?? renderToStaticMarkup(<MapPin color="white" />),
+                    name: service.type.name,
+                    id: `DETAILS-SERVICE-${service.id}`,
+                  }))}
                   infrastructure={outdoorSiteContent.infrastructure}
                 />
               </MobileMapContainer>

--- a/frontend/src/modules/details/adapter.ts
+++ b/frontend/src/modules/details/adapter.ts
@@ -14,6 +14,7 @@ import { TrekResult } from 'modules/results/interface';
 import { formatDistance } from 'modules/results/utils';
 import { SensitiveArea } from 'modules/sensitiveArea/interface';
 import { SignageDictionary } from 'modules/signage/interface';
+import { Service } from 'modules/service/interface';
 import { InfrastructureDictionary } from 'modules/infrastructure/interface';
 import { SourceDictionnary } from 'modules/source/interface';
 import { TouristicContent } from 'modules/touristicContent/interface';
@@ -43,6 +44,7 @@ export const adaptResults = ({
   childrenGeometry,
   sensitiveAreas,
   signage,
+  service,
   infrastructure,
   reservation,
   trekRating,
@@ -66,6 +68,7 @@ export const adaptResults = ({
   childrenGeometry: TrekChildGeometry[];
   sensitiveAreas: SensitiveArea[];
   signage: SignageDictionary | null;
+  service: Service[] | null;
   infrastructure: InfrastructureDictionary | null;
   reservation: Reservation | null;
   trekRating: TrekRatingChoices;
@@ -180,6 +183,7 @@ export const adaptResults = ({
         }) ?? [],
       ratingsDescription: rawDetailsProperties.ratings_description ?? '',
       signage,
+      service,
       infrastructure,
     };
   } catch (e) {

--- a/frontend/src/modules/details/connector.ts
+++ b/frontend/src/modules/details/connector.ts
@@ -12,6 +12,7 @@ import { getPois } from 'modules/poi/connector';
 import { getTrekResultsById } from 'modules/results/connector';
 import { getSensitiveAreas } from 'modules/sensitiveArea/connector';
 import { getSignage } from 'modules/signage/connector';
+import { getService } from 'modules/service/connector';
 import { getInfrastructure } from 'modules/infrastructure/connector';
 import { getSources } from 'modules/source/connector';
 import { getGlobalConfig } from 'modules/utils/api.config';
@@ -56,6 +57,7 @@ export const getDetails = async (id: string, language: string): Promise<Details>
     const [
       informationDeskDictionnary,
       signage,
+      service,
       infrastructure,
       labelsDictionnary,
       children,
@@ -63,6 +65,7 @@ export const getDetails = async (id: string, language: string): Promise<Details>
     ] = await Promise.all([
       getInformationDesks(language),
       getSignage(language, id, 'TREK'),
+      getService(language, id, 'TREK'),
       getInfrastructure(language, id, 'TREK'),
       getLabels(language),
       getTrekResultsById(rawDetails.properties.children, language),
@@ -99,6 +102,7 @@ export const getDetails = async (id: string, language: string): Promise<Details>
       trekRating,
       trekRatingScale,
       signage,
+      service,
       infrastructure,
       reservation:
         getGlobalConfig().reservationPartner && getGlobalConfig().reservationProject

--- a/frontend/src/modules/details/interface.ts
+++ b/frontend/src/modules/details/interface.ts
@@ -21,6 +21,7 @@ import { Label } from 'modules/label/interface';
 import { TrekResult } from 'modules/results/interface';
 import { SensitiveArea } from 'modules/sensitiveArea/interface';
 import { SignageDictionary } from 'modules/signage/interface';
+import { Service } from 'modules/service/interface';
 import { InfrastructureDictionary } from 'modules/infrastructure/interface';
 import { TrekRatingWithScale } from '../trekRating/interface';
 
@@ -187,6 +188,7 @@ export interface Details extends DetailsHtml {
   reservation: Reservation | null;
   reservation_id: string | null;
   signage: SignageDictionary | null;
+  service: Service[] | null;
   infrastructure: InfrastructureDictionary | null;
 }
 

--- a/frontend/src/modules/outdoorCourse/adapter.ts
+++ b/frontend/src/modules/outdoorCourse/adapter.ts
@@ -1,5 +1,6 @@
 import { SensitiveArea } from 'modules/sensitiveArea/interface';
 import { SignageDictionary } from 'modules/signage/interface';
+import { Service } from 'modules/service/interface';
 import { InfrastructureDictionary } from 'modules/infrastructure/interface';
 import { getAttachments, getThumbnails } from 'modules/utils/adapter';
 import { adaptGeometry } from 'modules/utils/geometry';
@@ -53,6 +54,7 @@ export const adaptOutdoorCourseDetails = ({
   outdoorCourseType,
   sensitiveAreas,
   signage,
+  service,
   infrastructure,
 }: {
   rawOutdoorCourseDetails: RawOutdoorCourseDetails;
@@ -64,6 +66,7 @@ export const adaptOutdoorCourseDetails = ({
   outdoorCourseType: OutdoorSiteTypeChoices;
   sensitiveAreas: SensitiveArea[];
   signage: SignageDictionary | null;
+  service: Service[] | null;
   infrastructure: InfrastructureDictionary | null;
 }): OutdoorCourseDetails => {
   return {
@@ -105,6 +108,7 @@ export const adaptOutdoorCourseDetails = ({
     id: rawOutdoorCourseDetails.id,
     sensitiveAreas,
     signage,
+    service,
     infrastructure,
   };
 };

--- a/frontend/src/modules/outdoorCourse/connector.ts
+++ b/frontend/src/modules/outdoorCourse/connector.ts
@@ -1,6 +1,7 @@
 import { getSensitiveAreas } from 'modules/sensitiveArea/connector';
 import { getGlobalConfig } from 'modules/utils/api.config';
 import { getSignage } from 'modules/signage/connector';
+import { getService } from 'modules/service/connector';
 import { getInfrastructure } from 'modules/infrastructure/connector';
 import { getCities } from '../city/connector';
 import { getOutdoorCourseType } from '../outdoorCourseType/connector';
@@ -29,6 +30,7 @@ export const getOutdoorCourseDetails = async (
   language: string,
 ): Promise<OutdoorCourseDetails> => {
   try {
+    // Typescript limit for Promise.all is for 10 promises
     const [
       rawOutdoorCourseDetails,
       pois,
@@ -38,8 +40,6 @@ export const getOutdoorCourseDetails = async (
       outdoorRatingScale,
       outdoorCourseType,
       sensitiveAreas,
-      signage,
-      infrastructure,
     ] = await Promise.all([
       fetchOutdoorCourseDetails({ language }, id),
       getPois(Number(id), language, 'courses'),
@@ -51,7 +51,11 @@ export const getOutdoorCourseDetails = async (
       getGlobalConfig().enableSensitiveAreas
         ? getSensitiveAreas('outdoorCourse', Number(id), language)
         : [],
+    ]);
+
+    const [signage, service, infrastructure] = await Promise.all([
       getSignage(language, id, 'OUTDOOR_COURSE'),
+      getService(language, id, 'OUTDOOR_COURSE'),
       getInfrastructure(language, id, 'OUTDOOR_COURSE'),
     ]);
 
@@ -65,6 +69,7 @@ export const getOutdoorCourseDetails = async (
       outdoorCourseType,
       sensitiveAreas,
       signage,
+      service,
       infrastructure,
     });
   } catch (e) {

--- a/frontend/src/modules/outdoorCourse/interface.ts
+++ b/frontend/src/modules/outdoorCourse/interface.ts
@@ -12,6 +12,7 @@ import {
   RawGeometryCollection,
 } from 'modules/interface';
 import { SignageDictionary } from 'modules/signage/interface';
+import { Service } from 'modules/service/interface';
 import { InfrastructureDictionary } from 'modules/infrastructure/interface';
 import { OutdoorCourseType } from '../outdoorCourseType/interface';
 import { OutdoorRatingWithScale } from '../outdoorRating/interface';
@@ -91,5 +92,6 @@ export interface OutdoorCourseDetails extends OutdoorCourse {
   typeCourse?: OutdoorCourseType;
   sensitiveAreas: SensitiveArea[];
   signage: SignageDictionary | null;
+  service: Service[] | null;
   infrastructure: InfrastructureDictionary | null;
 }

--- a/frontend/src/modules/outdoorSite/adapter.ts
+++ b/frontend/src/modules/outdoorSite/adapter.ts
@@ -1,5 +1,6 @@
 import { SensitiveArea } from 'modules/sensitiveArea/interface';
 import { SignageDictionary } from 'modules/signage/interface';
+import { Service } from 'modules/service/interface';
 import { InfrastructureDictionary } from 'modules/infrastructure/interface';
 import { getAttachments, getThumbnail, getThumbnails } from 'modules/utils/adapter';
 import { adaptGeometry } from 'modules/utils/geometry';
@@ -73,6 +74,7 @@ export const adaptOutdoorSiteDetails = ({
   outdoorSiteType,
   sensitiveAreas,
   signage,
+  service,
   infrastructure,
 }: {
   rawOutdoorSiteDetails: RawOutdoorSiteDetails;
@@ -93,6 +95,7 @@ export const adaptOutdoorSiteDetails = ({
   outdoorSiteType: OutdoorSiteTypeChoices;
   sensitiveAreas: SensitiveArea[];
   signage: SignageDictionary | null;
+  service: Service[] | null;
   infrastructure: InfrastructureDictionary | null;
 }): OutdoorSiteDetails => ({
   ...adaptOutdoorSites({
@@ -143,6 +146,7 @@ export const adaptOutdoorSiteDetails = ({
   typeSite: outdoorSiteType[Number(rawOutdoorSiteDetails?.properties?.type)],
   sensitiveAreas,
   signage,
+  service,
   infrastructure,
 });
 

--- a/frontend/src/modules/outdoorSite/connector.ts
+++ b/frontend/src/modules/outdoorSite/connector.ts
@@ -1,5 +1,6 @@
 import { getSensitiveAreas } from 'modules/sensitiveArea/connector';
 import { getSignage } from 'modules/signage/connector';
+import { getService } from 'modules/service/connector';
 import { getInfrastructure } from 'modules/infrastructure/connector';
 import { getCities } from '../city/connector';
 import { getThemes } from '../filters/theme/connector';
@@ -78,6 +79,7 @@ export const getOutdoorSiteDetails = async (
       outdoorRatingScale,
       outdoorSiteType,
       signage,
+      service,
       infrastructure,
       sensitiveAreas,
     ] = await Promise.all([
@@ -88,6 +90,7 @@ export const getOutdoorSiteDetails = async (
       getOutdoorRatingScale(language),
       getOutdoorSiteType(language),
       getSignage(language, id, 'OUTDOOR_SITE'),
+      getService(language, id, 'OUTDOOR_SITE'),
       getInfrastructure(language, id, 'OUTDOOR_SITE'),
       getGlobalConfig().enableSensitiveAreas
         ? getSensitiveAreas('outdoorSite', Number(id), language)
@@ -113,6 +116,7 @@ export const getOutdoorSiteDetails = async (
       outdoorSiteType,
       sensitiveAreas,
       signage,
+      service,
       infrastructure,
     });
   } catch (e) {

--- a/frontend/src/modules/outdoorSite/interface.ts
+++ b/frontend/src/modules/outdoorSite/interface.ts
@@ -13,6 +13,7 @@ import {
   RawWebLink,
 } from 'modules/interface';
 import { SignageDictionary } from 'modules/signage/interface';
+import { Service } from 'modules/service/interface';
 import { InfrastructureDictionary } from 'modules/infrastructure/interface';
 import { Activity } from '../activities/interface';
 import { InformationDesk } from '../informationDesk/interface';
@@ -112,6 +113,7 @@ export interface OutdoorSiteDetails extends OutdoorSite {
   ratings: OutdoorRatingWithScale[];
   ratingsDescription: string;
   signage: SignageDictionary | null;
+  service: Service[] | null;
   infrastructure: InfrastructureDictionary | null;
   typeSite?: OutdoorSiteType;
   sensitiveAreas: SensitiveArea[];

--- a/frontend/src/modules/service/adapter.ts
+++ b/frontend/src/modules/service/adapter.ts
@@ -1,0 +1,20 @@
+import { ServiceTypeDictionary } from 'modules/serviceType/interface';
+import { RawService, Service } from './interface';
+
+export const adaptServices = ({
+  rawService,
+  serviceTypeDictionary,
+}: {
+  rawService: RawService[];
+  serviceTypeDictionary: ServiceTypeDictionary;
+}): Service[] => {
+  return rawService.map(service => ({
+    id: service.id.toString(),
+    geometry: {
+      x: service.geometry.coordinates[0],
+      y: service.geometry.coordinates[1],
+      z: service.geometry.coordinates[2],
+    },
+    type: serviceTypeDictionary[service.type],
+  }));
+};

--- a/frontend/src/modules/service/api.ts
+++ b/frontend/src/modules/service/api.ts
@@ -1,0 +1,16 @@
+import { GeotrekAPI } from 'services/api/client';
+import { APIQuery, APIResponseForList } from 'services/api/interface';
+import { RawService } from './interface';
+
+const fieldsParams = {
+  fields: 'id,geometry,type',
+};
+
+export const fetchService = (query: APIQuery): Promise<APIResponseForList<RawService>> => {
+  try {
+    return GeotrekAPI.get('/service', { params: { ...query, ...fieldsParams } }).then(r => r.data);
+  } catch (e) {
+    console.error('Error in service/api/fetch', e);
+    throw e;
+  }
+};

--- a/frontend/src/modules/service/connector.ts
+++ b/frontend/src/modules/service/connector.ts
@@ -1,0 +1,38 @@
+import { getServiceType } from 'modules/serviceType/connector';
+import { adaptServices } from './adapter';
+import { fetchService } from './api';
+import { Service } from './interface';
+
+type Type =
+  | 'TREK'
+  | 'TOURISTIC_CONTENT'
+  | 'OUTDOOR_SITE'
+  | 'OUTDOOR_COURSE'
+  | 'TOURISTIC_EVENT'
+  | undefined;
+
+const getNearProp = (type: Type): string | null => {
+  if (type === undefined) {
+    return null;
+  }
+  return `near_${type.replace('_', '').toLowerCase()}`;
+};
+export const getService = async (
+  language: string,
+  id: string,
+  type?: Type,
+): Promise<Service[] | null> => {
+  const nearProp = getNearProp(type);
+  try {
+    const [rawService, serviceTypeDictionary] = await Promise.all([
+      fetchService({ language, ...(nearProp !== null && { [nearProp]: Number(id) }) }),
+      getServiceType(language),
+    ]);
+    return adaptServices({
+      rawService: rawService.results,
+      serviceTypeDictionary,
+    });
+  } catch (e) {
+    return null;
+  }
+};

--- a/frontend/src/modules/service/interface.ts
+++ b/frontend/src/modules/service/interface.ts
@@ -1,0 +1,14 @@
+import { Coordinate3D, RawPointGeometry3D } from 'modules/interface';
+import { ServiceType } from 'modules/serviceType/interface';
+
+export interface RawService {
+  id: number;
+  geometry: RawPointGeometry3D;
+  structure: string;
+  type: number;
+}
+export interface Service {
+  id: string;
+  geometry: Coordinate3D;
+  type: ServiceType;
+}

--- a/frontend/src/modules/service/mocks/index.ts
+++ b/frontend/src/modules/service/mocks/index.ts
@@ -1,0 +1,25 @@
+import { mockRoute } from 'services/testing/utils';
+
+export const mockServiceResponse = () => ({
+  count: 1,
+  next: null,
+  previous: null,
+  results: [
+    {
+      id: 1,
+      geometry: { type: 'Point', coordinates: [1, 2] },
+      type: 1,
+    },
+  ],
+});
+
+export const mockServiceRoute = (times: number, nearTrek: number): void =>
+  mockRoute({
+    route: '/service',
+    mockData: mockServiceResponse(),
+    additionalQueries: {
+      fields: 'id,geometry,type',
+      near_trek: nearTrek,
+    },
+    times,
+  });

--- a/frontend/src/modules/serviceType/adapter.ts
+++ b/frontend/src/modules/serviceType/adapter.ts
@@ -1,0 +1,10 @@
+import { ServiceType, ServiceTypeDictionary } from './interface';
+export const adaptServiceType = (serviceType: ServiceType[]): ServiceTypeDictionary => {
+  return serviceType.reduce(
+    (list, item) => ({
+      ...list,
+      [item.id]: item,
+    }),
+    {},
+  );
+};

--- a/frontend/src/modules/serviceType/api.ts
+++ b/frontend/src/modules/serviceType/api.ts
@@ -1,0 +1,12 @@
+import { GeotrekAPI } from 'services/api/client';
+import { APIQuery, APIResponseForList } from 'services/api/interface';
+import { ServiceType } from './interface';
+
+const fieldsParams = {
+  fields: 'id,name,pictogram',
+};
+
+export const fetchServiceType = (query: APIQuery): Promise<APIResponseForList<ServiceType>> =>
+  GeotrekAPI.get('/service_type', {
+    params: { ...query, ...fieldsParams },
+  }).then(r => r.data);

--- a/frontend/src/modules/serviceType/connector.ts
+++ b/frontend/src/modules/serviceType/connector.ts
@@ -1,0 +1,9 @@
+import { adaptServiceType } from './adapter';
+import { fetchServiceType } from './api';
+import { ServiceTypeDictionary } from './interface';
+
+export const getServiceType = async (language: string): Promise<ServiceTypeDictionary> => {
+  const rawServiceType = await fetchServiceType({ language });
+
+  return adaptServiceType(rawServiceType.results);
+};

--- a/frontend/src/modules/serviceType/interface.ts
+++ b/frontend/src/modules/serviceType/interface.ts
@@ -1,0 +1,9 @@
+export interface ServiceType {
+  id: number;
+  name: string;
+  pictogram: string;
+}
+
+export interface ServiceTypeDictionary {
+  [id: number]: ServiceType;
+}

--- a/frontend/src/modules/serviceType/mocks/index.ts
+++ b/frontend/src/modules/serviceType/mocks/index.ts
@@ -1,0 +1,26 @@
+import { mockRoute } from 'services/testing/utils';
+
+export const mockServiceTypeResponse = () => ({
+  count: 1,
+  next: null,
+  previous: null,
+  results: [
+    {
+      type: {
+        id: 1,
+        name: "Petit cours d'eau",
+        pictogram: null,
+      },
+    },
+  ],
+});
+
+export const mockServiceTypeRoute = (times: number): void =>
+  mockRoute({
+    route: '/service_type',
+    mockData: mockServiceTypeResponse(),
+    additionalQueries: {
+      fields: 'id,label,pictogram',
+    },
+    times,
+  });

--- a/frontend/src/translations/ca.json
+++ b/frontend/src/translations/ca.json
@@ -69,7 +69,8 @@
         "courses": "Parcours",
         "experiences": "Lieux de pratique",
         "signage": "Senyalització",
-        "infrastructure": "Infrastructures"
+        "infrastructure": "Infrastructures",
+        "service": "Others infos"
       },
       "resetView": "Recenter el mapa"
     }

--- a/frontend/src/translations/de.json
+++ b/frontend/src/translations/de.json
@@ -69,7 +69,8 @@
         "courses": "Parcours",
         "experiences": "Lieux de pratique",
         "signage": "Beschilderung",
-        "infrastructure": "Infrastructures"
+        "infrastructure": "Infrastructures",
+        "service": "Others infos"
       },
       "resetView": "Karte zentrieren"
     }

--- a/frontend/src/translations/en.json
+++ b/frontend/src/translations/en.json
@@ -71,7 +71,8 @@
         "courses": "Parcours",
         "experiences": "Lieux de pratique",
         "signage": "Signage",
-        "infrastructure": "Infrastructures"
+        "infrastructure": "Infrastructures",
+        "service": "Others infos"
       },
       "resetView": "Recenter map"
     }

--- a/frontend/src/translations/es.json
+++ b/frontend/src/translations/es.json
@@ -69,7 +69,8 @@
         "courses": "Parcours",
         "experiences": "Lieux de pratique",
         "signage": "Señalización",
-        "infrastructure": "Infrastructures"
+        "infrastructure": "Infrastructures",
+        "service": "Others infos"
       },
       "resetView": "Centrarse la mapa"
     }

--- a/frontend/src/translations/fr.json
+++ b/frontend/src/translations/fr.json
@@ -72,7 +72,8 @@
         "courses": "Parcours",
         "experiences": "Lieux de pratique",
         "signage": "Signalétiques",
-        "infrastructure": "Aménagements"
+        "infrastructure": "Aménagements",
+        "service": "Autres infos"
       },
       "resetView": "Recentrer la carte"
     }

--- a/frontend/src/translations/it.json
+++ b/frontend/src/translations/it.json
@@ -71,7 +71,8 @@
         "courses": "Parcours",
         "experiences": "Lieux de pratique",
         "signage": "Segnaletica",
-        "infrastructure": "Infrastructures"
+        "infrastructure": "Infrastructures",
+        "service": "Others infos"
       },
       "resetView": "Rimettere a fuoco la mappa"
     }


### PR DESCRIPTION
## Check before merging

- [x] 3rd part of the Ticket : [Ajouter les objets secondaires sur la carte (signalétique, aménagements, services)](https://github.com/GeotrekCE/Geotrek-rando-v3/issues/408)
- [x] I made sure that all displayed texts are imported from translation files.

