### PR TITLE
Translate dates without trying to determine the current timezone

### DIFF
--- a/frontend/src/components/pages/details/components/DetailsPreview/DetailsPreview.tsx
+++ b/frontend/src/components/pages/details/components/DetailsPreview/DetailsPreview.tsx
@@ -171,14 +171,22 @@ export const DetailsPreview: React.FC<DetailsPreviewProps> = ({
               {informations.date.beginDate === informations.date.endDate ? (
                 <FormattedMessage
                   id={'dates.singleDate'}
-                  values={{ date: intl.formatDate(informations.date.beginDate) }}
+                  values={{
+                    date: new Intl.DateTimeFormat(intl.locale).format(
+                      new Date(informations.date.beginDate),
+                    ),
+                  }}
                 />
               ) : (
                 <FormattedMessage
                   id={'dates.multipleDates'}
                   values={{
-                    beginDate: intl.formatDate(informations.date.beginDate),
-                    endDate: intl.formatDate(informations.date.endDate),
+                    beginDate: new Intl.DateTimeFormat(intl.locale).format(
+                      new Date(informations.date.beginDate),
+                    ),
+                    endDate: new Intl.DateTimeFormat(intl.locale).format(
+                      new Date(informations.date.endDate),
+                    ),
                   }}
                 />
               )}

--- a/frontend/src/components/pages/search/components/ResultCard/ResultCard.tsx
+++ b/frontend/src/components/pages/search/components/ResultCard/ResultCard.tsx
@@ -130,7 +130,7 @@ export const ResultCard: React.FC<
   } = props;
   const { setHoveredCardId } = useContext(ListAndMapContext);
 
-  const intl = useIntl();
+  const { locale } = useIntl();
   const router = useRouter();
 
   return (
@@ -183,19 +183,27 @@ export const ResultCard: React.FC<
             </TagContainer>
             {isTouristicEvent(props) && (
               <InformationContainer>
-                {props.informations.date && (
+                {props.informations.date !== undefined && (
                   <LocalIconInformation icon={Calendar}>
                     {props.informations.date.beginDate === props.informations.date.endDate ? (
                       <FormattedMessage
                         id={'dates.singleDate'}
-                        values={{ date: intl.formatDate(props.informations.date.beginDate) }}
+                        values={{
+                          date: new Intl.DateTimeFormat(locale).format(
+                            new Date(props.informations.date.beginDate),
+                          ),
+                        }}
                       />
                     ) : (
                       <FormattedMessage
                         id={'dates.multipleDates'}
                         values={{
-                          beginDate: intl.formatDate(props.informations.date.beginDate),
-                          endDate: intl.formatDate(props.informations.date.endDate),
+                          beginDate: new Intl.DateTimeFormat(locale).format(
+                            new Date(props.informations.date.beginDate),
+                          ),
+                          endDate: new Intl.DateTimeFormat(locale).format(
+                            new Date(props.informations.date.endDate),
+                          ),
                         }}
                       />
                     )}


### PR DESCRIPTION
To format and translate date the app use https://formatjs.io/docs/react-intl/api/#formatdate but we encounter an issue if the timezone of the user is far from GMT+0.

This is because the API returns the shortest date value (e.g. `2022/08/11`) and without explicitly setting the time zone, `FormatDate` determines this by checking the information in the browser client. 
An user in Europe will see `11/08/2022` but one in America will read `10/08/2022`.

This PR allows to only translate the date without trying to determine the current timezone.

Fix https://github.com/GeotrekCE/Geotrek-rando-v3/issues/751 
