### PR TITLE
Rewrite usage of loading spinner

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -69,7 +69,6 @@
     "react-leaflet": "3.1.0",
     "react-leaflet-markercluster": "^3.0.0-rc1",
     "react-leaflet-textpath": "2.1.0",
-    "react-loader": "^2.4.7",
     "react-media-hook": "^0.5.0",
     "react-select": "^5.4.0",
     "react-slick": "0.28.1",

--- a/frontend/src/components/Layout/Layout.tsx
+++ b/frontend/src/components/Layout/Layout.tsx
@@ -1,24 +1,17 @@
 import { Header } from 'components/Header';
 import ConditionallyRender from 'components/ConditionallyRender';
-import { colorPalette, zIndex } from 'stylesheet';
-import Loader from 'react-loader';
+import Loader from 'components/Loader';
 import { useNavigationLoader } from './useRedirection';
 
 export const Layout: React.FC = ({ children }) => {
   const { isNavigationLoading } = useNavigationLoader();
 
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-col min-h-full">
       <Header />
-      <main className="flex-grow">
+      <main className="relative flex-grow">
         <ConditionallyRender client>
-          <Loader
-            loaded={!isNavigationLoading}
-            options={{
-              color: colorPalette.primary1,
-              zIndex: zIndex.loader,
-            }}
-          >
+          <Loader loaded={!isNavigationLoading} className="z-loader absolute inset-0">
             {children}
           </Loader>
         </ConditionallyRender>

--- a/frontend/src/components/Loader/Loader.style.ts
+++ b/frontend/src/components/Loader/Loader.style.ts
@@ -1,97 +1,76 @@
 import styled, { keyframes } from 'styled-components';
-import { colorPalette } from 'stylesheet';
-
-const loaderAnimation = keyframes`
-  0%, 20%, 80%, 100% {
-    transform: scale(1);
-  }
-  50% {
-    transform: scale(1.5);
-  }
-`;
-
-export const LoaderWrapper = styled.div`
-  width: 100%;
-  height: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-`;
 
 // Loader from https://loading.io/css/
-export const LoaderContainer = styled.div`
-  display: inline-block;
-  position: relative;
-  width: 64px;
-  height: 64px;
+const loaderAnimation = keyframes`
+  0% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
 `;
-
 export const Dot = styled.div`
-  position: absolute;
-  width: 5px;
-  height: 5px;
-  background: ${colorPalette.primary3};
-  border-radius: 50%;
+  transform-origin: 30px 30px;
   animation: ${loaderAnimation} 1.2s linear infinite;
 
+  &::after {
+    content: ' ';
+    display: block;
+    position: absolute;
+    top: 6px;
+    left: 28px;
+    width: 5px;
+    height: 12px;
+    border-radius: 20%;
+    background: currentColor;
+  }
+
   :nth-child(1) {
-    animation-delay: 0s;
-    top: 29px;
-    left: 53px;
+    transform: rotate(0deg);
+    animation-delay: -1.1s;
   }
   :nth-child(2) {
-    animation-delay: -0.1s;
-    top: 18px;
-    left: 50px;
+    transform: rotate(30deg);
+    animation-delay: -1s;
   }
   :nth-child(3) {
-    animation-delay: -0.2s;
-    top: 9px;
-    left: 41px;
+    transform: rotate(60deg);
+    animation-delay: -0.9s;
   }
   :nth-child(4) {
-    animation-delay: -0.3s;
-    top: 6px;
-    left: 29px;
+    transform: rotate(90deg);
+    animation-delay: -0.8s;
   }
   :nth-child(5) {
-    animation-delay: -0.4s;
-    top: 9px;
-    left: 18px;
+    transform: rotate(120deg);
+    animation-delay: -0.7s;
   }
   :nth-child(6) {
-    animation-delay: -0.5s;
-    top: 18px;
-    left: 9px;
+    transform: rotate(150deg);
+    animation-delay: -0.6s;
   }
   :nth-child(7) {
-    animation-delay: -0.6s;
-    top: 29px;
-    left: 6px;
+    transform: rotate(180deg);
+    animation-delay: -0.5s;
   }
   :nth-child(8) {
-    animation-delay: -0.7s;
-    top: 41px;
-    left: 9px;
+    transform: rotate(210deg);
+    animation-delay: -0.4s;
   }
   :nth-child(9) {
-    animation-delay: -0.8s;
-    top: 50px;
-    left: 18px;
+    transform: rotate(240deg);
+    animation-delay: -0.3s;
   }
   :nth-child(10) {
-    animation-delay: -0.9s;
-    top: 53px;
-    left: 29px;
+    transform: rotate(270deg);
+    animation-delay: -0.2s;
   }
   :nth-child(11) {
-    animation-delay: -1s;
-    top: 50px;
-    left: 41px;
+    transform: rotate(300deg);
+    animation-delay: -0.1s;
   }
   :nth-child(12) {
-    animation-delay: -1.1s;
-    top: 41px;
-    left: 50px;
+    transform: rotate(330deg);
+    animation-delay: 0s;
   }
 `;

--- a/frontend/src/components/Loader/Loader.tsx
+++ b/frontend/src/components/Loader/Loader.tsx
@@ -1,23 +1,38 @@
-import { Dot, LoaderContainer, LoaderWrapper } from './Loader.style';
+import { FormattedMessage } from 'react-intl';
+import { Dot } from './Loader.style';
+
+type LoaderProps = {
+  className?: string;
+  children?: React.ReactNode;
+  loaded?: boolean;
+};
 
 // Loader from https://loading.io/css/
-const Loader: React.FC = () => (
-  <LoaderWrapper>
-    <LoaderContainer>
-      <Dot />
-      <Dot />
-      <Dot />
-      <Dot />
-      <Dot />
-      <Dot />
-      <Dot />
-      <Dot />
-      <Dot />
-      <Dot />
-      <Dot />
-      <Dot />
-    </LoaderContainer>
-  </LoaderWrapper>
-);
+const Loader: React.FC<LoaderProps> = ({ className = '', loaded = false, children = '' }) => {
+  if (loaded === true) {
+    return <>{children}</>;
+  }
+  return (
+    <div className={`flex w-full h-full justify-center items-center text-primary1 ${className}`}>
+      <p className="sr-only" aria-live="polite">
+        <FormattedMessage id="loading" />
+      </p>
+      <div className="relative inline-block w-15 h-15">
+        <Dot />
+        <Dot />
+        <Dot />
+        <Dot />
+        <Dot />
+        <Dot />
+        <Dot />
+        <Dot />
+        <Dot />
+        <Dot />
+        <Dot />
+        <Dot />
+      </div>
+    </div>
+  );
+};
 
 export default Loader;

--- a/frontend/src/components/Map/components/Popup/index.tsx
+++ b/frontend/src/components/Map/components/Popup/index.tsx
@@ -3,7 +3,7 @@ import { routes } from 'services/routes';
 import styled, { css } from 'styled-components';
 import { Popup as LeafletPopup, Tooltip as LeafletTooltip } from 'react-leaflet';
 import { FormattedMessage } from 'react-intl';
-import Loader from 'react-loader';
+import Loader from 'components/Loader';
 
 import { colorPalette, desktopOnly, getSpacing } from 'stylesheet';
 import { textEllipsisAfterNLines } from 'services/cssHelpers';
@@ -39,12 +39,7 @@ const PopupContent: React.FC<PropsPC> = ({ showButton, id, type, parentId }) => 
   const { isLoading, trekPopupResult } = usePopupResult(id.toString(), true, type);
 
   return (
-    <Loader
-      loaded={!isLoading}
-      options={{
-        color: colorPalette.primary1,
-      }}
-    >
+    <Loader className="absolute inset-0" loaded={!isLoading}>
       {trekPopupResult && (
         <div className="flex flex-col">
           <CoverImage src={trekPopupResult.imgUrl} />

--- a/frontend/src/components/Report/Report.tsx
+++ b/frontend/src/components/Report/Report.tsx
@@ -3,12 +3,11 @@ import InputRow from 'components/InputRow';
 import TextareaRow from 'components/TextareaRow';
 import React, { useEffect, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
-import Loader from 'react-loader';
+import Loader from 'components/Loader';
 
 import { SelectableDropdown } from 'components/pages/search/components/FilterBar/SelectableDropdown';
 import useReport from 'components/Report/useReport';
 import { useMediaPredicate } from 'react-media-hook';
-import styled from 'styled-components';
 import { useDetailsAndMapContext } from 'components/pages/details/DetailsAndMapContext';
 import { Arrow } from 'components/Icons/Arrow';
 import { getFooterConfig } from 'components/Footer/useFooter';
@@ -62,7 +61,7 @@ const Report: React.FC<Props> = ({ displayMobileMap, startPoint, trekId }) => {
   };
 
   return (
-    <ReportWrapper>
+    <>
       <div className="flex gap-5 items-center mb-5">
         <p className="text-lg">
           <FormattedMessage id={'report.intro'} />
@@ -218,16 +217,8 @@ const Report: React.FC<Props> = ({ displayMobileMap, startPoint, trekId }) => {
           )}
         </Loader>
       )}
-    </ReportWrapper>
+    </>
   );
 };
-
-const ReportWrapper = styled.div`
-  position: relative;
-  z-index: 0;
-  > .loader {
-    min-height: 80px;
-  }
-`;
 
 export default Report;

--- a/frontend/src/components/pages/details/Details.tsx
+++ b/frontend/src/components/pages/details/Details.tsx
@@ -1,7 +1,7 @@
 import MoreLink from 'components/Information/MoreLink';
 import { Layout } from 'components/Layout/Layout';
 import { Modal } from 'components/Modal';
-import Loader from 'react-loader';
+import Loader from 'components/Loader';
 
 import parse from 'html-react-parser';
 import { FormattedMessage } from 'react-intl';
@@ -11,7 +11,7 @@ import { OpenMapButton } from 'components/OpenMapButton';
 import { MobileMapContainer } from 'components/pages/search';
 import { useShowOnScrollPosition } from 'hooks/useShowOnScrollPosition';
 import { useMediaPredicate } from 'react-media-hook';
-import { colorPalette, sizes, zIndex } from 'stylesheet';
+import { sizes } from 'stylesheet';
 import React, { useMemo, useRef } from 'react';
 import { TrekChildGeometry } from 'modules/details/interface';
 import { cleanHTMLElementsFromString } from 'modules/utils/string';
@@ -118,18 +118,13 @@ export const DetailsUIWithoutContext: React.FC<Props> = ({ detailsId, parentId, 
           }
         />
         {details === undefined ? (
-          isLoading ? (
-            <Loader
-              loaded={!isLoading}
-              options={{
-                top: `${sizes.desktopHeader + sizes.filterBar}px`,
-                color: colorPalette.primary1,
-                zIndex: zIndex.loader,
-              }}
-            />
-          ) : (
-            <ErrorFallback refetch={refetch} />
-          )
+          <Layout>
+            {isLoading ? (
+              <Loader className="absolute inset-0" />
+            ) : (
+              <ErrorFallback refetch={refetch} />
+            )}
+          </Layout>
         ) : (
           <>
             <Layout>

--- a/frontend/src/components/pages/details/components/DetailsReservationWidget/DetailsReservationWidget.tsx
+++ b/frontend/src/components/pages/details/components/DetailsReservationWidget/DetailsReservationWidget.tsx
@@ -1,5 +1,6 @@
 import { Reservation } from 'modules/details/interface';
 import { useCallback, useEffect } from 'react';
+import Loader from 'components/Loader';
 import Script from 'next/script';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
@@ -91,7 +92,9 @@ export const DetailsReservationWidget: React.FC<DetailsReservationWidgetProps> =
         strategy="lazyOnload"
       />
       <div className="OsItinerance OsItPartner CssCustom">
-        <div id="eiti-partner"></div>
+        <div id="eiti-partner">
+          <Loader />
+        </div>
       </div>
     </>
   );

--- a/frontend/src/components/pages/flatPage/FlatPage.tsx
+++ b/frontend/src/components/pages/flatPage/FlatPage.tsx
@@ -1,5 +1,5 @@
 import { Layout } from 'components/Layout/Layout';
-import Loader from 'react-loader';
+import Loader from 'components/Loader';
 import { colorPalette, sizes, zIndex } from 'stylesheet';
 import parse from 'html-react-parser';
 import { Footer } from 'components/Footer';
@@ -34,14 +34,7 @@ export const FlatPageUI: React.FC<FlatPageUIProps> = ({ flatPageUrl }) => {
       />
       {flatPage === undefined ? (
         isLoading === true ? (
-          <Loader
-            loaded={!isLoading}
-            options={{
-              top: `${sizes.desktopHeader + sizes.filterBar}px`,
-              color: colorPalette.primary1,
-              zIndex: zIndex.loader,
-            }}
-          />
+          <Loader />
         ) : (
           <ErrorFallback refetch={refetch} />
         )

--- a/frontend/src/components/pages/search/Search.tsx
+++ b/frontend/src/components/pages/search/Search.tsx
@@ -4,9 +4,9 @@ import { useEffect } from 'react';
 import { useMediaPredicate } from 'react-media-hook';
 import styled from 'styled-components';
 import { FormattedMessage, useIntl } from 'react-intl';
-import Loader from 'react-loader';
+import Loader from 'components/Loader';
 import InfiniteScroll from 'react-infinite-scroll-component';
-import { colorPalette, sizes, zIndex } from 'stylesheet';
+import { colorPalette, sizes } from 'stylesheet';
 
 import { Layout } from 'components/Layout/Layout';
 import { TouristicContentCategoryMapping } from 'modules/touristicContentCategory/interface';
@@ -112,14 +112,20 @@ export const SearchUI: React.FC<Props> = ({ language }) => {
           id,
           selectedOptions: [
             ...list[index].selectedOptions,
-            ...item.selectedOptions.map(option => ({ ...option, include: false })),
+            ...item.selectedOptions.map(option => ({
+              ...option,
+              include: false,
+            })),
           ],
         };
       }
     } else {
       list.push({
         ...item,
-        selectedOptions: item.selectedOptions.map(option => ({ ...option, include: true })),
+        selectedOptions: item.selectedOptions.map(option => ({
+          ...option,
+          include: true,
+        })),
       });
     }
     return list;
@@ -128,7 +134,7 @@ export const SearchUI: React.FC<Props> = ({ language }) => {
   const numberSelected = countFiltersSelected(filtersState, null, null);
 
   return (
-    <div id="Search">
+    <div id="Search" className="h-full">
       <PageHead
         title={`${intl.formatMessage({ id: 'search.title' })}`}
         description={`${intl.formatMessage({ id: 'search.description' })}`}
@@ -181,15 +187,7 @@ export const SearchUI: React.FC<Props> = ({ language }) => {
               className="flex flex-col w-full desktop:w-1/2 overflow-y-scroll"
             >
               <div className="p-4 flex-1">
-                <Loader
-                  loaded={!isLoading}
-                  options={{
-                    top: '40px',
-                    color: colorPalette.primary1,
-                    zIndex: zIndex.loader,
-                    position: 'relative',
-                  }}
-                >
+                <Loader loaded={!isLoading}>
                   <div className="flex flex-col desktop:flex-row desktop:justify-between">
                     <div className="flex justify-between items-end" id="search_resultMapTitle">
                       <SearchResultsMeta resultsNumber={searchResults?.resultsNumber ?? 0} />
@@ -213,14 +211,8 @@ export const SearchUI: React.FC<Props> = ({ language }) => {
                     next={fetchNextPage}
                     hasMore={hasNextPage ?? false}
                     loader={
-                      <div className={` my-10 ${isFetchingNextPage ? 'h-10' : ''}`}>
-                        <Loader
-                          loaded={!isFetchingNextPage}
-                          options={{
-                            color: colorPalette.primary1,
-                            zIndex: zIndex.loader,
-                          }}
-                        ></Loader>
+                      <div className={`relative my-10 ${isFetchingNextPage ? 'h-10' : ''}`}>
+                        <Loader loaded={!isFetchingNextPage} />
                       </div>
                     }
                     scrollableTarget="search_resultCardList"
@@ -332,20 +324,8 @@ export const SearchUI: React.FC<Props> = ({ language }) => {
               className="hidden desktop:flex desktop:z-content desktop:w-1/2 desktop:fixed desktop:right-0 desktop:bottom-0 desktop:top-headerAndFilterBar"
               id="search_resultMap"
             >
-              {isMapLoading && (
-                <div
-                  className="absolute bg-primary2 opacity-40 w-full h-full"
-                  style={{ zIndex: 2000 }}
-                />
-              )}
-              <Loader
-                loaded={!isMapLoading}
-                options={{
-                  color: colorPalette.primary1,
-                  zIndex: 2500,
-                  scale: 2,
-                }}
-              />
+              {isMapLoading && <div className="absolute bg-primary2 opacity-40 inset-0 z-map" />}
+              <Loader loaded={!isMapLoading} className="absolute inset-0 z-map" />
               {!isMobile && (
                 <SearchMapDynamicComponent
                   type="DESKTOP"
@@ -389,7 +369,9 @@ const Separator = styled.hr`
   border: 0;
 `;
 
-export const MobileMapContainer = styled.div<{ displayState: 'DISPLAYED' | 'HIDDEN' | null }>`
+export const MobileMapContainer = styled.div<{
+  displayState: 'DISPLAYED' | 'HIDDEN' | null;
+}>`
   transition: top 0.3s ease-in-out 0.1s;
   top: ${({ displayState }) => (displayState === 'DISPLAYED' ? 0 : 100)}%;
 `;

--- a/frontend/src/components/pages/site/OutdoorCourseUI.tsx
+++ b/frontend/src/components/pages/site/OutdoorCourseUI.tsx
@@ -14,9 +14,9 @@ import { OutdoorSiteChildrenSection } from 'components/pages/site/components/Out
 import { useOutdoorCourse } from 'components/pages/site/useOutdoorCourse';
 import React, { useMemo, useRef } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
-import Loader from 'react-loader';
+import Loader from 'components/Loader';
 import { useMediaPredicate } from 'react-media-hook';
-import { colorPalette, sizes, zIndex } from 'stylesheet';
+import { sizes } from 'stylesheet';
 import { DetailsMapDynamicComponent } from 'components/Map';
 import { PageHead } from 'components/PageHead';
 import { Footer } from 'components/Footer';
@@ -91,18 +91,13 @@ export const OutdoorCourseUIWithoutContext: React.FC<Props> = ({ outdoorCourseUr
           }
         />
         {outdoorCourseContent === undefined ? (
-          isLoading ? (
-            <Loader
-              loaded={!isLoading}
-              options={{
-                top: `${sizes.desktopHeader + sizes.filterBar}px`,
-                color: colorPalette.primary1,
-                zIndex: zIndex.loader,
-              }}
-            />
-          ) : (
-            <ErrorFallback refetch={refetch} />
-          )
+          <Layout>
+            {isLoading ? (
+              <Loader className="absolute inset-0" />
+            ) : (
+              <ErrorFallback refetch={refetch} />
+            )}
+          </Layout>
         ) : (
           <>
             <Layout>

--- a/frontend/src/components/pages/site/OutdoorSiteUI.tsx
+++ b/frontend/src/components/pages/site/OutdoorSiteUI.tsx
@@ -19,9 +19,9 @@ import { OutdoorCoursesChildrenSection } from 'components/pages/site/components/
 import { OutdoorSiteChildrenSection } from 'components/pages/site/components/OutdoorSiteChildrenSection';
 import React, { useMemo, useRef } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
-import Loader from 'react-loader';
+import Loader from 'components/Loader';
 import { useMediaPredicate } from 'react-media-hook';
-import { colorPalette, sizes, zIndex } from 'stylesheet';
+import { sizes } from 'stylesheet';
 import { DetailsMapDynamicComponent } from 'components/Map';
 import { PageHead } from 'components/PageHead';
 import { Footer } from 'components/Footer';
@@ -103,18 +103,13 @@ const OutdoorSiteUIWithoutContext: React.FC<Props> = ({ outdoorSiteUrl, language
           }
         />
         {outdoorSiteContent === undefined ? (
-          isLoading ? (
-            <Loader
-              loaded={!isLoading}
-              options={{
-                top: `${sizes.desktopHeader + sizes.filterBar}px`,
-                color: colorPalette.primary1,
-                zIndex: zIndex.loader,
-              }}
-            />
-          ) : (
-            <ErrorFallback refetch={refetch} />
-          )
+          <Layout>
+            {isLoading ? (
+              <Loader className="absolute inset-0" />
+            ) : (
+              <ErrorFallback refetch={refetch} />
+            )}
+          </Layout>
         ) : (
           <>
             <Layout>

--- a/frontend/src/components/pages/touristicContent/TouristicContentUI.tsx
+++ b/frontend/src/components/pages/touristicContent/TouristicContentUI.tsx
@@ -1,8 +1,7 @@
 import { Layout } from 'components/Layout/Layout';
 import { Modal } from 'components/Modal';
-import Loader from 'react-loader';
+import Loader from 'components/Loader';
 import { useMediaPredicate } from 'react-media-hook';
-import { colorPalette, sizes, zIndex } from 'stylesheet';
 import parse from 'html-react-parser';
 import { FormattedMessage } from 'react-intl';
 import { TouristicContentMapDynamicComponent } from 'components/Map';
@@ -56,18 +55,13 @@ export const TouristicContentUI: React.FC<TouristicContentUIProps> = ({
         }
       />
       {touristicContent === undefined ? (
-        isLoading ? (
-          <Loader
-            loaded={!isLoading}
-            options={{
-              top: `${sizes.desktopHeader + sizes.filterBar}px`,
-              color: colorPalette.primary1,
-              zIndex: zIndex.loader,
-            }}
-          />
-        ) : (
-          <ErrorFallback refetch={refetch} />
-        )
+        <Layout>
+          {isLoading ? (
+            <Loader className="absolute inset-0" />
+          ) : (
+            <ErrorFallback refetch={refetch} />
+          )}
+        </Layout>
       ) : (
         <>
           <div id="touristicContent_page" className="flex flex-1">

--- a/frontend/src/components/pages/touristicEvent/TouristicEventUI.tsx
+++ b/frontend/src/components/pages/touristicEvent/TouristicEventUI.tsx
@@ -10,11 +10,11 @@ import { useOnScreenSection } from 'components/pages/details/hooks/useHighlighte
 import { generateTouristicContentUrl } from 'components/pages/details/utils';
 import { VisibleSectionProvider } from 'components/pages/details/VisibleSectionContext';
 import { useTouristicEvent } from 'components/pages/touristicEvent/useTouristicEvent';
-import React, { useMemo, useRef } from 'react';
+import { useMemo, useRef } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
-import Loader from 'react-loader';
+import Loader from 'components/Loader';
 import { useMediaPredicate } from 'react-media-hook';
-import { colorPalette, sizes, zIndex } from 'stylesheet';
+import { sizes } from 'stylesheet';
 import { DetailsMapDynamicComponent } from 'components/Map';
 import { PageHead } from 'components/PageHead';
 import { Footer } from 'components/Footer';
@@ -87,18 +87,13 @@ export const TouristicEventUIWithoutContext: React.FC<Props> = ({
           }
         />
         {touristicEventContent === undefined ? (
-          isLoading ? (
-            <Loader
-              loaded={!isLoading}
-              options={{
-                top: `${sizes.desktopHeader + sizes.filterBar}px`,
-                color: colorPalette.primary1,
-                zIndex: zIndex.loader,
-              }}
-            />
-          ) : (
-            <ErrorFallback refetch={refetch} />
-          )
+          <Layout>
+            {isLoading ? (
+              <Loader className="absolute inset-0" />
+            ) : (
+              <ErrorFallback refetch={refetch} />
+            )}
+          </Layout>
         ) : (
           <>
             <Layout>

--- a/frontend/src/translations/ca.json
+++ b/frontend/src/translations/ca.json
@@ -19,6 +19,7 @@
     "territoryTreks": "Excursions a descobrir",
     "itinerantTreks": "Itineràncies a descobrir"
   },
+  "loading": "Carregant",
   "page": {
     "back": "Tornada",
     "not-found": "No s’ha trobat la pàgina",

--- a/frontend/src/translations/de.json
+++ b/frontend/src/translations/de.json
@@ -19,6 +19,7 @@
     "territoryTreks": "Wanderungen, die es zu entdecken gilt",
     "itinerantTreks": "Reiserouten zum Entdecken"
   },
+  "loading": "Laden",
   "page": {
     "back": "Zurück",
     "not-found": "Diese Seite ist unauffindbar",

--- a/frontend/src/translations/en.json
+++ b/frontend/src/translations/en.json
@@ -22,6 +22,7 @@
     "events": "Events not to miss",
     "outdoor": "Outdoor to discover"
   },
+  "loading": "Loading",
   "page": {
     "back": "Back",
     "not-found": "This page was not found"

--- a/frontend/src/translations/es.json
+++ b/frontend/src/translations/es.json
@@ -19,6 +19,7 @@
     "territoryTreks": "Excursiones para descubrir",
     "itinerantTreks": "Itinerancias para descubrir"
   },
+  "loading": "Cargando",
   "page": {
     "back": "Vuelta",
     "not-found": "No hemos encontrado la página",

--- a/frontend/src/translations/fr.json
+++ b/frontend/src/translations/fr.json
@@ -22,6 +22,7 @@
     "events": "Événements à ne pas rater",
     "outdoor": "Sites outdoor à découvrir"
   },
+  "loading": "Chargement",
   "page": {
     "back": "Retour",
     "not-found": "Cette page est introuvable",

--- a/frontend/src/translations/it.json
+++ b/frontend/src/translations/it.json
@@ -22,6 +22,7 @@
     "events": "Eventi da non perdere",
     "outdoor": "Siti outdoor da scoprire"
   },
+  "loading": "Caricamento",
   "page": {
     "back": "Ritorno",
     "not-found": "Questa pagina non è stata trovata"

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -159,7 +159,7 @@ module.exports = {
     },
   },
   plugins: [
-    // plugin should be drop with TW v3
+    // plugins should be drop with TW v3
     plugin(function ({ addUtilities, variants }) {
       const scrollBehaviors = {
         '.scroll-smooth': {
@@ -169,8 +169,32 @@ module.exports = {
           'scroll-behavior': 'auto',
         },
       };
+      const srOnly = {
+        '.sr-only': {
+          position: 'absolute',
+          width: '1px',
+          height: '1px',
+          padding: 0,
+          margin: '-1px',
+          overflow: 'hidden',
+          clip: 'rect(0, 0, 0, 0)',
+          'white-space': 'nowrap',
+          'border-width': 0,
+        },
+        '.not-sr-only': {
+          position: 'static',
+          width: 'auto',
+          height: 'auto',
+          padding: 0,
+          margin: 0,
+          overflow: 'visible',
+          clip: 'auto',
+          'white-space': 'normal',
+        },
+      };
 
       addUtilities(scrollBehaviors, variants('scrollBehavior', ['motion-safe', 'motion-reduce']));
-    })
+      addUtilities(srOnly);
+    }),
   ],
 };

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4486,14 +4486,6 @@ cosmiconfig@^7.0.1:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
-create-react-class@^15.5.2:
-  version "15.7.0"
-  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.7.0.tgz#7499d7ca2e69bb51d13faf59bd04f0c65a1d6c1e"
-  integrity sha512-QZv4sFWG9S5RUvkTYWbflxeZX+JG7Cz0Tn33rQBJ+WFQTqTfUTjMjiv9tnfXazjsO5r0KhPs+AqCjyrQX6h2ng==
-  dependencies:
-    loose-envify "^1.3.1"
-    object-assign "^4.1.1"
-
 create-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
@@ -8100,7 +8092,7 @@ longest-streak@^2.0.0:
   resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-2.0.4.tgz#b8599957da5b5dab64dee3fe316fa774597d90e4"
   integrity sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==
 
-loose-envify@^1.1.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
+loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -9384,7 +9376,7 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@15.7.2, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@15.7.2, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -9629,15 +9621,6 @@ react-leaflet@^3.0.0:
   integrity sha512-0hJwwRMo5ChY+0nr1yO/UDCT4alIqMgJ7S/HoMBkL65Sr1yJ8eX5lAXk3EkdBUOwxQlMYCduU87pczYmudnlbQ==
   dependencies:
     "@react-leaflet/core" "^1.0.2"
-
-react-loader@^2.4.7:
-  version "2.4.7"
-  resolved "https://registry.yarnpkg.com/react-loader/-/react-loader-2.4.7.tgz#729abe746155456a954a97ff830aff0d6b05f2a9"
-  integrity sha512-pNW5xoSt0Q7HdmQh/EaIeeFbG0Ii74y6Le8gPdDyWyEFNgCiY1NcreQxMioQGjQ4Jo4EenQGKN/qMbxW+dpZkQ==
-  dependencies:
-    create-react-class "^15.5.2"
-    prop-types "^15.5.8"
-    spin.js "2.x"
 
 react-media-hook@^0.5.0:
   version "0.5.0"
@@ -10530,11 +10513,6 @@ specificity@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/specificity/-/specificity-0.4.1.tgz#aab5e645012db08ba182e151165738d00887b019"
   integrity sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==
-
-spin.js@2.x:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/spin.js/-/spin.js-2.3.2.tgz#6caa56d520673450fd5cfbc6971e6d0772c37a1a"
-  integrity sha1-bKpW1SBnNFD9XPvGlx5tB3LDeho=
 
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"


### PR DESCRIPTION
Replaced the `React-Loader` package which has not been updated for 3 years and will not be react 18 compliant, by a new component.

- Added some a11y
- Always keep the layout (header/footer) when transitionning from page to another
- Fix: [Widget reservation : mettre un loading pendant le chargement des scripts #732](https://github.com/GeotrekCE/Geotrek-rando-v3/issues/732)
- Fix: [ Lorsque j'arrive en bas de page et que des nouveaux résultats sont chargés, je ne vois le loader au milieu de l'écran #414](https://github.com/GeotrekCE/Geotrek-rando-v3/issues/414)

