### PR TITLE
Clean document

### DIFF
--- a/frontend/src/components/Layout/Layout.tsx
+++ b/frontend/src/components/Layout/Layout.tsx
@@ -1,30 +1,16 @@
-import React, { FunctionComponent } from 'react';
-import styled from 'styled-components';
-
 import { Header } from 'components/Header';
 import ConditionallyRender from 'components/ConditionallyRender';
 import { colorPalette, zIndex } from 'stylesheet';
 import Loader from 'react-loader';
 import { useNavigationLoader } from './useRedirection';
 
-const Container = styled.div`
-  display: flex;
-  flex-direction: column;
-`;
-Container.displayName = 'Container';
-
-export const PageContent = styled.main`
-  flex-grow: 1;
-`;
-PageContent.displayName = 'PageContent';
-
-export const Layout: FunctionComponent = props => {
+export const Layout: React.FC = ({ children }) => {
   const { isNavigationLoading } = useNavigationLoader();
 
   return (
-    <Container>
+    <div className="flex flex-col">
       <Header />
-      <PageContent>
+      <main className="flex-grow">
         <ConditionallyRender client>
           <Loader
             loaded={!isNavigationLoading}
@@ -33,11 +19,11 @@ export const Layout: FunctionComponent = props => {
               zIndex: zIndex.loader,
             }}
           >
-            {props.children}
+            {children}
           </Loader>
         </ConditionallyRender>
-        <ConditionallyRender server>{props.children}</ConditionallyRender>
-      </PageContent>
-    </Container>
+        <ConditionallyRender server>{children}</ConditionallyRender>
+      </main>
+    </div>
   );
 };

--- a/frontend/src/components/PageHead.tsx
+++ b/frontend/src/components/PageHead.tsx
@@ -10,17 +10,18 @@ interface Props {
   sharingImageUrl?: string;
 }
 
