### PR TITLE
Display main geometry when hovering over points of the search map

### DIFF
--- a/frontend/src/components/Map/DetailsMap/DetailsMap.tsx
+++ b/frontend/src/components/Map/DetailsMap/DetailsMap.tsx
@@ -49,8 +49,8 @@ export interface GeometryListProps {
     | PointGeometry
     | MultiPointGeometry
     | GeometryCollection;
-  pictogramUri: string | null;
-  name: string;
+  pictogramUri?: string | null;
+  name?: string;
   id: string;
 }
 

--- a/frontend/src/components/Map/DetailsMap/GeometryItem.tsx
+++ b/frontend/src/components/Map/DetailsMap/GeometryItem.tsx
@@ -67,6 +67,7 @@ export const GeometryItem = ({
             key={`${id}${JSON.stringify(group)}`}
             id={id}
             positions={group.map(point => [point.y, point.x])}
+            type={type}
           />
         ))}
       </>
@@ -83,6 +84,7 @@ export const GeometryItem = ({
             key={`${id}${JSON.stringify(group)}`}
             id={id}
             positions={group.map(line => line.map<[number, number]>(point => [point.y, point.x]))}
+            type={type}
           />
         ))}
       </>

--- a/frontend/src/components/Map/components/HoverablePolygon.tsx
+++ b/frontend/src/components/Map/components/HoverablePolygon.tsx
@@ -1,5 +1,6 @@
+import getActivityColor from 'components/pages/search/components/ResultCard/getActivityColor';
 import { useListAndMapContext } from 'modules/map/ListAndMapContext';
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { Polygon } from 'react-leaflet';
 import { colorPalette } from 'stylesheet';
 
@@ -9,23 +10,18 @@ const DEFAULT_WEIGHT = 3;
 interface Props {
   id: string;
   positions: [number, number][][];
+  type: 'TREK' | 'TOURISTIC_CONTENT' | 'OUTDOOR_SITE' | 'TOURISTIC_EVENT' | null;
 }
 
 export const HoverablePolygon: React.FC<Props> = props => {
   const { hoveredCardId } = useListAndMapContext();
   const isCorrespondingCardHovered = props.id === hoveredCardId;
+  const color = getActivityColor(props.type);
 
   const weight = isCorrespondingCardHovered ? ZOOMED_WEIGHT : DEFAULT_WEIGHT;
 
   return useMemo(
-    () => (
-      <Polygon
-        key={props.id}
-        positions={props.positions}
-        color={colorPalette.map.touristicContentLines}
-        weight={weight}
-      />
-    ),
+    () => <Polygon key={props.id} positions={props.positions} color={color} weight={weight} />,
     [props.id, props.positions, weight],
   );
 };

--- a/frontend/src/components/Map/components/HoverablePolyline.tsx
+++ b/frontend/src/components/Map/components/HoverablePolyline.tsx
@@ -1,5 +1,6 @@
+import getActivityColor from 'components/pages/search/components/ResultCard/getActivityColor';
 import { useListAndMapContext } from 'modules/map/ListAndMapContext';
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { Polyline } from 'react-leaflet';
 import { colorPalette } from 'stylesheet';
 
@@ -9,23 +10,18 @@ const DEFAULT_WEIGHT = 3;
 interface Props {
   id: string;
   positions: [number, number][];
+  type: 'TREK' | 'TOURISTIC_CONTENT' | 'OUTDOOR_SITE' | 'TOURISTIC_EVENT' | null;
 }
 
 export const HoverablePolyline: React.FC<Props> = props => {
   const { hoveredCardId } = useListAndMapContext();
   const isCorrespondingCardHovered = props.id === hoveredCardId;
+  const color = getActivityColor(props.type);
 
   const weight = isCorrespondingCardHovered ? ZOOMED_WEIGHT : DEFAULT_WEIGHT;
 
   return useMemo(
-    () => (
-      <Polyline
-        key={props.id}
-        positions={props.positions}
-        color={colorPalette.map.touristicContentLines}
-        weight={weight}
-      />
-    ),
+    () => <Polyline key={props.id} positions={props.positions} color={color} weight={weight} />,
     [props.id, props.positions, weight],
   );
 };

