### PR TITLE
Add the ability to secure form with captcha

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -34,9 +34,11 @@ In json files, you can just override the primary keys you need. You have to over
     ![Activity Icon on filter list](assets/labeledTouristicContentExample.png)
   - `applicationName`: application name appearing on PWA
   - `enableReport`: to enable report form in trek detail pages
+  - `hCaptchaKey`: string key to enable Captcha validation in the report form. To create/define a key, see https://www.hcaptcha.com/
   - `enableSearchByMap`: to enable searching by map displayed area (bbox)
   - `maxLengthTrekAllowedFor3DRando`: Maximum length of meters allowed to enable 3D mode in the current trek. Adjust this setting carefully as too long a trek could freeze your browser. If this setting is defined to `0` (or  `mapSatelliteLayers` from `map.json` is defined to `null`) the 3D mode feature is disabled for the whole application
   - `minAltitudeDifferenceToDisplayElevationProfile`: Minimum altitude difference in meters required to display the elevation profile in the current trek
+  - `accessibilityCodeNumber`: emergency number. Default set to `114`.
 
 - `header.json` to define logo URL, default and available languages, number items to flatpages to display in navbar (see default values in https://github.com/GeotrekCE/Geotrek-rando-v3/blob/main/frontend/config/header.json)
 

--- a/frontend/config/global.json
+++ b/frontend/config/global.json
@@ -24,5 +24,6 @@
   "maxLengthTrekAllowedFor3DRando": 25000,
   "minAltitudeDifferenceToDisplayElevationProfile": 0,
   "accessibilityCodeNumber": "114",
-  "groupTreksAndOutdoorFilters": false
+  "groupTreksAndOutdoorFilters": false,
+  "hCaptchaKey": null
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@20tab/react-leaflet-resetview": "^1.0.1",
+    "@hcaptcha/react-hcaptcha": "^1.4.4",
     "@makina-corpus/rando3d": "^1.3.3",
     "@raruto/leaflet-elevation": "1.7.0",
     "@sentry/nextjs": "^7.12.1",

--- a/frontend/src/components/HCaptcha/index.js
+++ b/frontend/src/components/HCaptcha/index.js
@@ -1,0 +1,18 @@
+import { getGlobalConfig } from 'modules/utils/api.config';
+import { useRef } from 'react';
+import { useRouter } from 'next/router';
+import HCaptcha from '@hcaptcha/react-hcaptcha';
+
+const Captcha = () => {
+  const { hCaptchaKey } = getGlobalConfig();
+  const captchaRef = useRef(null);
+  const { locale } = useRouter();
+
+  if (hCaptchaKey === null) {
+    return null;
+  }
+
+  return <HCaptcha hl={locale} ref={captchaRef} sitekey={hCaptchaKey} />;
+};
+
+export default Captcha;

--- a/frontend/src/components/Report/Report.tsx
+++ b/frontend/src/components/Report/Report.tsx
@@ -37,7 +37,7 @@ const Report: React.FC<Props> = ({ displayMobileMap, startPoint, trekId }) => {
     startPoint,
   });
 
-  const { contact: { name, number, mail } = {} } = getFooterConfig();
+  const { contact: { name, number = '', mail } = {} } = getFooterConfig();
 
   const { reportVisibility, setReportVisibility } = useDetailsAndMapContext();
   const [displayForm, setDisplayForm] = useState<boolean>(false);