-export const PageHead = ({ title, description, sharingImageUrl }: Props) => {
+export const PageHead: React.FC<Props> = ({ title, description, sharingImageUrl }) => {
   const { baseUrl, applicationName } = getGlobalConfig();
   const router = useRouter();
   const currentLanguage = router.locale ?? getDefaultLanguage();
   const intl = useIntl();
+  const homeTitle = intl.formatMessage({ id: 'home.title' });
   const titleWithSiteName =
     title !== undefined
-      ? title.includes(intl.formatMessage({ id: 'home.title' }))
+      ? title.includes(homeTitle)
         ? title
-        : `${title} - ${intl.formatMessage({ id: 'home.title' })}`
-      : intl.formatMessage({ id: 'home.title' });
+        : `${title} - ${homeTitle}`
+      : homeTitle;
 
   const canonicalURL = `${baseUrl}${
     currentLanguage !== getDefaultLanguage() ? `/${currentLanguage}` : ''

--- a/frontend/src/components/PageHead.tsx
+++ b/frontend/src/components/PageHead.tsx
@@ -42,7 +42,6 @@ export const PageHead = ({ title, description, sharingImageUrl }: Props) => {
     <Head>
       <title>{titleWithSiteName}</title>
       {description !== undefined && <meta name="description" content={description} />}
-      <meta charSet="utf-8" />
       <meta name="viewport" content="initial-scale=1.0, width=device-width" />
 
       <link rel="canonical" href={canonicalURL} />

--- a/frontend/src/components/pages/_app/Root.tsx
+++ b/frontend/src/components/pages/_app/Root.tsx
@@ -26,6 +26,7 @@ export const Root: React.FC = props => {
   return (
     <IntlProvider locale={language} messages={(locales as Messages)[language]}>
       <Head>
+        <title>{applicationName}</title>
         <link rel="manifest" href="/manifest.json" />
 
         <meta name="application-name" content={applicationName} />

--- a/frontend/src/components/pages/_app/Root.tsx
+++ b/frontend/src/components/pages/_app/Root.tsx
@@ -43,10 +43,6 @@ export const Root: React.FC = props => {
         <link rel="icon" type="image/png" sizes="16x16" href="/medias/favicon.png" />
         <link rel="mask-icon" href="/medias/favicon.png" color={colorPalette.primary1} />
         <link rel="shortcut icon" href="/medias/favicon.png" />
-        <link
-          rel="stylesheet"
-          href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&display=swap"
-        />
         {googleSiteVerificationToken !== null && (
           <meta name="google-site-verification" content={googleSiteVerificationToken} />
         )}

--- a/frontend/src/modules/interface.ts
+++ b/frontend/src/modules/interface.ts
@@ -66,7 +66,20 @@ export interface RawGeometryCollection {
   >;
 }
 
+export interface ColorsConfig {
+  primary1?: { DEFAULT?: string; light?: string };
+  primary2?: string;
+  primary3?: string;
+  greySoft?: { DEFAULT?: string; light?: string };
+  warning?: string;
+  easyOK?: string;
+  hardKO?: string;
+  red?: string;
+  redMarker?: string;
+}
+
 export interface APICallsConfig {
+  colors: ColorsConfig;
   searchResultsPageSize: number;
   mapResultsPageSize: number;
   maxPoiPerPage: number;

--- a/frontend/src/pages/_document.tsx
+++ b/frontend/src/pages/_document.tsx
@@ -1,15 +1,35 @@
 import { getGlobalConfig } from 'modules/utils/api.config';
 import parse from 'html-react-parser';
 import getNextConfig from 'next/config';
-import Document, { DocumentContext, Head, Html, Main, NextScript } from 'next/document';
+import Document, {
+  DocumentContext,
+  DocumentInitialProps,
+  Head,
+  Html,
+  Main,
+  NextScript,
+} from 'next/document';
 import { ServerStyleSheet } from 'styled-components';
+import { ColorsConfig } from 'modules/interface';
 
 const {
   publicRuntimeConfig: { style, colors, scriptsHeaderHtml, scriptsFooterHtml },
 } = getNextConfig();
 
+const {
+  primary1: { DEFAULT: primary1 = '#aa397d', light: primary1Light = '#bd3e8b' } = {},
+  primary2 = '#f5E7ef',
+  primary3 = '#791150',
+  greySoft: { DEFAULT: greySoft = '#d7d6d9', light: greySoftLight = '#d7d6d950' } = {},
+  warning = '#d77E00',
+  easyOK = '4fad79',
+  hardKO = '#e25316',
+  red = '#ff7373',
+  redMarker = '#e83737',
+} = colors as ColorsConfig;
+
 export default class MyDocument extends Document {
-  static async getInitialProps(ctx: DocumentContext) {
+  static async getInitialProps(ctx: DocumentContext): Promise<DocumentInitialProps> {
     const sheet = new ServerStyleSheet();
     const originalRenderPage = ctx.renderPage;
 
@@ -40,7 +60,7 @@ export default class MyDocument extends Document {
     return (
       <Html className="scroll-smooth">
         <Head>
-          {!!googleAnalyticsId && (
+          {googleAnalyticsId !== null && (
             <>
               <script
                 async
@@ -60,17 +80,17 @@ export default class MyDocument extends Document {
           )}
           <style>{`
 :root {
-  --color-primary1-default: ${String(colors.primary1?.DEFAULT || '#AA397D')};
-  --color-primary1-light: ${String(colors.primary1?.light || '#bd3e8b')};
-  --color-primary2: ${String(colors.primary2 || '#F5E7EF')};
-  --color-primary3: ${String(colors.primary3 || '#791150')};
-  --color-greySoft-default: ${String(colors.greySoft?.DEFAULT || '#D7D6D9')};
-  --color-greySoft-light: ${String(colors.greySoft?.light || '#D7D6D950')};
-  --color-warning: ${String(colors.warning || '#D77E00')};
-  --color-easyOK: ${String(colors.easyOK || '#4FAD79')};
-  --color-hardKO: ${String(colors.hardKO || '#E25316')};
-  --color-red: ${String(colors.red || '#FF7373')};
-  --color-redMarker: ${String(colors.redMarker || '#E83737')};
+  --color-primary1-default: ${primary1};
+  --color-primary1-light: ${primary1Light};
+  --color-primary2: ${primary2};
+  --color-primary3: ${primary3};
+  --color-greySoft-default: ${greySoft};
+  --color-greySoft-light: ${greySoftLight};
+  --color-warning: ${warning};
+  --color-easyOK: ${easyOK};
+  --color-hardKO: ${hardKO};
+  --color-red: ${red};
+  --color-redMarker: ${redMarker};
 }
 `}</style>
           {style !== undefined && <style dangerouslySetInnerHTML={{ __html: style }} />}

--- a/frontend/src/pages/_document.tsx
+++ b/frontend/src/pages/_document.tsx
@@ -58,7 +58,6 @@ export default class MyDocument extends Document {
               />
             </>
           )}
-          <style dangerouslySetInnerHTML={{ __html: style }} />
           <style>{`
 :root {
   --color-primary1-default: ${String(colors.primary1?.DEFAULT || '#AA397D')};
@@ -74,6 +73,7 @@ export default class MyDocument extends Document {
   --color-redMarker: ${String(colors.redMarker || '#E83737')};
 }
 `}</style>
+          {style !== undefined && <style dangerouslySetInnerHTML={{ __html: style }} />}
           {scriptsHeaderHtml !== undefined && <>{parse(scriptsHeaderHtml)}</>}
         </Head>
         <body>

--- a/frontend/src/pages/_document.tsx
+++ b/frontend/src/pages/_document.tsx
@@ -38,7 +38,7 @@ export default class MyDocument extends Document {
     const { googleAnalyticsId } = getGlobalConfig();
 
     return (
-      <Html style={{ scrollBehavior: 'smooth' }}>
+      <Html className="scroll-smooth">
         <Head>
           {!!googleAnalyticsId && (
             <>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,3 +1,4 @@
+const plugin = require('tailwindcss/plugin');
 const SPACING_UNIT = 4;
 
 module.exports = {
@@ -157,5 +158,19 @@ module.exports = {
       margin: ['last'],
     },
   },
-  plugins: [],
+  plugins: [
+    // plugin should be drop with TW v3
+    plugin(function ({ addUtilities, variants }) {
+      const scrollBehaviors = {
+        '.scroll-smooth': {
+          'scroll-behavior': 'smooth',
+        },
+        '.scroll-auto': {
+          'scroll-behavior': 'auto',
+        },
+      };
+
+      addUtilities(scrollBehaviors, variants('scrollBehavior', ['motion-safe', 'motion-reduce']));
+    })
+  ],
 };


### PR DESCRIPTION
This PR cleans/types document/layout 

⚠️ : The call of `Roboto` font is removed from the application.

Indeed Geotrek Rando does not use it (nldr: The application uses the `Assistant` font).  

If the `Roboto` font is needed, it's still possible with customization; you just have to add the following line in the `scriptsHeader.html` file ([related documentation](https://github.com/GeotrekCE/Geotrek-rando-v3/blob/main/docs/customization.md#html--scripts)) .

```html
<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&display=swap" />
```