### PR TITLE
Features/on click image redirect to details page

### DIFF
--- a/frontend/src/components/pages/details/__tests__/Details.test.tsx
+++ b/frontend/src/components/pages/details/__tests__/Details.test.tsx
@@ -120,7 +120,7 @@ describe('Details', () => {
     await component.findByText('La Motte-en-Champsaur');
     await component.findAllByText('Lagopède alpin');
     await component.findAllByText('Refuge de la Lavey');
-    await component.findByText('Auberge Gaillard');
+    await component.findAllByText('Auberge Gaillard');
     await component.findByText(
       "L'auberge propose, dans un hameau de montagne en bout de route, en pleine nature, un hébergement de séjour, nuitée, demi-pension et pension complète dans un décor de la vie d'antan et d'aujourd'hui.",
     );

--- a/frontend/src/components/pages/details/components/DetailsCard/DetailsCard.tsx
+++ b/frontend/src/components/pages/details/components/DetailsCard/DetailsCard.tsx
@@ -6,6 +6,7 @@ import { HtmlText } from 'components/pages/details/utils';
 import getActivityColor from 'components/pages/search/components/ResultCard/getActivityColor';
 import parse from 'html-react-parser';
 import { ListAndMapContext } from 'modules/map/ListAndMapContext';
+import { useRouter } from 'next/router';
 import { useContext } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { textEllipsisAfterNLines } from 'services/cssHelpers';
@@ -55,6 +56,8 @@ export const DetailsCard: React.FC<DetailsCardProps> = ({
 
   const { setHoveredCardId } = useContext(ListAndMapContext);
 
+  const router = useRouter();
+
   return (
     <DetailsCardContainer
       height={heightState}
@@ -81,10 +84,15 @@ export const DetailsCard: React.FC<DetailsCardProps> = ({
           {({ isFullscreen, toggleFullscreen }) => (
             <>
               {isFullscreen &&
-                attachments &&
+                redirectionUrl &&
                 attachments.length > 0 &&
                 typeof navigator !== 'undefined' &&
-                navigator?.onLine && <DetailsCoverCarousel attachments={attachments} />}
+                navigator?.onLine && (
+                  <DetailsCoverCarousel
+                    onClickImage={() => router.push(redirectionUrl)}
+                    attachments={attachments}
+                  />
+                )}
               {!isFullscreen && (
                 <DetailsCardCarousel
                   thumbnailUris={

--- a/frontend/src/components/pages/details/components/DetailsCard/DetailsCard.tsx
+++ b/frontend/src/components/pages/details/components/DetailsCard/DetailsCard.tsx
@@ -84,16 +84,42 @@ export const DetailsCard: React.FC<DetailsCardProps> = ({
           {({ isFullscreen, toggleFullscreen }) => (
             <>
               {isFullscreen &&
+                type === 'TOURISTIC_CONTENT' &&
                 redirectionUrl &&
                 attachments.length > 0 &&
                 typeof navigator !== 'undefined' &&
                 navigator?.onLine && (
                   <DetailsCoverCarousel
+                    attachments={attachments}
                     onClickImage={() => router.push(redirectionUrl)}
+                  />
+                )}
+              {!isFullscreen &&
+                type === 'TOURISTIC_CONTENT' &&
+                redirectionUrl &&
+                attachments.length > 0 &&
+                typeof navigator !== 'undefined' &&
+                navigator?.onLine && (
+                  <DetailsCoverCarousel
+                    attachments={attachments}
+                    onClickImage={() => router.push(redirectionUrl)}
+                  />
+                )}
+              {isFullscreen &&
+                type !== 'TOURISTIC_CONTENT' &&
+                attachments.length > 0 &&
+                typeof navigator !== 'undefined' &&
+                navigator?.onLine && (
+                  <DetailsCoverCarousel
+                    onClickImage={
+                      typeof navigator !== 'undefined' && navigator?.onLine
+                        ? toggleFullscreen
+                        : undefined
+                    }
                     attachments={attachments}
                   />
                 )}
-              {!isFullscreen && (
+              {!isFullscreen && type !== 'TOURISTIC_CONTENT' && (
                 <DetailsCardCarousel
                   thumbnailUris={
                     typeof navigator !== 'undefined' && navigator?.onLine


### PR DESCRIPTION
## Détails PR : petit ajout par rapport à la PR [744](https://github.com/GeotrekCE/Geotrek-rando-v3/pull/744)
 
Sur la fiche détails d'une rando, dans la rubrique "Etapes" et "A proximité", le clic sur les images redirige aussi vers les objets. (comme suggéré sur le ticket : 
![image](https://user-images.githubusercontent.com/99249234/178562931-a56274aa-5fdb-4b7a-93d2-3c4185dccdb5.png)
)

A tester ici : [](https://demo.geotrekrando.natural-solutions.eu/trek/501-Petite-rando-itinerante-sympa)(https://demo.geotrekrando.natural-solutions.eu/trek/501-Petite-rando-itinerante-sympa)
## Screenshots

![image](https://user-images.githubusercontent.com/99249234/178563059-6e544ea7-effc-43e7-b27d-fd0581f7093b.png)
![image](https://user-images.githubusercontent.com/99249234/178563066-3339b066-7093-4e4e-adf4-572d46154d4f.png)


### Mobile

### Desktop
