### PR TITLE
Add new Github Action workflow to trigger GitLab deployment on demo

### DIFF
--- a/.github/workflows/deploy-to-demo.yml
+++ b/.github/workflows/deploy-to-demo.yml
@@ -1,0 +1,14 @@
+name: Deploy release to demo instance
+
+on:
+  registry_package:
+    types:
+      - published
+
+jobs:
+  trigger-gitlab-webhook:
+    name: Trigger GitLab webhook
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Call webhook
+        run: "curl -X POST --fail -F token=${{ secrects.GITLAB_WEBHOOK_TOKEN }} -F ref=master ${{ secrets.GITLAB_WEBHOOK }}"


### PR DESCRIPTION
The job runs once the docker image has been published on the Github package repository. It calls GitLab webhook to start the deployment on the demo instance.