--- a/frontend/src/components/Map/components/TrekCourse/index.tsx
+++ b/frontend/src/components/Map/components/TrekCourse/index.tsx
@@ -1,7 +1,5 @@
-import React from 'react';
-import { Polyline } from 'react-leaflet';
-
-import { colorPalette } from 'stylesheet';
+import { GeometryItem } from 'components/Map/DetailsMap/GeometryItem';
+import { GeometryObject } from 'modules/interface';
 
 import { useObjectGeometry } from '../../hooks/useTrekGeometry';
 
@@ -10,17 +8,26 @@ interface TrekCourseProps {
   type: 'TREK' | 'TOURISTIC_CONTENT' | 'OUTDOOR_SITE' | 'TOURISTIC_EVENT';
 }
 
+function removePointsFromGeometry(geometry: GeometryObject): GeometryObject {
+  if (geometry.type === 'GeometryCollection') {
+    return {
+      ...geometry,
+      geometries: geometry.geometries
+        .filter(nextGeom => !nextGeom.type.includes('Point'))
+        .map(nextGeom => removePointsFromGeometry(nextGeom)),
+    };
+  }
+  return geometry;
+}
+
 export const TrekCourse: React.FC<TrekCourseProps> = ({ id, type }) => {
   const { trekGeometry } = useObjectGeometry(id, type);
 
-  return (
-    <>
-      {trekGeometry !== undefined && (
-        <Polyline
-          positions={trekGeometry.geometry.map(coordinates => [coordinates.y, coordinates.x])}
-          color={colorPalette.primary1}
-        />
-      )}
-    </>
-  );
+  if (trekGeometry === undefined || trekGeometry.type.includes('Point')) {
+    return null;
+  }
+
+  const filteredGeometry = removePointsFromGeometry(trekGeometry);
+
+  return <GeometryItem id={String(id)} geometry={filteredGeometry} type={type} />;
 };

--- a/frontend/src/components/Map/hooks/useTrekGeometry.ts
+++ b/frontend/src/components/Map/hooks/useTrekGeometry.ts
@@ -5,6 +5,7 @@ import { GeometryObject } from 'modules/interface';
 import { useRouter } from 'next/router';
 import { getDefaultLanguage } from 'modules/header/utills';
 import { getTouristicContentGeometryResult } from 'modules/touristicContent/connector';
