### PR TITLE
Fix display of truncated cards

### DIFF
--- a/frontend/src/components/pages/details/components/DetailsCard/DetailsCard.tsx
+++ b/frontend/src/components/pages/details/components/DetailsCard/DetailsCard.tsx
@@ -33,14 +33,14 @@ export interface DetailsCardProps {
 export const DetailsCard: React.FC<DetailsCardProps> = ({
   id,
   name,
-  description,
+  description = '',
   thumbnailUris,
   attachments,
   iconUri,
   iconName,
   place,
   logoUri,
-  className,
+  className = '',
   redirectionUrl,
   type,
 }) => {
@@ -48,10 +48,10 @@ export const DetailsCard: React.FC<DetailsCardProps> = ({
   const descriptionStyled =
     truncateState === 'TRUNCATE' ? (
       <TruncatedHtmlText className="text-greyDarkColored">
-        {parse(description ?? '')}
+        <div>{parse(description)}</div>
       </TruncatedHtmlText>
     ) : (
-      <HtmlText className="text-greyDarkColored">{parse(description ?? '')}</HtmlText>
+      <HtmlText className="text-greyDarkColored">{parse(description)}</HtmlText>
     );
 
   const { setHoveredCardId } = useContext(ListAndMapContext);
@@ -65,7 +65,7 @@ export const DetailsCard: React.FC<DetailsCardProps> = ({
       flex-none overflow-hidden relative
       flex flex-col h-auto desktop:flex-row desktop:w-auto mx-1
       cursor-pointer hover:border-blackSemiTransparent transition-all duration-500
-      ${className ?? ''}`}
+      ${className}`}
       onMouseEnter={() => {
         setHoveredCardId(id);
       }}

--- a/frontend/src/components/pages/details/components/DetailsCard/__tests__/__snapshots__/DetailsCard.test.tsx.snap
+++ b/frontend/src/components/pages/details/components/DetailsCard/__tests__/__snapshots__/DetailsCard.test.tsx.snap
@@ -59,9 +59,11 @@ Object {
             <div
               class="utils__HtmlText-sc-16l79i-0 DetailsCard__TruncatedHtmlText-sc-1paweiv-2 jgscmn ewDPit text-greyDarkColored"
             >
-              <span>
-                Pour espérer apercevoir cet oiseau, partir la nuit au printemps, parcourir un grand dénivelé afin d'arriver sur son terrain de prédilection à plus de 2000 m voire 3000 m d'altitude avant le lever du jour et là, entendre le chant guttural caractéristique qui trahit sa présence. Mais pour le voir, il faudra bien ouvrir les yeux ou se munir d'une paire de jumelles. Et alors là, quel bonheur ! Le lagopède alpin est l'espèce arctique par excellence, menacée entre autre par le réchauffement climatique. Il fait partie des espèces à protéger dans le cœur du Parc national des Ecrins.
-              </span>
+              <div>
+                <span>
+                  Pour espérer apercevoir cet oiseau, partir la nuit au printemps, parcourir un grand dénivelé afin d'arriver sur son terrain de prédilection à plus de 2000 m voire 3000 m d'altitude avant le lever du jour et là, entendre le chant guttural caractéristique qui trahit sa présence. Mais pour le voir, il faudra bien ouvrir les yeux ou se munir d'une paire de jumelles. Et alors là, quel bonheur ! Le lagopède alpin est l'espèce arctique par excellence, menacée entre autre par le réchauffement climatique. Il fait partie des espèces à protéger dans le cœur du Parc national des Ecrins.
+                </span>
+              </div>
             </div>
             <span
               class="text-primary1 underline cursor-pointer flex-shrink-0 desktop:ml-1"
@@ -217,9 +219,11 @@ Object {
             <div
               class="utils__HtmlText-sc-16l79i-0 DetailsCard__TruncatedHtmlText-sc-1paweiv-2 jgscmn ewDPit text-greyDarkColored"
             >
-              <span>
-                Pour espérer apercevoir cet oiseau, partir la nuit au printemps, parcourir un grand dénivelé afin d'arriver sur son terrain de prédilection à plus de 2000 m voire 3000 m d'altitude avant le lever du jour et là, entendre le chant guttural caractéristique qui trahit sa présence. Mais pour le voir, il faudra bien ouvrir les yeux ou se munir d'une paire de jumelles. Et alors là, quel bonheur ! Le lagopède alpin est l'espèce arctique par excellence, menacée entre autre par le réchauffement climatique. Il fait partie des espèces à protéger dans le cœur du Parc national des Ecrins.
-              </span>
+              <div>
+                <span>
+                  Pour espérer apercevoir cet oiseau, partir la nuit au printemps, parcourir un grand dénivelé afin d'arriver sur son terrain de prédilection à plus de 2000 m voire 3000 m d'altitude avant le lever du jour et là, entendre le chant guttural caractéristique qui trahit sa présence. Mais pour le voir, il faudra bien ouvrir les yeux ou se munir d'une paire de jumelles. Et alors là, quel bonheur ! Le lagopède alpin est l'espèce arctique par excellence, menacée entre autre par le réchauffement climatique. Il fait partie des espèces à protéger dans le cœur du Parc national des Ecrins.
+                </span>
+              </div>
             </div>
             <span
               class="text-primary1 underline cursor-pointer flex-shrink-0 desktop:ml-1"
@@ -286,9 +290,11 @@ Object {
           <div
             class="utils__HtmlText-sc-16l79i-0 DetailsCard__TruncatedHtmlText-sc-1paweiv-2 jgscmn ewDPit text-greyDarkColored"
           >
-            <span>
-              Pour espérer apercevoir cet oiseau, partir la nuit au printemps, parcourir un grand dénivelé afin d'arriver sur son terrain de prédilection à plus de 2000 m voire 3000 m d'altitude avant le lever du jour et là, entendre le chant guttural caractéristique qui trahit sa présence. Mais pour le voir, il faudra bien ouvrir les yeux ou se munir d'une paire de jumelles. Et alors là, quel bonheur ! Le lagopède alpin est l'espèce arctique par excellence, menacée entre autre par le réchauffement climatique. Il fait partie des espèces à protéger dans le cœur du Parc national des Ecrins.
-            </span>
+            <div>
+              <span>
+                Pour espérer apercevoir cet oiseau, partir la nuit au printemps, parcourir un grand dénivelé afin d'arriver sur son terrain de prédilection à plus de 2000 m voire 3000 m d'altitude avant le lever du jour et là, entendre le chant guttural caractéristique qui trahit sa présence. Mais pour le voir, il faudra bien ouvrir les yeux ou se munir d'une paire de jumelles. Et alors là, quel bonheur ! Le lagopède alpin est l'espèce arctique par excellence, menacée entre autre par le réchauffement climatique. Il fait partie des espèces à protéger dans le cœur du Parc national des Ecrins.
+              </span>
+            </div>
           </div>
           <span
             class="text-primary1 underline cursor-pointer flex-shrink-0 desktop:ml-1"
@@ -412,9 +418,11 @@ Object {
             <div
               class="utils__HtmlText-sc-16l79i-0 DetailsCard__TruncatedHtmlText-sc-1paweiv-2 jgscmn ewDPit text-greyDarkColored"
             >
-              <span>
-                Pour espérer apercevoir cet oiseau, partir la nuit au printemps, parcourir un grand dénivelé afin d'arriver sur son terrain de prédilection à plus de 2000 m voire 3000 m d'altitude avant le lever du jour et là, entendre le chant guttural caractéristique qui trahit sa présence. Mais pour le voir, il faudra bien ouvrir les yeux ou se munir d'une paire de jumelles. Et alors là, quel bonheur ! Le lagopède alpin est l'espèce arctique par excellence, menacée entre autre par le réchauffement climatique. Il fait partie des espèces à protéger dans le cœur du Parc national des Ecrins.
-              </span>
+              <div>
+                <span>
+                  Pour espérer apercevoir cet oiseau, partir la nuit au printemps, parcourir un grand dénivelé afin d'arriver sur son terrain de prédilection à plus de 2000 m voire 3000 m d'altitude avant le lever du jour et là, entendre le chant guttural caractéristique qui trahit sa présence. Mais pour le voir, il faudra bien ouvrir les yeux ou se munir d'une paire de jumelles. Et alors là, quel bonheur ! Le lagopède alpin est l'espèce arctique par excellence, menacée entre autre par le réchauffement climatique. Il fait partie des espèces à protéger dans le cœur du Parc national des Ecrins.
+                </span>
+              </div>
             </div>
             <span
               class="text-primary1 underline cursor-pointer flex-shrink-0 desktop:ml-1"
@@ -570,9 +578,11 @@ Object {
             <div
               class="utils__HtmlText-sc-16l79i-0 DetailsCard__TruncatedHtmlText-sc-1paweiv-2 jgscmn ewDPit text-greyDarkColored"
             >
-              <span>
-                Pour espérer apercevoir cet oiseau, partir la nuit au printemps, parcourir un grand dénivelé afin d'arriver sur son terrain de prédilection à plus de 2000 m voire 3000 m d'altitude avant le lever du jour et là, entendre le chant guttural caractéristique qui trahit sa présence. Mais pour le voir, il faudra bien ouvrir les yeux ou se munir d'une paire de jumelles. Et alors là, quel bonheur ! Le lagopède alpin est l'espèce arctique par excellence, menacée entre autre par le réchauffement climatique. Il fait partie des espèces à protéger dans le cœur du Parc national des Ecrins.
-              </span>
+              <div>
+                <span>
+                  Pour espérer apercevoir cet oiseau, partir la nuit au printemps, parcourir un grand dénivelé afin d'arriver sur son terrain de prédilection à plus de 2000 m voire 3000 m d'altitude avant le lever du jour et là, entendre le chant guttural caractéristique qui trahit sa présence. Mais pour le voir, il faudra bien ouvrir les yeux ou se munir d'une paire de jumelles. Et alors là, quel bonheur ! Le lagopède alpin est l'espèce arctique par excellence, menacée entre autre par le réchauffement climatique. Il fait partie des espèces à protéger dans le cœur du Parc national des Ecrins.
+                </span>
+              </div>
             </div>
             <span
               class="text-primary1 underline cursor-pointer flex-shrink-0 desktop:ml-1"
@@ -729,9 +739,11 @@ Object {
           <div
             class="utils__HtmlText-sc-16l79i-0 DetailsCard__TruncatedHtmlText-sc-1paweiv-2 jgscmn ewDPit text-greyDarkColored"
           >
-            <span>
-              Pour espérer apercevoir cet oiseau, partir la nuit au printemps, parcourir un grand dénivelé afin d'arriver sur son terrain de prédilection à plus de 2000 m voire 3000 m d'altitude avant le lever du jour et là, entendre le chant guttural caractéristique qui trahit sa présence. Mais pour le voir, il faudra bien ouvrir les yeux ou se munir d'une paire de jumelles. Et alors là, quel bonheur ! Le lagopède alpin est l'espèce arctique par excellence, menacée entre autre par le réchauffement climatique. Il fait partie des espèces à protéger dans le cœur du Parc national des Ecrins.
-            </span>
+            <div>
+              <span>
+                Pour espérer apercevoir cet oiseau, partir la nuit au printemps, parcourir un grand dénivelé afin d'arriver sur son terrain de prédilection à plus de 2000 m voire 3000 m d'altitude avant le lever du jour et là, entendre le chant guttural caractéristique qui trahit sa présence. Mais pour le voir, il faudra bien ouvrir les yeux ou se munir d'une paire de jumelles. Et alors là, quel bonheur ! Le lagopède alpin est l'espèce arctique par excellence, menacée entre autre par le réchauffement climatique. Il fait partie des espèces à protéger dans le cœur du Parc national des Ecrins.
+              </span>
+            </div>
           </div>
           <span
             class="text-primary1 underline cursor-pointer flex-shrink-0 desktop:ml-1"

--- a/frontend/src/components/pages/details/components/DetailsInformationDesk/DetailsInformationDesk.tsx
+++ b/frontend/src/components/pages/details/components/DetailsInformationDesk/DetailsInformationDesk.tsx
@@ -80,7 +80,9 @@ export const DetailsInformationDesk: React.FC<DetailsInformationDeskProps> = ({
 
         <div className="flex flex-col desktop:flex-row desktop:items-end mt-4">
           {truncateState === 'TRUNCATE' ? (
-            <TruncatedHtmlText>{parse(description)}</TruncatedHtmlText>
+            <TruncatedHtmlText>
+              <div>{parse(description)}</div>
+            </TruncatedHtmlText>
           ) : (
             <HtmlText>{parse(description)}</HtmlText>
           )}


### PR DESCRIPTION
Fix: [Le texte des patrimoines est parfois illisible #693](https://github.com/GeotrekCE/Geotrek-rando-v3/issues/693)

