### PR TITLE
Provide translations for filters label from config

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -115,7 +115,9 @@ In json files, you can just override the primary keys you need. You have to over
   - Contact information such as your name, address, phone number and email.
   - Links based on the key pair `label`/`url` (can be based on translation labels for multilingual) and/or the key `informationID` whose value is equal to a flatpage identifier.
 
-- `filter.json` to define filters to hide, their order and values (see example in https://github.com/GeotrekCE/Geotrek-rando-v3/blob/main/frontend/config/filter.json). If you want to hide some of the filter, you have to override their properties with `"display": false`.
+- `filter.json` to define filters to hide, their order and values (see example in https://github.com/GeotrekCE/Geotrek-rando-v3/blob/main/frontend/config/filter.json). If you want to :
+  - Hide some of filters, you have to override their properties with `"display": false`.
+  - Change the label for some filters, you need to define `translatedKey`, and copy the values into the translation files.
   The `labels` filter contains an additional `withExclude` parameter. Its default value is `true`. By setting it to `true`, the user can filter the search by excluding a label (`withExclude` only works if your version of Geotrek Admin is equal to or higher than [2.77.0](https://github.com/GeotrekCE/Geotrek-admin/releases/tag/2.77.0); please set it to `false` if this is not the case)
 
 - `map.json` to define basemaps URL and attributions, center (y, x), default and max zoom level (see example in https://github.com/GeotrekCE/Geotrek-rando-v3/blob/main/frontend/customization/config/map.json).

--- a/frontend/config/filter.json
+++ b/frontend/config/filter.json
@@ -42,22 +42,22 @@
       {
         "minValue": 0,
         "maxValue": 1,
-        "label": "0 - 1h"
+        "translatedKey": "search.filters.durationOptions.H:0-1"
       },
       {
         "minValue": 1,
         "maxValue": 2,
-        "label": "1h - 2h"
+        "translatedKey": "search.filters.durationOptions.H:1-2"
       },
       {
         "minValue": 2,
         "maxValue": 5,
-        "label": "2h - 5h"
+        "translatedKey": "search.filters.durationOptions.H:2-5"
       },
       {
         "minValue": 5,
         "maxValue": 10,
-        "label": "5h - 10h"
+        "translatedKey": "search.filters.durationOptions.H:5-10"
       }
     ]
   },
@@ -69,22 +69,22 @@
       {
         "minValue": 0,
         "maxValue": 5000,
-        "label": "0 - 5km"
+        "translatedKey": "search.filters.lengthOptions.KM:0-5"
       },
       {
         "minValue": 5000,
         "maxValue": 10000,
-        "label": "5km - 10km"
+        "translatedKey": "search.filters.lengthOptions.KM:5-10"
       },
       {
         "minValue": 10000,
         "maxValue": 15000,
-        "label": "10km - 15km"
+        "translatedKey": "search.filters.lengthOptions.KM:10-15"
       },
       {
         "minValue": 15000,
         "maxValue": 50000,
-        "label": "15km - 50km"
+        "translatedKey": "search.filters.lengthOptions.KM:15-50"
       }
     ]
   },
@@ -96,12 +96,12 @@
       {
         "minValue": 0,
         "maxValue": 500,
-        "label": "0 - 500m"
+        "translatedKey": "search.filters.ascentOptions.M:0-500"
       },
       {
         "minValue": 500,
         "maxValue": 1000,
-        "label": "500m - 1km"
+        "translatedKey": "search.filters.ascentOptions.M:500-1000"
       }
     ]
   },

--- a/frontend/src/components/pages/search/components/FilterBar/Field.tsx
+++ b/frontend/src/components/pages/search/components/FilterBar/Field.tsx
@@ -63,7 +63,11 @@ const Field: React.FC<Props> = ({ filterState, onSelect, hideLabel }) => {
             >
               <span className={`flex items-center ${option.pictogramUrl ? 'mr-1' : ''}`}>
                 {getIcon(option, Boolean(selectedOption))}
-                {option.label}
+                {
+                  option.translatedKey !== undefined
+                    ? intl.formatMessage({ id: option.translatedKey })
+                    : option.label // Deprecated: Backward compatibility
+                }
               </span>
             </button>
           );

