### PR TITLE
Fix cards for ios display

### DIFF
--- a/frontend/src/components/Carousel/Carousel.tsx
+++ b/frontend/src/components/Carousel/Carousel.tsx
@@ -22,6 +22,9 @@ export const Carousel: React.FC<CarouselProps> = ({
   prevArrow,
   dots,
 }) => {
+  if (Array.isArray(children) && children.length <= 1) {
+    return <>{children}</>;
+  }
   return (
     <StyledSlider
       lazyLoad="ondemand"

--- a/frontend/src/components/pages/details/components/DetailsCard/__tests__/DetailsCard.test.tsx
+++ b/frontend/src/components/pages/details/components/DetailsCard/__tests__/DetailsCard.test.tsx
@@ -19,7 +19,17 @@ describe('DetailsCard', () => {
         "<span>Pour esp&eacute;rer apercevoir cet oiseau, partir la nuit au printemps, parcourir un grand d&eacute;nivel&eacute; afin d'arriver sur son terrain de pr&eacute;dilection &agrave; plus de 2000 m voire 3000 m d'altitude avant le lever du jour et l&agrave;, entendre le chant guttural&nbsp;caract&eacute;ristique qui trahit sa pr&eacute;sence. Mais pour le voir, il faudra bien ouvrir les yeux ou se munir d'une paire de jumelles. Et alors l&agrave;, quel bonheur&nbsp;! Le lagop&egrave;de alpin est l'esp&egrave;ce arctique par excellence, menac&eacute;e entre autre par le r&eacute;chauffement climatique. Il fait partie des esp&egrave;ces &agrave; prot&eacute;ger dans le c&oelig;ur du Parc national des Ecrins.</span>",
     };
     const detailsDescription = render(<DetailsCard {...propsCard} />);
+    const detailsDescriptionWithCarousel = render(
+      <DetailsCard
+        {...propsCard}
+        thumbnailUris={[
+          'https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_1280.jpg',
+          'https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_1280.jpg',
+        ]}
+      />,
+    );
 
     expect(detailsDescription).toMatchSnapshot();
+    expect(detailsDescriptionWithCarousel).toMatchSnapshot();
   });
 });

