### PR TITLE
Define explicitly a range zoom for group layers

### DIFF
--- a/frontend/src/components/Map/components/TileLayerExtended/index.tsx
+++ b/frontend/src/components/Map/components/TileLayerExtended/index.tsx
@@ -7,6 +7,7 @@ interface TileLayerExtendedProps {
   url: string;
   bounds?: string;
   options?: LayerOptions;
+  rangeZoom?: number[];
 }
 
 interface ExtendedProperties {
@@ -79,7 +80,12 @@ const getGeoJSONLayer = async (url: string, options: LayerOptions) => {
   );
 };
 
-const TileLayerExtended: React.FC<TileLayerExtendedProps> = ({ url, bounds, options = {} }) => {
+const TileLayerExtended: React.FC<TileLayerExtendedProps> = ({
+  url,
+  bounds,
+  options = {},
+  rangeZoom = [0, 20],
+}) => {
   const [tile, setTile] = useState(null);
   const map = useMap();
 
@@ -105,24 +111,24 @@ const TileLayerExtended: React.FC<TileLayerExtendedProps> = ({ url, bounds, opti
       map.addLayer(nextTile);
     }
     map.attributionControl?.setPrefix('');
-  }, [url, bounds, options]);
+  }, [url, bounds, options, map]);
 
   useEffect(() => {
     if (map === undefined) {
       return;
     }
+    map.setMinZoom(rangeZoom[0]);
+    map.setMaxZoom(rangeZoom[1]);
     void loadLayer();
-    return () => {
-      if (options?.attribution !== undefined) {
-        map.attributionControl?.removeAttribution(options?.attribution);
-      }
-    };
-  }, [map]);
+  }, [loadLayer, map]);
 
   useEffect(() => {
     return () => {
       if (map !== undefined && tile !== null) {
         map.removeLayer(tile);
+        if (options?.attribution !== undefined) {
+          map.attributionControl?.removeAttribution(options?.attribution);
+        }
       }
     };
   }, [map, tile]);

--- a/frontend/src/components/Map/components/TileLayerGroup/index.tsx
+++ b/frontend/src/components/Map/components/TileLayerGroup/index.tsx
@@ -10,10 +10,17 @@ const TileLayerGroup: React.FC<TileLayerGroupProps> = ({ layers }) => {
     return null;
   }
 
+  const groupRangeZoom = layers.reduce(
+    (list, { options: { minZoom = 0, maxZoom = 20 } = {} }) => {
+      return [Math.min(minZoom, list[0]), Math.max(maxZoom, list[1])];
+    },
+    [Infinity, -Infinity],
+  );
+
   return (
     <>
       {layers.map(layer => (
-        <TileLayerExtended key={layer.url} {...layer} />
+        <TileLayerExtended key={layer.url} rangeZoom={groupRangeZoom} {...layer} />
       ))}
     </>
   );


### PR DESCRIPTION
This PR fixes a zoom bug that could occur after clicking on the map switcher (e.g. classic to satellite) from a base map composed of a group of layers. 
Leaflet keeps the last layer of the stack to set the minZoom / maxZoom on the map: If the user navigates in a zoom range outside the zoom range of this layer and clicks on the map switcher, Leaflet should adapt the zoom to its range.