### PR TITLE
Fix display of Accessibility images

### DIFF
--- a/frontend/src/components/Accessibility/index.tsx
+++ b/frontend/src/components/Accessibility/index.tsx
@@ -27,7 +27,8 @@ const Accessibility: React.FC<Props> = ({ details, language }) => {
             a => a.info_accessibility === k,
           );
           return attachments.length;
-        }).length > 0
+        })
+        .filter(Boolean).length > 0
     : false;
 
   return (

--- a/frontend/src/components/Carousel/Carousel.tsx
+++ b/frontend/src/components/Carousel/Carousel.tsx
@@ -16,19 +16,19 @@ interface LargeOrSmallCarouselProps {
 }
 
 export const Carousel: React.FC<CarouselProps> = ({
-  className,
+  className = '',
   children,
   nextArrow,
   prevArrow,
   dots,
 }) => {
   if (Array.isArray(children) && children.length <= 1) {
-    return <>{children}</>;
+    return <span className={className}>{children}</span>;
   }
   return (
     <StyledSlider
       lazyLoad="ondemand"
-      className={className ?? ''}
+      className={className}
       dots
       infinite
       speed={500}

--- a/frontend/src/components/pages/details/components/DetailsCard/DetailsCard.tsx
+++ b/frontend/src/components/pages/details/components/DetailsCard/DetailsCard.tsx
@@ -78,6 +78,7 @@ export const DetailsCard: React.FC<DetailsCardProps> = ({
         <img
           className="hidden desktop:absolute h-12 object-cover object-center right-6 top-6"
           src={logoUri}
+          alt=""
         />
       )}
       <div className="flex-none desktop:w-2/5">

--- a/frontend/src/components/pages/details/components/DetailsCard/__tests__/__snapshots__/DetailsCard.test.tsx.snap
+++ b/frontend/src/components/pages/details/components/DetailsCard/__tests__/__snapshots__/DetailsCard.test.tsx.snap
@@ -25,11 +25,15 @@ Object {
               <div
                 class="w-full h-full"
               >
-                <img
-                  class="sc-kstqJO cpcdgp"
-                  height="200"
-                  src="https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_1280.jpg"
-                />
+                <span
+                  class=""
+                >
+                  <img
+                    class="sc-kstqJO cpcdgp"
+                    height="200"
+                    src="https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_1280.jpg"
+                  />
+                </span>
               </div>
             </div>
           </div>
@@ -256,11 +260,15 @@ Object {
             <div
               class="w-full h-full"
             >
-              <img
-                class="sc-kstqJO cpcdgp"
-                height="200"
-                src="https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_1280.jpg"
-              />
+              <span
+                class=""
+              >
+                <img
+                  class="sc-kstqJO cpcdgp"
+                  height="200"
+                  src="https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_1280.jpg"
+                />
+              </span>
             </div>
           </div>
         </div>
@@ -384,11 +392,15 @@ Object {
               <div
                 class="w-full h-full"
               >
-                <img
-                  class="sc-kstqJO cpcdgp"
-                  height="200"
-                  src="https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_1280.jpg"
-                />
+                <span
+                  class=""
+                >
+                  <img
+                    class="sc-kstqJO cpcdgp"
+                    height="200"
+                    src="https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_1280.jpg"
+                  />
+                </span>
               </div>
             </div>
           </div>

--- a/frontend/src/components/pages/details/components/DetailsCard/index.ts
+++ b/frontend/src/components/pages/details/components/DetailsCard/index.ts
@@ -1,2 +1,1 @@
-export { DetailsCard } from './DetailsCard';
-export { CardSingleImage } from './DetailsCard';
+export { CardSingleImage, DetailsCard } from './DetailsCard';

--- a/frontend/src/components/pages/search/components/ResultCard/__tests__/__snapshots__/ResultCard.test.tsx.snap
+++ b/frontend/src/components/pages/search/components/ResultCard/__tests__/__snapshots__/ResultCard.test.tsx.snap
@@ -21,15 +21,19 @@ Object {
               <div
                 class="sc-hBEYId hCIdqa h-full w-full flex-grow relative desktop:w-resultCardDesktop"
               >
-                <div
-                  class="relative h-full"
+                <span
+                  class=""
                 >
-                  <img
-                    alt=""
-                    class="object-cover object-top w-full h-full"
-                    src=""
-                  />
-                </div>
+                  <div
+                    class="relative h-full"
+                  >
+                    <img
+                      alt=""
+                      class="object-cover object-top w-full h-full"
+                      src=""
+                    />
+                  </div>
+                </span>
               </div>
             </div>
           </div>
@@ -213,15 +217,19 @@ Object {
             <div
               class="sc-hBEYId hCIdqa h-full w-full flex-grow relative desktop:w-resultCardDesktop"
             >
-              <div
-                class="relative h-full"
+              <span
+                class=""
               >
-                <img
-                  alt=""
-                  class="object-cover object-top w-full h-full"
-                  src=""
-                />
-              </div>
+                <div
+                  class="relative h-full"
+                >
+                  <img
+                    alt=""
+                    class="object-cover object-top w-full h-full"
+                    src=""
+                  />
+                </div>
+              </span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
- If there is only one image to display: Set the same styles as the carousel images
- If there is not one image for all accessibility types: Delete them all instead of displaying the default image