--- a/frontend/src/components/pages/details/components/DetailsCard/__tests__/__snapshots__/DetailsCard.test.tsx.snap
+++ b/frontend/src/components/pages/details/components/DetailsCard/__tests__/__snapshots__/DetailsCard.test.tsx.snap
@@ -25,10 +25,81 @@ Object {
               <div
                 style="width: 100%; height: 100%;"
               >
+                <img
+                  class="DetailsCard__CardSingleImage-sc-1paweiv-1 fzeiag"
+                  height="200"
+                  src="https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_1280.jpg"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="CardIcon__Wrapper-sc-cv6h96-0 bXmPlv absolute top-4 left-4 h-8 flex items-center rounded-full shadow-sm text-white border-2 border-white border-solid overflow-hidden"
+            color="#AA397D"
+          >
+            <div
+              class="pr-3 whitespace-nowrap"
+            >
+              Randonnée pédestre
+            </div>
+          </div>
+        </div>
+        <div
+          class="flex flex-col relative
+        p-2 desktop:p-6 desktop:my-auto"
+        >
+          <p
+            class="text-Mobile-C1 desktop:text-H4 text-primary1 font-bold"
+          >
+            Église St Louis
+          </p>
+          <div
+            class="mt-1 desktop:mt-4 flex flex-col desktop:flex-row desktop:items-end text-Mobile-C2 desktop:text-P1 text-greyDarkColored"
+          >
+            <div
+              class="utils__HtmlText-sc-16l79i-0 DetailsCard__TruncatedHtmlText-sc-1paweiv-2 jgscmn ewDPit text-greyDarkColored"
+            >
+              <span>
+                Pour espérer apercevoir cet oiseau, partir la nuit au printemps, parcourir un grand dénivelé afin d'arriver sur son terrain de prédilection à plus de 2000 m voire 3000 m d'altitude avant le lever du jour et là, entendre le chant guttural caractéristique qui trahit sa présence. Mais pour le voir, il faudra bien ouvrir les yeux ou se munir d'une paire de jumelles. Et alors là, quel bonheur ! Le lagopède alpin est l'espèce arctique par excellence, menacée entre autre par le réchauffement climatique. Il fait partie des espèces à protéger dans le cœur du Parc national des Ecrins.
+              </span>
+            </div>
+            <span
+              class="text-primary1 underline cursor-pointer flex-shrink-0 desktop:ml-1"
+            >
+              lire la suite
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div>
+      <div
+        class="DetailsCard__DetailsCardContainer-sc-1paweiv-0 jZvBUu border border-solid border-greySoft rounded-card
+      flex-none overflow-hidden relative
+      flex flex-col h-auto desktop:flex-row desktop:w-auto mx-1
+      cursor-pointer hover:border-blackSemiTransparent transition-all duration-500
+      "
+        height="200"
+      >
+        <div
+          class="flex-none desktop:w-2/5"
+        >
+          <div
+            style="background-color: white; position: relative;"
+          >
+            <div
+              style="display: flex; align-items: center; justify-content: center; width: 100%; height: 100%;"
+            >
+              <div
+                style="width: 100%; height: 100%;"
+              >
                 <div
                   class="slick-slider Carousel__StyledSlider-sc-1tck7ng-0 iyRBSY slick-initialized"
+                  dir="ltr"
                 >
-                  
+                  <div
+                    class="Carousel__StyledArrow-sc-1tck7ng-1 Carousel__SmallStyledArrow-sc-1tck7ng-2 Carousel__SmallStyledLeftArrow-sc-1tck7ng-5 hBtEpW gaMWOH clvhZH slick-arrow slick-prev"
+                  />
                   <div
                     class="slick-list"
                   >
@@ -36,6 +107,13 @@ Object {
                       class="slick-track"
                       style="opacity: 1; transform: translate3d(0px, 0px, 0px);"
                     >
+                      <div
+                        aria-hidden="true"
+                        class="slick-slide slick-cloned"
+                        data-index="-1"
+                        style="width: 0px;"
+                        tabindex="-1"
+                      />
                       <div
                         aria-hidden="false"
                         class="slick-slide slick-active slick-current"
@@ -53,10 +131,415 @@ Object {
                           />
                         </div>
                       </div>
+                      <div
+                        aria-hidden="true"
+                        class="slick-slide"
+                        data-index="1"
+                        style="outline: none; width: 0px;"
+                        tabindex="-1"
+                      />
+                      <div
+                        aria-hidden="true"
+                        class="slick-slide slick-cloned"
+                        data-index="2"
+                        style="width: 0px;"
+                        tabindex="-1"
+                      >
+                        <div>
+                          <img
+                            class="DetailsCard__CardSingleImage-sc-1paweiv-1 fzeiag"
+                            height="200"
+                            src="https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_1280.jpg"
+                            style="width: 100%; display: inline-block;"
+                            tabindex="-1"
+                          />
+                        </div>
+                      </div>
+                      <div
+                        aria-hidden="true"
+                        class="slick-slide slick-cloned"
+                        data-index="3"
+                        style="width: 0px;"
+                        tabindex="-1"
+                      />
                     </div>
                   </div>
-                  
-                  
+                  <div
+                    class="Carousel__StyledArrow-sc-1tck7ng-1 Carousel__SmallStyledArrow-sc-1tck7ng-2 Carousel__SmallStyledRightArrow-sc-1tck7ng-4 hBtEpW gaMWOH eYPdUK slick-arrow slick-next"
+                  />
+                  <div
+                    class="Carousel__StyledDots-sc-1tck7ng-8 Carousel__SmallStyledDots-sc-1tck7ng-9 fOVzLR slick-dots"
+                  >
+                    <ul>
+                      <li
+                        class="slick-active"
+                      >
+                        <button>
+                          1
+                        </button>
+                      </li>
+                      <li
+                        class=""
+                      >
+                        <button>
+                          2
+                        </button>
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="CardIcon__Wrapper-sc-cv6h96-0 bXmPlv absolute top-4 left-4 h-8 flex items-center rounded-full shadow-sm text-white border-2 border-white border-solid overflow-hidden"
+            color="#AA397D"
+          >
+            <div
+              class="pr-3 whitespace-nowrap"
+            >
+              Randonnée pédestre
+            </div>
+          </div>
+        </div>
+        <div
+          class="flex flex-col relative
+        p-2 desktop:p-6 desktop:my-auto"
+        >
+          <p
+            class="text-Mobile-C1 desktop:text-H4 text-primary1 font-bold"
+          >
+            Église St Louis
+          </p>
+          <div
+            class="mt-1 desktop:mt-4 flex flex-col desktop:flex-row desktop:items-end text-Mobile-C2 desktop:text-P1 text-greyDarkColored"
+          >
+            <div
+              class="utils__HtmlText-sc-16l79i-0 DetailsCard__TruncatedHtmlText-sc-1paweiv-2 jgscmn ewDPit text-greyDarkColored"
+            >
+              <span>
+                Pour espérer apercevoir cet oiseau, partir la nuit au printemps, parcourir un grand dénivelé afin d'arriver sur son terrain de prédilection à plus de 2000 m voire 3000 m d'altitude avant le lever du jour et là, entendre le chant guttural caractéristique qui trahit sa présence. Mais pour le voir, il faudra bien ouvrir les yeux ou se munir d'une paire de jumelles. Et alors là, quel bonheur ! Le lagopède alpin est l'espèce arctique par excellence, menacée entre autre par le réchauffement climatique. Il fait partie des espèces à protéger dans le cœur du Parc national des Ecrins.
+              </span>
+            </div>
+            <span
+              class="text-primary1 underline cursor-pointer flex-shrink-0 desktop:ml-1"
+            >
+              lire la suite
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="DetailsCard__DetailsCardContainer-sc-1paweiv-0 jZvBUu border border-solid border-greySoft rounded-card
+      flex-none overflow-hidden relative
+      flex flex-col h-auto desktop:flex-row desktop:w-auto mx-1
+      cursor-pointer hover:border-blackSemiTransparent transition-all duration-500
+      "
+      height="200"
+    >
+      <div
+        class="flex-none desktop:w-2/5"
+      >
+        <div
+          style="background-color: white; position: relative;"
+        >
+          <div
+            style="display: flex; align-items: center; justify-content: center; width: 100%; height: 100%;"
+          >
+            <div
+              style="width: 100%; height: 100%;"
+            >
+              <img
+                class="DetailsCard__CardSingleImage-sc-1paweiv-1 fzeiag"
+                height="200"
+                src="https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_1280.jpg"
+              />
+            </div>
+          </div>
+        </div>
+        <div
+          class="CardIcon__Wrapper-sc-cv6h96-0 bXmPlv absolute top-4 left-4 h-8 flex items-center rounded-full shadow-sm text-white border-2 border-white border-solid overflow-hidden"
+          color="#AA397D"
+        >
+          <div
+            class="pr-3 whitespace-nowrap"
+          >
+            Randonnée pédestre
+          </div>
+        </div>
+      </div>
+      <div
+        class="flex flex-col relative
+        p-2 desktop:p-6 desktop:my-auto"
+      >
+        <p
+          class="text-Mobile-C1 desktop:text-H4 text-primary1 font-bold"
+        >
+          Église St Louis
+        </p>
+        <div
+          class="mt-1 desktop:mt-4 flex flex-col desktop:flex-row desktop:items-end text-Mobile-C2 desktop:text-P1 text-greyDarkColored"
+        >
+          <div
+            class="utils__HtmlText-sc-16l79i-0 DetailsCard__TruncatedHtmlText-sc-1paweiv-2 jgscmn ewDPit text-greyDarkColored"
+          >
+            <span>
+              Pour espérer apercevoir cet oiseau, partir la nuit au printemps, parcourir un grand dénivelé afin d'arriver sur son terrain de prédilection à plus de 2000 m voire 3000 m d'altitude avant le lever du jour et là, entendre le chant guttural caractéristique qui trahit sa présence. Mais pour le voir, il faudra bien ouvrir les yeux ou se munir d'une paire de jumelles. Et alors là, quel bonheur ! Le lagopède alpin est l'espèce arctique par excellence, menacée entre autre par le réchauffement climatique. Il fait partie des espèces à protéger dans le cœur du Parc national des Ecrins.
+            </span>
+          </div>
+          <span
+            class="text-primary1 underline cursor-pointer flex-shrink-0 desktop:ml-1"
+          >
+            lire la suite
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`DetailsCard should display a well parsed description Element 2`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    <div>
+      <div
+        class="DetailsCard__DetailsCardContainer-sc-1paweiv-0 jZvBUu border border-solid border-greySoft rounded-card
+      flex-none overflow-hidden relative
+      flex flex-col h-auto desktop:flex-row desktop:w-auto mx-1
+      cursor-pointer hover:border-blackSemiTransparent transition-all duration-500
+      "
+        height="200"
+      >
+        <div
+          class="flex-none desktop:w-2/5"
+        >
+          <div
+            style="background-color: white; position: relative;"
+          >
+            <div
+              style="display: flex; align-items: center; justify-content: center; width: 100%; height: 100%;"
+            >
+              <div
+                style="width: 100%; height: 100%;"
+              >
+                <img
+                  class="DetailsCard__CardSingleImage-sc-1paweiv-1 fzeiag"
+                  height="200"
+                  src="https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_1280.jpg"
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="CardIcon__Wrapper-sc-cv6h96-0 bXmPlv absolute top-4 left-4 h-8 flex items-center rounded-full shadow-sm text-white border-2 border-white border-solid overflow-hidden"
+            color="#AA397D"
+          >
+            <div
+              class="pr-3 whitespace-nowrap"
+            >
+              Randonnée pédestre
+            </div>
+          </div>
+        </div>
+        <div
+          class="flex flex-col relative
+        p-2 desktop:p-6 desktop:my-auto"
+        >
+          <p
+            class="text-Mobile-C1 desktop:text-H4 text-primary1 font-bold"
+          >
+            Église St Louis
+          </p>
+          <div
+            class="mt-1 desktop:mt-4 flex flex-col desktop:flex-row desktop:items-end text-Mobile-C2 desktop:text-P1 text-greyDarkColored"
+          >
+            <div
+              class="utils__HtmlText-sc-16l79i-0 DetailsCard__TruncatedHtmlText-sc-1paweiv-2 jgscmn ewDPit text-greyDarkColored"
+            >
+              <span>
+                Pour espérer apercevoir cet oiseau, partir la nuit au printemps, parcourir un grand dénivelé afin d'arriver sur son terrain de prédilection à plus de 2000 m voire 3000 m d'altitude avant le lever du jour et là, entendre le chant guttural caractéristique qui trahit sa présence. Mais pour le voir, il faudra bien ouvrir les yeux ou se munir d'une paire de jumelles. Et alors là, quel bonheur ! Le lagopède alpin est l'espèce arctique par excellence, menacée entre autre par le réchauffement climatique. Il fait partie des espèces à protéger dans le cœur du Parc national des Ecrins.
+              </span>
+            </div>
+            <span
+              class="text-primary1 underline cursor-pointer flex-shrink-0 desktop:ml-1"
+            >
+              lire la suite
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div>
+      <div
+        class="DetailsCard__DetailsCardContainer-sc-1paweiv-0 jZvBUu border border-solid border-greySoft rounded-card
+      flex-none overflow-hidden relative
+      flex flex-col h-auto desktop:flex-row desktop:w-auto mx-1
+      cursor-pointer hover:border-blackSemiTransparent transition-all duration-500
+      "
+        height="200"
+      >
+        <div
+          class="flex-none desktop:w-2/5"
+        >
+          <div
+            style="background-color: white; position: relative;"
+          >
+            <div
+              style="display: flex; align-items: center; justify-content: center; width: 100%; height: 100%;"
+            >
+              <div
+                style="width: 100%; height: 100%;"
+              >
+                <div
+                  class="slick-slider Carousel__StyledSlider-sc-1tck7ng-0 iyRBSY slick-initialized"
+                  dir="ltr"
+                >
+                  <div
+                    class="Carousel__StyledArrow-sc-1tck7ng-1 Carousel__SmallStyledArrow-sc-1tck7ng-2 Carousel__SmallStyledLeftArrow-sc-1tck7ng-5 hBtEpW gaMWOH clvhZH slick-arrow slick-prev"
+                  />
+                  <div
+                    class="slick-list"
+                  >
+                    <div
+                      class="slick-track"
+                      style="opacity: 1; transform: translate3d(0px, 0px, 0px);"
+                    >
+                      <div
+                        aria-hidden="true"
+                        class="slick-slide slick-cloned"
+                        data-index="-1"
+                        style="width: 0px;"
+                        tabindex="-1"
+                      />
+                      <div
+                        aria-hidden="false"
+                        class="slick-slide slick-active slick-current"
+                        data-index="0"
+                        style="outline: none; width: 0px;"
+                        tabindex="-1"
+                      >
+                        <div>
+                          <img
+                            class="DetailsCard__CardSingleImage-sc-1paweiv-1 fzeiag"
+                            height="200"
+                            src="https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_1280.jpg"
+                            style="width: 100%; display: inline-block;"
+                            tabindex="-1"
+                          />
+                        </div>
+                      </div>
+                      <div
+                        aria-hidden="true"
+                        class="slick-slide"
+                        data-index="1"
+                        style="outline: none; width: 0px;"
+                        tabindex="-1"
+                      />
+                      <div
+                        aria-hidden="true"
+                        class="slick-slide slick-cloned"
+                        data-index="2"
+                        style="width: 0px;"
+                        tabindex="-1"
+                      >
+                        <div>
+                          <img
+                            class="DetailsCard__CardSingleImage-sc-1paweiv-1 fzeiag"
+                            height="200"
+                            src="https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_1280.jpg"
+                            style="width: 100%; display: inline-block;"
+                            tabindex="-1"
+                          />
+                        </div>
+                      </div>
+                      <div
+                        aria-hidden="true"
+                        class="slick-slide slick-cloned"
+                        data-index="3"
+                        style="width: 0px;"
+                        tabindex="-1"
+                      />
+                    </div>
+                  </div>
+                  <div
+                    class="Carousel__StyledArrow-sc-1tck7ng-1 Carousel__SmallStyledArrow-sc-1tck7ng-2 Carousel__SmallStyledRightArrow-sc-1tck7ng-4 hBtEpW gaMWOH eYPdUK slick-arrow slick-next"
+                  />
+                  <div
+                    class="Carousel__StyledDots-sc-1tck7ng-8 Carousel__SmallStyledDots-sc-1tck7ng-9 fOVzLR slick-dots"
+                  >
+                    <ul>
+                      <li
+                        class="slick-active"
+                      >
+                        <button>
+                          1
+                        </button>
+                      </li>
+                      <li
+                        class=""
+                      >
+                        <button>
+                          2
+                        </button>
+                      </li>
+                    </ul>
+                  </div>
                 </div>
               </div>
             </div>
@@ -124,8 +607,11 @@ Object {
             >
               <div
                 class="slick-slider Carousel__StyledSlider-sc-1tck7ng-0 iyRBSY slick-initialized"
+                dir="ltr"
               >
-                
+                <div
+                  class="Carousel__StyledArrow-sc-1tck7ng-1 Carousel__SmallStyledArrow-sc-1tck7ng-2 Carousel__SmallStyledLeftArrow-sc-1tck7ng-5 hBtEpW gaMWOH clvhZH slick-arrow slick-prev"
+                />
                 <div
                   class="slick-list"
                 >
@@ -133,6 +619,13 @@ Object {
                     class="slick-track"
                     style="opacity: 1; transform: translate3d(0px, 0px, 0px);"
                   >
+                    <div
+                      aria-hidden="true"
+                      class="slick-slide slick-cloned"
+                      data-index="-1"
+                      style="width: 0px;"
+                      tabindex="-1"
+                    />
                     <div
                       aria-hidden="false"
                       class="slick-slide slick-active slick-current"
@@ -150,10 +643,62 @@ Object {
                         />
                       </div>
                     </div>
+                    <div
+                      aria-hidden="true"
+                      class="slick-slide"
+                      data-index="1"
+                      style="outline: none; width: 0px;"
+                      tabindex="-1"
+                    />
+                    <div
+                      aria-hidden="true"
+                      class="slick-slide slick-cloned"
+                      data-index="2"
+                      style="width: 0px;"
+                      tabindex="-1"
+                    >
+                      <div>
+                        <img
+                          class="DetailsCard__CardSingleImage-sc-1paweiv-1 fzeiag"
+                          height="200"
+                          src="https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_1280.jpg"
+                          style="width: 100%; display: inline-block;"
+                          tabindex="-1"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      aria-hidden="true"
+                      class="slick-slide slick-cloned"
+                      data-index="3"
+                      style="width: 0px;"
+                      tabindex="-1"
+                    />
                   </div>
                 </div>
-                
-                
+                <div
+                  class="Carousel__StyledArrow-sc-1tck7ng-1 Carousel__SmallStyledArrow-sc-1tck7ng-2 Carousel__SmallStyledRightArrow-sc-1tck7ng-4 hBtEpW gaMWOH eYPdUK slick-arrow slick-next"
+                />
+                <div
+                  class="Carousel__StyledDots-sc-1tck7ng-8 Carousel__SmallStyledDots-sc-1tck7ng-9 fOVzLR slick-dots"
+                >
+                  <ul>
+                    <li
+                      class="slick-active"
+                    >
+                      <button>
+                        1
+                      </button>
+                    </li>
+                    <li
+                      class=""
+                    >
+                      <button>
+                        2
+                      </button>
+                    </li>
+                  </ul>
+                </div>
               </div>
             </div>
           </div>

--- a/frontend/src/components/pages/search/components/ResultCard/ResultCard.tsx
+++ b/frontend/src/components/pages/search/components/ResultCard/ResultCard.tsx
@@ -163,7 +163,7 @@ export const ResultCard: React.FC<
         )}
       </Modal>
 
-      <Link href={redirectionUrl} testId={`Link-ResultCard-${id}`} className="w-full min-h-0">
+      <Link href={redirectionUrl} testId={`Link-ResultCard-${id}`} className="w-full">
         <DetailsContainer>
           <DetailsLayout>
             {place !== null && <Place>{place}</Place>}

--- a/frontend/src/components/pages/search/components/ResultCard/ResultCardCarousel/ResultCardCarousel.tsx
+++ b/frontend/src/components/pages/search/components/ResultCard/ResultCardCarousel/ResultCardCarousel.tsx
@@ -27,7 +27,7 @@ export const ResultCardCarousel: React.FC<ResultCardCarouselProps> = ({
 
   return (
     <Wrapper
-      className={`h-full w-full flex-shrink-0 relative desktop:w-resultCardDesktop`}
+      className={`h-full w-full flex-grow relative desktop:w-resultCardDesktop`}
       asColumn={asColumn}
     >
       <SmallCarousel>

--- a/frontend/src/components/pages/search/components/ResultCard/__tests__/__snapshots__/ResultCard.test.tsx.snap
+++ b/frontend/src/components/pages/search/components/ResultCard/__tests__/__snapshots__/ResultCard.test.tsx.snap
@@ -19,7 +19,7 @@ Object {
               style="width: 100%; height: 100%;"
             >
               <div
-                class="ResultCardCarousel__Wrapper-sc-13vjoai-0 botBuK h-full w-full flex-shrink-0 relative desktop:w-resultCardDesktop"
+                class="ResultCardCarousel__Wrapper-sc-13vjoai-0 botBuK h-full w-full flex-grow relative desktop:w-resultCardDesktop"
               >
                 <div
                   class="slick-slider Carousel__StyledSlider-sc-1tck7ng-0 iyRBSY slick-initialized"
@@ -63,7 +63,7 @@ Object {
           </div>
         </div>
         <a
-          class="Link__StyledLink-sc-oanbk8-0 htOOkH w-full min-h-0"
+          class="Link__StyledLink-sc-oanbk8-0 htOOkH w-full"
           data-testid="Link-ResultCard-2"
           href="/details-2-Balade-au-pays-des-menhirs"
         >
@@ -239,7 +239,7 @@ Object {
             style="width: 100%; height: 100%;"
           >
             <div
-              class="ResultCardCarousel__Wrapper-sc-13vjoai-0 botBuK h-full w-full flex-shrink-0 relative desktop:w-resultCardDesktop"
+              class="ResultCardCarousel__Wrapper-sc-13vjoai-0 botBuK h-full w-full flex-grow relative desktop:w-resultCardDesktop"
             >
               <div
                 class="slick-slider Carousel__StyledSlider-sc-1tck7ng-0 iyRBSY slick-initialized"
@@ -283,7 +283,7 @@ Object {
         </div>
       </div>
       <a
-        class="Link__StyledLink-sc-oanbk8-0 htOOkH w-full min-h-0"
+        class="Link__StyledLink-sc-oanbk8-0 htOOkH w-full"
         data-testid="Link-ResultCard-2"
         href="/details-2-Balade-au-pays-des-menhirs"
       >

--- a/frontend/src/components/pages/search/components/ResultCard/__tests__/__snapshots__/ResultCard.test.tsx.snap
+++ b/frontend/src/components/pages/search/components/ResultCard/__tests__/__snapshots__/ResultCard.test.tsx.snap
@@ -22,41 +22,13 @@ Object {
                 class="ResultCardCarousel__Wrapper-sc-13vjoai-0 botBuK h-full w-full flex-grow relative desktop:w-resultCardDesktop"
               >
                 <div
-                  class="slick-slider Carousel__StyledSlider-sc-1tck7ng-0 iyRBSY slick-initialized"
+                  class="relative h-full"
                 >
-                  
-                  <div
-                    class="slick-list"
-                  >
-                    <div
-                      class="slick-track"
-                      style="opacity: 1; transform: translate3d(0px, 0px, 0px);"
-                    >
-                      <div
-                        aria-hidden="false"
-                        class="slick-slide slick-active slick-current"
-                        data-index="0"
-                        style="outline: none; width: 0px;"
-                        tabindex="-1"
-                      >
-                        <div>
-                          <div
-                            class="relative h-full"
-                            style="width: 100%; display: inline-block;"
-                            tabindex="-1"
-                          >
-                            <img
-                              alt=""
-                              class="object-cover object-top w-full h-full"
-                              src=""
-                            />
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  
-                  
+                  <img
+                    alt=""
+                    class="object-cover object-top w-full h-full"
+                    src=""
+                  />
                 </div>
               </div>
             </div>
@@ -242,41 +214,13 @@ Object {
               class="ResultCardCarousel__Wrapper-sc-13vjoai-0 botBuK h-full w-full flex-grow relative desktop:w-resultCardDesktop"
             >
               <div
-                class="slick-slider Carousel__StyledSlider-sc-1tck7ng-0 iyRBSY slick-initialized"
+                class="relative h-full"
               >
-                
-                <div
-                  class="slick-list"
-                >
-                  <div
-                    class="slick-track"
-                    style="opacity: 1; transform: translate3d(0px, 0px, 0px);"
-                  >
-                    <div
-                      aria-hidden="false"
-                      class="slick-slide slick-active slick-current"
-                      data-index="0"
-                      style="outline: none; width: 0px;"
-                      tabindex="-1"
-                    >
-                      <div>
-                        <div
-                          class="relative h-full"
-                          style="width: 100%; display: inline-block;"
-                          tabindex="-1"
-                        >
-                          <img
-                            alt=""
-                            class="object-cover object-top w-full h-full"
-                            src=""
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                
-                
+                <img
+                  alt=""
+                  class="object-cover object-top w-full h-full"
+                  src=""
+                />
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Check before merging

- [x] Ticket : [Encarts remontant des fiches de la page d'accueil ne s'affichent pas entièrement sur IOS15+](https://github.com/GeotrekCE/Geotrek-rando-v3/issues/645)

- Fix (for good) the cards display for IOS browsers!
- Optimization of images in the card: If there is only one image in the card, the application displays it without mounting a carousel. So this solves a part of card swiping issues (the carousel hijacks the swiping to change image). 

