### PR TITLE
Set eslint rule explicit-module-boundary-types to off

### DIFF
--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -32,6 +32,7 @@
     "react/prop-types": "off",
     "react/react-in-jsx-scope": "off",
     "@typescript-eslint/explicit-function-return-type": "off",
+    "@typescript-eslint/explicit-module-boundary-types": "off",
     "@typescript-eslint/member-ordering": "error",
     "@typescript-eslint/no-inferrable-types": "error",
     "@typescript-eslint/prefer-for-of": "error",


### PR DESCRIPTION
Let TypeScript infers the return output itself