--- a/frontend/src/modules/filters/interface.ts
+++ b/frontend/src/modules/filters/interface.ts
@@ -30,10 +30,11 @@ export interface RawDuration {
 // Config file interface
 
 export interface Option {
-  label: string;
+  label?: string;
   value: string;
   pictogramUrl?: string;
   include?: boolean;
+  translatedKey?: string;
 }
 
 export interface FilterWithoutType {
@@ -60,7 +61,8 @@ export interface FilterConfigWithOptions {
   options: {
     minValue: number;
     maxValue: number;
-    label: string;
+    label?: string;
+    translatedKey?: string;
   }[];
   withExclude?: boolean;
 }

--- a/frontend/src/modules/filters/utils.ts
+++ b/frontend/src/modules/filters/utils.ts
@@ -49,6 +49,7 @@ const adaptFilterConfigWithOptionsToFilter = (
   options: filterConfigWithOptions.options.map(option => ({
     value: `${option.minValue}`,
     label: option.label,
+    translatedKey: option.translatedKey,
   })),
 });
 

--- a/frontend/src/translations/ca.json
+++ b/frontend/src/translations/ca.json
@@ -46,12 +46,28 @@
       "cities": "poble",
       "localization": "Localització",
       "duration": "Durada",
+      "durationOptions": {
+        "H:0-1": "0 - 1h",
+        "H:1-2": "1h - 2h",
+        "H:2-5": "2h - 5h",
+        "H:5-10": "5h - 10h"
+      },
       "districts": "Sector",
       "themes": "Temes",
       "routes": "Tipus de recorregut",
       "accessibilities": "Accessibilitat",
       "ascent": "Denivell positiu",
+      "ascentOptions": {
+        "M:0-500": "0 - 500m",
+        "M:500-1000": "500m - 1km"
+      },
       "length": "Llargada",
+      "lengthOptions": {
+        "KM:0-5": "0 - 5km",
+        "KM:5-10": "5km - 10km",
+        "KM:10-15": "10km - 15km",
+        "KM:15-50": "15km - 50km"
+      },
       "structures": "Estructura",
       "clearAll": "Esborrar-ho tot",
       "filters": "Filtres",

--- a/frontend/src/translations/de.json
+++ b/frontend/src/translations/de.json
@@ -46,12 +46,28 @@
       "cities": "Gemeinde",
       "localization": "Lokalisierung",
       "duration": "Dauer",
+      "durationOptions": {
+        "H:0-1": "0 - 1h",
+        "H:1-2": "1h - 2h",
+        "H:2-5": "2h - 5h",
+        "H:5-10": "5h - 10h"
+      },
       "districts": "Sektor",
       "themes": "Themen",
       "routes": "Streckentyp",
       "accessibilities": "Zugänglichkeit",
       "ascent": "Positiver Höhenunterschied",
+      "ascentOptions": {
+        "M:0-500": "0 - 500m",
+        "M:500-1000": "500m - 1km"
+      },
       "length": "Länge",
+      "lengthOptions": {
+        "KM:0-5": "0 - 5km",
+        "KM:5-10": "5km - 10km",
+        "KM:10-15": "10km - 15km",
+        "KM:15-50": "15km - 50km"
+      },
       "structures": "Struktur",
       "clearAll": "Alles löschen",
       "filters": "Filter",

--- a/frontend/src/translations/en.json
+++ b/frontend/src/translations/en.json
@@ -48,12 +48,28 @@
       "localization": "Localization",
       "cities": "City",
       "duration": "Duration",
+      "durationOptions": {
+        "H:0-1": "0 - 1h",
+        "H:1-2": "1h - 2h",
+        "H:2-5": "2h - 5h",
+        "H:5-10": "5h - 10h"
+      },
       "districts": "District",
       "themes": "Themes",
       "routes": "Type",
       "accessibilities": "Accessibility",
       "ascent": "Ascent",
+      "ascentOptions": {
+        "M:0-500": "0 - 500m",
+        "M:500-1000": "500m - 1km"
+      },
       "length": "Length",
+      "lengthOptions": {
+        "KM:0-5": "0 - 5km",
+        "KM:5-10": "5km - 10km",
+        "KM:10-15": "10km - 15km",
+        "KM:15-50": "15km - 50km"
+      },
       "structures": "Structure",
       "clearAll": "Clear all",
       "filters": "Filters",

--- a/frontend/src/translations/es.json
+++ b/frontend/src/translations/es.json
@@ -46,12 +46,28 @@
       "cities": "pueblo",
       "localization": "Localización",
       "duration": "Duración",
+      "durationOptions": {
+        "H:0-1": "0 - 1h",
+        "H:1-2": "1h - 2h",
+        "H:2-5": "2h - 5h",
+        "H:5-10": "5h - 10h"
+      },
       "districts": "Sector",
       "themes": "Temas",
       "routes": "Tipo de recorrido",
       "accessibilities": "Accesibilidad",
       "ascent": "Denivel positivo",
+      "ascentOptions": {
+        "M:0-500": "0 - 500m",
+        "M:500-1000": "500m - 1km"
+      },
       "length": "Largo",
+      "lengthOptions": {
+        "KM:0-5": "0 - 5km",
+        "KM:5-10": "5km - 10km",
+        "KM:10-15": "10km - 15km",
+        "KM:15-50": "15km - 50km"
+      },
       "structures": "Estructura",
       "clearAll": "Borrar todo",
       "filters": "Filtros",

--- a/frontend/src/translations/fr.json
+++ b/frontend/src/translations/fr.json
@@ -49,12 +49,28 @@
       "cities": "Commune",
       "localization": "Localisation",
       "duration": "Durée",
+      "durationOptions": {
+        "H:0-1": "0 - 1h",
+        "H:1-2": "1h - 2h",
+        "H:2-5": "2h - 5h",
+        "H:5-10": "5h - 10h"
+      },
       "districts": "Secteur",
       "themes": "Thèmes",
       "routes": "Type de parcours",
       "accessibilities": "Accessibilité",
       "ascent": "Denivelé positif",
+      "ascentOptions": {
+        "M:0-500": "0 - 500m",
+        "M:500-1000": "500m - 1km"
+      },
       "length": "Longueur",
+      "lengthOptions": {
+        "KM:0-5": "0 - 5km",
+        "KM:5-10": "5km - 10km",
+        "KM:10-15": "10km - 15km",
+        "KM:15-50": "15km - 50km"
+      },
       "structures": "Structure",
       "clearAll": "Tout effacer",
       "filters": "Filtres",

--- a/frontend/src/translations/it.json
+++ b/frontend/src/translations/it.json
@@ -48,12 +48,28 @@
       "cities": "Comune",
       "localization": "Posizione",
       "duration": "Durata",
+      "durationOptions": {
+        "H:0-1": "0 - 1h",
+        "H:1-2": "1h - 2h",
+        "H:2-5": "2h - 5h",
+        "H:5-10": "5h - 10h"
+      },
       "districts": "Settore",
       "themes": "Tema",
       "routes": "Tipo di percorso",
       "accessibilities": "Accessibilità",
       "ascent": "Dislivello positivo",
+      "ascentOptions": {
+        "M:0-500": "0 - 500m",
+        "M:500-1000": "500m - 1km"
+      },
       "length": "Lunghezza",
+      "lengthOptions": {
+        "KM:0-5": "0 - 5km",
+        "KM:5-10": "5km - 10km",
+        "KM:10-15": "10km - 15km",
+        "KM:15-50": "15km - 50km"
+      },
       "structures": "Struttura",
       "clearAll": "Cancellare tutto",
       "filters": "Filtri",


### PR DESCRIPTION
This PR provides translations for the filter labels in the `filters.json` configuration: `Duration`; `Length` and `Ascent`.

For now, there is no real need because of the use of the acronym for the units of measurement, which causes some transparency from one language to another.
For example, the duration "1 - 2h" means "1 to 2 hours" in English and "De 1 à 2 heures" in French, but this is not secure enough. 

If a user wants to expand the label or add a duration containing "days", it doesn't work anymore. 

Note: There is a backward compatilibity if the user config still contains `label` instead of `translatedKey` keys. 