+import { getOutdoorSiteGeometryResult } from 'modules/outdoorSite/connector';
 
 export const useObjectGeometry = (
   id: number,
@@ -12,11 +13,19 @@ export const useObjectGeometry = (
 ) => {
   const language = useRouter().locale ?? getDefaultLanguage();
 
-  const func = type === 'TREK' ? getTrekGeometryResult : getTouristicContentGeometryResult;
+  const func = () => {
+    if (type === 'TREK') {
+      return getTrekGeometryResult;
+    }
+    if (type === 'OUTDOOR_SITE') {
+      return getOutdoorSiteGeometryResult;
+    }
+    return getTouristicContentGeometryResult;
+  };
 
   const { data: trekGeometry } = useQuery<GeometryObject, Error>(
     ['trekPopupResult', id, language],
-    () => func(String(id), language),
+    () => func()(String(id), language),
   );
 
   return { trekGeometry };

--- a/frontend/src/components/Map/hooks/useTrekGeometry.ts
+++ b/frontend/src/components/Map/hooks/useTrekGeometry.ts
@@ -1,10 +1,10 @@
 import { useQuery } from 'react-query';
 
 import { getTrekGeometryResult } from 'modules/trekResult/connector';
-import { TrekGeometryResult } from 'modules/trekResult/interface';
+import { GeometryObject } from 'modules/interface';
 import { useRouter } from 'next/router';
 import { getDefaultLanguage } from 'modules/header/utills';
-import { getTouristicContentGeometryResult } from '../../../modules/touristicContent/connector';
+import { getTouristicContentGeometryResult } from 'modules/touristicContent/connector';
 
 export const useObjectGeometry = (
   id: number,
@@ -14,7 +14,7 @@ export const useObjectGeometry = (
 
   const func = type === 'TREK' ? getTrekGeometryResult : getTouristicContentGeometryResult;
 
-  const { data: trekGeometry } = useQuery<TrekGeometryResult, Error>(
+  const { data: trekGeometry } = useQuery<GeometryObject, Error>(
     ['trekPopupResult', id, language],
     () => func(String(id), language),
   );

--- a/frontend/src/components/Map/hooks/useTrekGeometry.ts
+++ b/frontend/src/components/Map/hooks/useTrekGeometry.ts
@@ -5,6 +5,7 @@ import { GeometryObject } from 'modules/interface';
 import { useRouter } from 'next/router';
 import { getDefaultLanguage } from 'modules/header/utills';
 import { getTouristicContentGeometryResult } from 'modules/touristicContent/connector';
+import { getTouristicEventGeometryResult } from 'modules/touristicEvent/connector';
 import { getOutdoorSiteGeometryResult } from 'modules/outdoorSite/connector';
 
 export const useObjectGeometry = (
@@ -19,6 +20,9 @@ export const useObjectGeometry = (
     }
     if (type === 'OUTDOOR_SITE') {
       return getOutdoorSiteGeometryResult;
+    }
+    if (type === 'TOURISTIC_EVENT') {
+      return getTouristicEventGeometryResult;
     }
     return getTouristicContentGeometryResult;
   };

--- a/frontend/src/modules/interface.ts
+++ b/frontend/src/modules/interface.ts
@@ -54,17 +54,18 @@ export interface RawMultiPolygonGeometry {
   coordinates: RawCoordinate2D[][][];
 }
 
+export type RawGeometryObject =
+  | RawPolygonGeometry
+  | RawMultiPolygonGeometry
+  | RawLineStringGeometry2D
+  | RawMultiLineStringGeometry
+  | RawPointGeometry2D
+  | RawMultiPointGeometry2D
+  | RawGeometryCollection;
+
 export interface RawGeometryCollection {
   type: 'GeometryCollection';
-  geometries: Array<
-    | RawPolygonGeometry
-    | RawMultiPolygonGeometry
-    | RawLineStringGeometry2D
-    | RawMultiLineStringGeometry
-    | RawPointGeometry2D
-    | RawMultiPointGeometry2D
-    | RawGeometryCollection
-  >;
+  geometries: Array<RawGeometryObject>;
 }
 
 export interface ColorsConfig {
@@ -170,17 +171,18 @@ export interface MultiPolygonGeometry {
   coordinates: Coordinate2D[][][];
 }
 
+export type GeometryObject =
+  | PolygonGeometry
+  | MultiPolygonGeometry
+  | LineStringGeometry
+  | MultiLineStringGeometry
+  | PointGeometry
+  | MultiPointGeometry
+  | GeometryCollection;
+
 export interface GeometryCollection {
   type: 'GeometryCollection';
-  geometries: Array<
-    | PolygonGeometry
-    | MultiPolygonGeometry
-    | LineStringGeometry
-    | MultiLineStringGeometry
-    | PointGeometry
-    | MultiPointGeometry
-    | GeometryCollection
-  >;
+  geometries: Array<GeometryObject>;
 }
 
 export interface RawWebLink {

--- a/frontend/src/modules/outdoorSite/api.ts
+++ b/frontend/src/modules/outdoorSite/api.ts
@@ -1,3 +1,4 @@
+import { RawGeometryObject } from 'modules/interface';
 import { portalsFilter } from 'modules/utils/api.config';
 import { GeotrekAPI } from 'services/api/client';
 import { APIQuery, APIResponseForList } from 'services/api/interface';
@@ -26,3 +27,11 @@ export const fetchOutdoorSiteDetails = (
     params: { ...fieldsParamsDetails, ...query, ...portalsFilter },
   }).then(r => r.data);
 };
+
+export const fetchOutdoorSiteResult = (
+  query: APIQuery,
+  id: string,
+): Promise<{ geometry: RawGeometryObject }> =>
+  GeotrekAPI.get(`/outdoor_site/${id}/`, { params: { ...query, fields: 'geometry' } }).then(
+    r => r.data,
+  );

--- a/frontend/src/modules/outdoorSite/connector.ts
+++ b/frontend/src/modules/outdoorSite/connector.ts
@@ -2,6 +2,8 @@ import { getSensitiveAreas } from 'modules/sensitiveArea/connector';
 import { getSignage } from 'modules/signage/connector';
 import { getService } from 'modules/service/connector';
 import { getInfrastructure } from 'modules/infrastructure/connector';
+import { adaptGeometry } from 'modules/utils/geometry';
+import { GeometryObject } from 'modules/interface';
 import { getCities } from '../city/connector';
 import { getThemes } from '../filters/theme/connector';
 import { getInformationDesks } from '../informationDesk/connector';
@@ -22,7 +24,7 @@ import {
   adaptOutdoorSitePopupResults,
   adaptOutdoorSites,
 } from './adapter';
-import { fetchOutdoorSiteDetails, fetchOutdoorSites } from './api';
+import { fetchOutdoorSiteDetails, fetchOutdoorSiteResult, fetchOutdoorSites } from './api';
 import { OutdoorSite, OutdoorSiteDetails } from './interface';
 
 export const getOutdoorSites = async (language: string, query = {}): Promise<OutdoorSite[]> => {
@@ -134,4 +136,12 @@ export const getOutdoorSitePopupResult = async (
   const [cityDictionnary] = await Promise.all([getCities(language)]);
 
   return adaptOutdoorSitePopupResults({ rawOutdoorSitePopupResult, cityDictionnary });
+};
+
+export const getOutdoorSiteGeometryResult = async (
+  id: string,
+  language: string,
+): Promise<GeometryObject> => {
+  const rawOutdoorGeometryResult = await fetchOutdoorSiteResult({ language }, id);
+  return adaptGeometry(rawOutdoorGeometryResult.geometry);
 };

--- a/frontend/src/modules/touristicContent/api.ts
+++ b/frontend/src/modules/touristicContent/api.ts
@@ -1,7 +1,7 @@
 import { portalsFilter } from 'modules/utils/api.config';
 import { GeotrekAPI } from 'services/api/client';
 import { APIQuery, APIResponseForList } from 'services/api/interface';
-import { RawTrekGeometryResult } from '../trekResult/interface';
+import { RawGeometryObject } from 'modules/interface';
 import {
   RawTouristicContent,
   RawTouristicContentDetails,
@@ -59,7 +59,7 @@ export const fetchTouristicContentPopupResult = (
 export const fetchTouristicContentGeometryResult = (
   query: APIQuery,
   id: string,
-): Promise<RawTrekGeometryResult> =>
+): Promise<{ geometry: RawGeometryObject }> =>
   GeotrekAPI.get(`/touristiccontent/${id}/`, { params: { ...query, fields: 'geometry' } }).then(
     r => r.data,
   );

--- a/frontend/src/modules/touristicContent/connector.ts
+++ b/frontend/src/modules/touristicContent/connector.ts
@@ -1,13 +1,14 @@
 import { getCities } from 'modules/city/connector';
 import { getThemes } from 'modules/filters/theme/connector';
+import { GeometryObject } from 'modules/interface';
 import { getSources } from 'modules/source/connector';
 import {
   getTouristicContentCategories,
   getTouristicContentCategory,
 } from 'modules/touristicContentCategory/connector';
-import { PopupResult, TrekGeometryResult } from 'modules/trekResult/interface';
+import { PopupResult } from 'modules/trekResult/interface';
 import { getGlobalConfig } from 'modules/utils/api.config';
-import { adaptTrekGeometryResults } from '../trekResult/adapter';
+import { adaptGeometry } from 'modules/utils/geometry';
 import {
   adaptTouristicContent,
   adaptTouristicContentDetails,
@@ -92,8 +93,10 @@ export const getTouristicContentPopupResult = async (
 export const getTouristicContentGeometryResult = async (
   id: string,
   language: string,
-): Promise<TrekGeometryResult> => {
-  const rawTrekGeometryResult = await fetchTouristicContentGeometryResult({ language }, id);
-
-  return adaptTrekGeometryResults(rawTrekGeometryResult);
+): Promise<GeometryObject> => {
+  const rawTouristicContentGeometryResult = await fetchTouristicContentGeometryResult(
+    { language },
+    id,
+  );
+  return adaptGeometry(rawTouristicContentGeometryResult.geometry);
 };

--- a/frontend/src/modules/touristicEvent/api.ts
+++ b/frontend/src/modules/touristicEvent/api.ts
@@ -1,3 +1,4 @@
+import { RawGeometryObject } from 'modules/interface';
 import { portalsFilter } from 'modules/utils/api.config';
 import { GeotrekAPI } from 'services/api/client';
 import { APIQuery, APIResponseForList } from 'services/api/interface';
@@ -31,3 +32,11 @@ export const fetchTouristicEventDetails = (
   GeotrekAPI.get(`/touristicevent/${id}/`, {
     params: { ...query, ...fieldsParamsDetails, ...portalsFilter },
   }).then(r => r.data);
+
+export const fetchTouristicEventResult = (
+  query: APIQuery,
+  id: string,
+): Promise<{ geometry: RawGeometryObject }> =>
+  GeotrekAPI.get(`/touristicevent/${id}/`, { params: { ...query, fields: 'geometry' } }).then(
+    r => r.data,
+  );

--- a/frontend/src/modules/touristicEvent/connector.ts
+++ b/frontend/src/modules/touristicEvent/connector.ts
@@ -1,3 +1,5 @@
+import { GeometryObject } from 'modules/interface';
+import { adaptGeometry } from 'modules/utils/geometry';
 import { getCities } from '../city/connector';
 import { getThemes } from '../filters/theme/connector';
 import { getSources } from '../source/connector';
@@ -9,7 +11,7 @@ import {
   adaptTouristicEventPopupResults,
   adaptTouristicEvents,
 } from './adapter';
-import { fetchTouristicEventDetails, fetchTouristicEvents } from './api';
+import { fetchTouristicEventDetails, fetchTouristicEventResult, fetchTouristicEvents } from './api';
 import { TouristicEvent, TouristicEventDetails } from './interface';
 
 export const getTouristicEvents = async (
@@ -76,4 +78,12 @@ export const getTouristicEventPopupResult = async (
   const [cityDictionnary] = await Promise.all([getCities(language)]);
 
   return adaptTouristicEventPopupResults({ rawTouristicEventPopupResult, cityDictionnary });
+};
+
+export const getTouristicEventGeometryResult = async (
+  id: string,
+  language: string,
+): Promise<GeometryObject> => {
+  const rawTouristicEventGeometryResult = await fetchTouristicEventResult({ language }, id);
+  return adaptGeometry(rawTouristicEventGeometryResult.geometry);
 };

--- a/frontend/src/modules/trekResult/adapter.ts
+++ b/frontend/src/modules/trekResult/adapter.ts
@@ -1,17 +1,6 @@
-import { RawCoordinate3D } from 'modules/interface';
 import { getThumbnail } from 'modules/utils/adapter';
 import { getGlobalConfig } from 'modules/utils/api.config';
-import {
-  adaptGeometry2D,
-  adaptGeometry3D,
-  flattenMultiLineStringCoordinates,
-} from 'modules/utils/geometry';
-import {
-  PopupResult,
-  RawTrekGeometryResult,
-  RawTrekPopupResult,
-  TrekGeometryResult,
-} from './interface';
+import { PopupResult, RawTrekPopupResult } from './interface';
 
 export const fallbackImgUri = getGlobalConfig().fallbackImageUri;
 
@@ -20,22 +9,5 @@ export const adaptTrekPopupResults = (rawDetails: RawTrekPopupResult): PopupResu
     title: rawDetails.name,
     place: rawDetails.departure,
     imgUrl: getThumbnail(rawDetails.attachments) ?? fallbackImgUri,
-  };
-};
-
-export const adaptTrekGeometryResults = (
-  rawGeometry: RawTrekGeometryResult,
-): TrekGeometryResult => {
-  if (rawGeometry.geometry.type === 'Point') {
-    return { geometry: [adaptGeometry2D(rawGeometry.geometry.coordinates)] };
-  }
-
-  const rawCoordinates: RawCoordinate3D[] =
-    rawGeometry.geometry.type === 'MultiLineString'
-      ? flattenMultiLineStringCoordinates(rawGeometry.geometry.coordinates)
-      : rawGeometry.geometry.coordinates;
-
-  return {
-    geometry: rawCoordinates.map(adaptGeometry3D),
   };
 };

--- a/frontend/src/modules/trekResult/api.ts
+++ b/frontend/src/modules/trekResult/api.ts
@@ -1,6 +1,7 @@
+import { RawGeometryObject } from 'modules/interface';
 import { GeotrekAPI } from 'services/api/client';
 import { APIQuery } from 'services/api/interface';
-import { RawTrekGeometryResult, RawTrekPopupResult } from './interface';
+import { RawTrekPopupResult } from './interface';
 
 const fieldsParams = {
   fields: 'name,departure,attachments',
@@ -12,5 +13,5 @@ export const fetchTrekPopupResult = (query: APIQuery, id: string): Promise<RawTr
 export const fetchTrekGeometryResult = (
   query: APIQuery,
   id: string,
-): Promise<RawTrekGeometryResult> =>
+): Promise<{ geometry: RawGeometryObject }> =>
   GeotrekAPI.get(`/trek/${id}/`, { params: { ...query, fields: 'geometry' } }).then(r => r.data);

--- a/frontend/src/modules/trekResult/connector.ts
+++ b/frontend/src/modules/trekResult/connector.ts
@@ -1,6 +1,8 @@
-import { adaptTrekGeometryResults, adaptTrekPopupResults } from './adapter';
+import { GeometryObject } from 'modules/interface';
+import { adaptGeometry } from 'modules/utils/geometry';
+import { adaptTrekPopupResults } from './adapter';
 import { fetchTrekGeometryResult, fetchTrekPopupResult } from './api';
-import { PopupResult, TrekGeometryResult } from './interface';
+import { PopupResult } from './interface';
 
 export const getTrekPopupResult = async (id: string, language: string): Promise<PopupResult> => {
   const rawTrekPopupResult = await fetchTrekPopupResult({ language }, id);
@@ -11,8 +13,7 @@ export const getTrekPopupResult = async (id: string, language: string): Promise<
 export const getTrekGeometryResult = async (
   id: string,
   language: string,
-): Promise<TrekGeometryResult> => {
+): Promise<GeometryObject> => {
   const rawTrekGeometryResult = await fetchTrekGeometryResult({ language }, id);
-
-  return adaptTrekGeometryResults(rawTrekGeometryResult);
+  return adaptGeometry(rawTrekGeometryResult.geometry);
 };

--- a/frontend/src/modules/trekResult/interface.ts
+++ b/frontend/src/modules/trekResult/interface.ts
@@ -1,11 +1,4 @@
-import {
-  Coordinate2D,
-  Coordinate3D,
-  RawAttachment,
-  RawLineStringGeometry3D,
-  RawMultiLineStringGeometry3D,
-  RawPointGeometry2D,
-} from 'modules/interface';
+import { RawAttachment } from 'modules/interface';
 
 export interface RawTrekPopupResult {
   name: string;
@@ -17,12 +10,4 @@ export interface PopupResult {
   title: string;
   place: string;
   imgUrl: string;
-}
-
-export interface RawTrekGeometryResult {
-  geometry: RawLineStringGeometry3D | RawMultiLineStringGeometry3D | RawPointGeometry2D;
-}
-
-export interface TrekGeometryResult {
-  geometry: Coordinate3D[] | Coordinate2D[];
 }

--- a/frontend/src/modules/utils/geometry.ts
+++ b/frontend/src/modules/utils/geometry.ts
@@ -2,6 +2,7 @@ import {
   Coordinate2D,
   Coordinate3D,
   GeometryCollection,
+  GeometryObject,
   LineStringGeometry,
   MultiLineStringGeometry,
   MultiPointGeometry,
@@ -11,6 +12,7 @@ import {
   RawCoordinate2D,
   RawCoordinate3D,
   RawGeometryCollection,
+  RawGeometryObject,
   RawLineStringGeometry2D,
   RawMultiLineStringGeometry,
   RawMultiPointGeometry2D,
@@ -31,23 +33,7 @@ export const adaptGeometry3D = (geometry: RawCoordinate3D): Coordinate3D => ({
 });
 
 /** Adapt any type of raw geometry */
-export const adaptGeometry = (
-  geometry:
-    | RawPolygonGeometry
-    | RawMultiPolygonGeometry
-    | RawLineStringGeometry2D
-    | RawMultiLineStringGeometry
-    | RawPointGeometry2D
-    | RawMultiPointGeometry2D
-    | RawGeometryCollection,
-):
-  | PolygonGeometry
-  | MultiPolygonGeometry
-  | LineStringGeometry
-  | MultiLineStringGeometry
-  | PointGeometry
-  | MultiPointGeometry
-  | GeometryCollection => {
+export const adaptGeometry = (geometry: RawGeometryObject): GeometryObject => {
   switch (geometry.type) {
     case 'Polygon':
       return adaptPolygonGeometry(geometry);
@@ -107,7 +93,7 @@ export const adaptMultiPoint = (geometry: RawMultiPointGeometry2D): MultiPointGe
   coordinates: geometry.coordinates.map(point => adaptGeometry2D(point)),
 });
 
-const adaptGeometryCollection = (geometry: RawGeometryCollection): GeometryCollection => ({
+export const adaptGeometryCollection = (geometry: RawGeometryCollection): GeometryCollection => ({
   type: geometry.type,
   geometries: geometry.geometries.map(geom => adaptGeometry(geom)),
 });

--- a/frontend/src/stylesheet.ts
+++ b/frontend/src/stylesheet.ts
@@ -82,9 +82,6 @@ export const colorPalette = {
     gradientOnImages: tailwindConfig.theme.extend.colors.gradientOnImages,
     shadowOnImages: tailwindConfig.theme.extend.colors.gradientOnImages,
   },
-  map: {
-    touristicContentLines: '#D65600',
-  },
 } as const;
 
 // This function collects in a list all the colors defined at the root of the color palette object. Duplicated colors are eliminated.


### PR DESCRIPTION
- Display main geometry of all kinds of geometry (Polygon, MultiPolygon, LineString, MultilineString, and GeometryCollection)
- Points and MultiPoints are filtered out and not displayed because it looks visually strange/buggy (this is my opinion, we might rethink it).
- Each Geometry get now the defined color of each type (https://github.com/GeotrekCE/Geotrek-rando-v3/blob/main/docs/customization.md#colors)
- Before this pull-request the feature was available for Trek and Touristic content, and now it supports Outdoor site and Touristic event geometries.

Related to [Apparition des tracés d'itinéraires sur le fond de carte #497](https://github.com/GeotrekCE/Geotrek-rando-v3/issues/497)

