### PR TITLE
Fixes/bug offline content

### DIFF
--- a/frontend/src/components/Header/BurgerMenu/BurgerMenu.tsx
+++ b/frontend/src/components/Header/BurgerMenu/BurgerMenu.tsx
@@ -59,8 +59,11 @@ export const BurgerMenu: React.FC<Props> = ({ config, menuItems, displayState = 
           {intl.formatMessage({ id: 'header.goToSearch' })}
         </a>
       </NextLink>
-      <NextLink href={routes.OFFLINE} passHref locale={currentLanguage} key={routes.OFFLINE}>
-        <a className="flex items-center pt-4 pb-4 font-bold outline-none cursor-pointer border-b pb-2 border-solid border-greySoft">
+      <NextLink href={routes.OFFLINE} locale={currentLanguage} key={routes.OFFLINE}>
+        <a
+          className="flex items-center pt-4 pb-4 font-bold outline-none cursor-pointer border-b pb-2 border-solid border-greySoft"
+          rel="nofollow"
+        >
           {intl.formatMessage({ id: 'header.offline' })}
         </a>
       </NextLink>

--- a/frontend/src/components/Header/BurgerMenu/__tests__/__snapshots__/BurgerMenu.test.tsx.snap
+++ b/frontend/src/components/Header/BurgerMenu/__tests__/__snapshots__/BurgerMenu.test.tsx.snap
@@ -225,6 +225,7 @@ Object {
               <a
                 class="flex items-center pt-4 pb-4 font-bold outline-none cursor-pointer border-b pb-2 border-solid border-greySoft"
                 href="/offline"
+                rel="nofollow"
               >
                 Contenus hors ligne
               </a>
@@ -484,6 +485,7 @@ Object {
             <a
               class="flex items-center pt-4 pb-4 font-bold outline-none cursor-pointer border-b pb-2 border-solid border-greySoft"
               href="/offline"
+              rel="nofollow"
             >
               Contenus hors ligne
             </a>

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -60,11 +60,8 @@ class MyApp extends App<AppProps> {
   static async getInitialProps(props: any): Promise<AppProps> {
     const { Component, ctx } = props;
     try {
-      const { pathname } = ctx;
       const pageProps =
-        Component.getInitialProps !== undefined && pathname !== '/offline'
-          ? await Component.getInitialProps(ctx)
-          : {};
+        Component.getInitialProps !== undefined ? await Component.getInitialProps(ctx) : {};
       const messages = await loadLocales(props);
       return { pageProps, hasError: false, errorEventId: undefined, messages };
     } catch (error) {

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -59,10 +59,12 @@ interface AppProps extends AppInitialProps {
 class MyApp extends App<AppProps> {
   static async getInitialProps(props: any): Promise<AppProps> {
     const { Component, ctx } = props;
-
     try {
+      const { pathname } = ctx;
       const pageProps =
-        Component.getInitialProps !== undefined ? await Component.getInitialProps(ctx) : {};
+        Component.getInitialProps !== undefined && pathname !== '/offline'
+          ? await Component.getInitialProps(ctx)
+          : {};
       const messages = await loadLocales(props);
       return { pageProps, hasError: false, errorEventId: undefined, messages };
     } catch (error) {


### PR DESCRIPTION
Détails PR : nous avons investigué sur ce bug qui rejoint le ticket [(https://github.com/GeotrekCE/Geotrek-rando-v3/issues/621)](https://github.com/GeotrekCE/Geotrek-rando-v3/issues/621). Nous avons réussi à enlever l'erreur qui apparaissait au premier rendu de la page en ajoutant une propriété sur le lien qui mène à "contenus hors ligne". (rel="nofollow"). Cela permet au clic de rafraîchir la page offline et d'enlever cette erreur de premier rendu. On a testé en mode mobile et en mode PWA, la page offline fonctionne bien. cf demo : [(https://demo.geotrekrando.natural-solutions.eu/)](https://demo.geotrekrando.natural-solutions.eu/)