@@ -81,7 +81,7 @@ const Report: React.FC<Props> = ({ displayMobileMap, startPoint, trekId }) => {
               <FormattedMessage id={'report.success'} />
             </div>
           ) : (
-            <form encType="multipart/form-data" onSubmit={void submit}>
+            <form encType="multipart/form-data" onSubmit={submit}>
               {(!isMobile || coordinatesReportTouched) && (
                 <CoordinatesRow
                   coordinates={[
@@ -199,7 +199,7 @@ const Report: React.FC<Props> = ({ displayMobileMap, startPoint, trekId }) => {
                           a: () => (
                             <a
                               className="underline"
-                              href={mail !== undefined ? `mailto:${mail}` : `tel:${number ?? ''}`}
+                              href={mail !== undefined ? `mailto:${mail}` : `tel:${number}`}
                             >
                               {mail ?? number}
                             </a>

--- a/frontend/src/components/Report/Report.tsx
+++ b/frontend/src/components/Report/Report.tsx
@@ -12,6 +12,7 @@ import styled from 'styled-components';
 import { useDetailsAndMapContext } from 'components/pages/details/DetailsAndMapContext';
 import { Arrow } from 'components/Icons/Arrow';
 import { getFooterConfig } from 'components/Footer/useFooter';
+import HCaptcha from 'components/HCaptcha';
 import { Option } from '../../modules/filters/interface';
 import { PointGeometry } from '../../modules/interface';
 import { MapReportButton } from './MapReportButton';
@@ -190,23 +191,25 @@ const Report: React.FC<Props> = ({ displayMobileMap, startPoint, trekId }) => {
                     </p>
                   )}
 
-                  <div className="flex items-center gap-6">
-                    <p className="text-sm text-italic">
-                      <FormattedMessage
-                        id={'report.GDPRDisclaimer'}
-                        values={{
-                          b: () => <strong className="font-bold">{name}</strong>,
-                          a: () => (
-                            <a
-                              className="underline"
-                              href={mail !== undefined ? `mailto:${mail}` : `tel:${number}`}
-                            >
-                              {mail ?? number}
-                            </a>
-                          ),
-                        }}
-                      />
-                    </p>
+                  <p className="text-sm text-italic">
+                    <FormattedMessage
+                      id={'report.GDPRDisclaimer'}
+                      values={{
+                        b: () => <strong className="font-bold">{name}</strong>,
+                        a: () => (
+                          <a
+                            className="underline"
+                            href={mail !== undefined ? `mailto:${mail}` : `tel:${number}`}
+                          >
+                            {mail ?? number}
+                          </a>
+                        ),
+                      }}
+                    />
+                  </p>
+
+                  <div className="desktop:flex items-center justify-end mt-4 gap-6">
+                    <HCaptcha />
 
                     <Button type="submit">
                       <FormattedMessage id={'report.button'} />

--- a/frontend/src/components/Report/useReport.ts
+++ b/frontend/src/components/Report/useReport.ts
@@ -149,7 +149,7 @@ const useReport = ({ startPoint }: Props) => {
       .catch(localError => {
         console.error(localError);
         const [context, key, field] = (localError.message as string).split('.');
-        setError({ id: `${context}.${key}`, values: { field: `${context}.${field}` } });
+        setError({ id: `${context}.${key}`, values: { field: `report.${field}` } });
       });
     setCoordinatesReportTouched(false);
   };

--- a/frontend/src/modules/interface.ts
+++ b/frontend/src/modules/interface.ts
@@ -108,6 +108,7 @@ export interface APICallsConfig {
   minAltitudeDifferenceToDisplayElevationProfile: number;
   accessibilityCodeNumber: string | null;
   groupTreksAndOutdoorFilters: boolean;
+  hCaptchaKey: string | null;
 }
 
 /** @deprecated please use Coordinate2D or Coordinate3D instead */

--- a/frontend/src/modules/report/connector.ts
+++ b/frontend/src/modules/report/connector.ts
@@ -1,10 +1,15 @@
+import { getGlobalConfig } from 'modules/utils/api.config';
 import { postReport } from './api';
 
 export const createReport = async (lang: string, params: FormData) => {
+  const { hCaptchaKey } = getGlobalConfig();
+
   if (params.get('email') === '') throw new Error('error.missing.email');
   if (params.get('problem_magnitude') === '') throw new Error('error.missing.magnitude');
   if (params.get('activity') === '') throw new Error('error.missing.activity');
   if (params.get('category') === '') throw new Error('error.missing.category');
+  if (hCaptchaKey !== null && params.get('g-recaptcha-response') === '')
+    throw new Error('error.missing.captcha');
 
   return postReport(lang, params);
 };

--- a/frontend/src/translations/ca.json
+++ b/frontend/src/translations/ca.json
@@ -179,6 +179,7 @@
     "title": "Assenyalar un problema o un error",
     "intro": "If you have found an error on this page or if you have noticed any problems during your hike, please report them to us here:",
     "activity": "Activitat",
+    "captcha": "Captcha",
     "category": "Categoria",
     "magnitude": "Amplitud del problema",
     "comment": "Comentaris",

--- a/frontend/src/translations/de.json
+++ b/frontend/src/translations/de.json
@@ -179,6 +179,7 @@
     "title": "Ein Problem oder einen Fehler melden",
     "intro": "If you have found an error on this page or if you have noticed any problems during your hike, please report them to us here:",
     "activity": "Aktivität",
+    "captcha": "Captcha",
     "category": "Kategorie",
     "magnitude": "Ausmaß des Problems",
     "comment": "Kommentare",

--- a/frontend/src/translations/en.json
+++ b/frontend/src/translations/en.json
@@ -186,6 +186,7 @@
     "title": "Report a problem or an error",
     "intro": "If you have found an error on this page or if you have noticed any problems during your hike, please report them to us here:",
     "activity": "Activity",
+    "captcha": "Captcha",
     "category": "Category",
     "magnitude": "Magnitude of the problem",
     "comment": "Comments",

--- a/frontend/src/translations/es.json
+++ b/frontend/src/translations/es.json
@@ -179,6 +179,7 @@
     "title": "Informar de un problema o un error",
     "intro": "If you have found an error on this page or if you have noticed any problems during your hike, please report them to us here:",
     "activity": "Actividad",
+    "captcha": "Captcha",
     "category": "Categoría",
     "magnitude": "Amplitud del problema",
     "comment": "Comentarios",

--- a/frontend/src/translations/fr.json
+++ b/frontend/src/translations/fr.json
@@ -187,6 +187,7 @@
     "title": "Signaler un problème ou une erreur",
     "intro": "Vous avez repéré une erreur sur cette page ou constaté un problème lors de votre randonnée, signalez-les nous ici :",
     "activity": "Activité",
+    "captcha": "Captcha",
     "category": "Catégorie",
     "magnitude": "Ampleur du problème",
     "comment": "Commentaires",

--- a/frontend/src/translations/it.json
+++ b/frontend/src/translations/it.json
@@ -186,6 +186,7 @@
     "title": "Segnala un problema o un errore",
     "intro": "If you have found an error on this page or if you have noticed any problems during your hike, please report them to us here:",
     "activity": "Attività",
+    "captcha": "Captcha",
     "category": "Categoria",
     "magnitude": "Portata del problema",
     "comment": "Commenti",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1420,6 +1420,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.17.9":
+  version "7.19.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.4.tgz#a42f814502ee467d55b38dd1c256f53a7b885c78"
+  integrity sha512-EXpLCrk55f+cYqmHsSR+yD/0gAIMxxA9QK9lnQWzhMCvt+YmoBN7Zx94s++Kv0+unHk39vxNO8t+CMA2WSS3wA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.12.7", "@babel/template@^7.3.3":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.7.tgz#c817233696018e39fbb6c491d2fb684e05ed43bc"
@@ -1855,6 +1862,13 @@
   integrity sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==
   dependencies:
     "@hapi/hoek" "^9.0.0"
+
+"@hcaptcha/react-hcaptcha@^1.4.4":
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/@hcaptcha/react-hcaptcha/-/react-hcaptcha-1.4.4.tgz#529c55369160995115735b5fe5453daef4670f04"
+  integrity sha512-Aen217LDnf5ywbPSwBG5CsoqBLIHIAS9lhj3zQjXJuO13doQ6/ubkCWNuY8jmwYLefoFt3V3MrZmCdKDaFoTuQ==
+  dependencies:
+    "@babel/runtime" "^7.17.9"
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"


### PR DESCRIPTION
- Fix the display of input error message
- Add captcha to the report form if an API key from HCAPTCHA is defined in `global.json` settings.
