### PR TITLE
Search pagination

### DIFF
--- a/frontend/src/components/pages/search/Search.tsx
+++ b/frontend/src/components/pages/search/Search.tsx
@@ -20,6 +20,7 @@ import { PageHead } from 'components/PageHead';
 import { FilterState } from 'modules/filters/interface';
 import { SearchMapDynamicComponent } from 'components/Map';
 import { useListAndMapContext } from 'modules/map/ListAndMapContext';
+import { useRouter } from 'next/router';
 import { countFiltersSelected } from '../../../modules/filters/utils';
 import { ResultCard } from './components/ResultCard';
 import { SearchResultsMeta } from './components/SearchResultsMeta';
@@ -40,6 +41,7 @@ interface Props {
 }
 
 export const SearchUI: React.FC<Props> = ({ language }) => {
+  const router = useRouter();
   const { filtersState, setFilterSelectedOptions, resetFilters } = useFilter();
 
   const { subMenuState, selectFilter, hideSubMenu, currentFilterId } = useFilterSubMenu();
@@ -48,6 +50,8 @@ export const SearchUI: React.FC<Props> = ({ language }) => {
   const { bboxState, handleMoveMap } = useBbox();
 
   const isMobile = useMediaPredicate('(max-width: 1024px)');
+
+  const page = Number(router.query.page ?? 1);
 
   const {
     textFilterInput,
@@ -67,10 +71,11 @@ export const SearchUI: React.FC<Props> = ({ language }) => {
     isFetchingNextPage,
     fetchNextPage,
     hasNextPage,
+    hasPreviousPage,
     mobileMapState,
     displayMobileMap,
     hideMobileMap,
-  } = useTrekResults({ filtersState, textFilterState, bboxState, dateFilter }, language);
+  } = useTrekResults({ filtersState, textFilterState, bboxState, dateFilter, page }, language);
 
   const { pageTitle, resultsTitle } = useTitle(filtersState, searchResults?.resultsNumber);
 
@@ -198,7 +203,7 @@ export const SearchUI: React.FC<Props> = ({ language }) => {
                 <InfiniteScroll
                   dataLength={searchResults?.results.length ?? 0}
                   next={fetchNextPage}
-                  hasMore={hasNextPage ?? false}
+                  hasMore={Boolean(hasNextPage)}
                   loader={
                     <div className={`relative my-10 ${isFetchingNextPage ? 'h-10' : ''}`}>
                       <Loader loaded={!isFetchingNextPage} />

--- a/frontend/src/components/pages/search/Search.tsx
+++ b/frontend/src/components/pages/search/Search.tsx
@@ -35,6 +35,7 @@ import InputWithMagnifier from './components/InputWithMagnifier';
 import { useTextFilter } from './hooks/useTextFilter';
 import { useDateFilter } from './hooks/useDateFilter';
 import { useTitle } from './hooks/useTitle';
+import { Pagination } from './components/Pagination';
 
 interface Props {
   language: string;
@@ -236,6 +237,12 @@ export const SearchUI: React.FC<Props> = ({ language }) => {
                     );
                   })}
                 </InfiniteScroll>
+
+                {/* noscript: Visible only for SEO purpose */}
+                <noscript>
+                  <Pagination hasPreviousPage={hasPreviousPage} hasNextPage={hasNextPage} />
+                </noscript>
+
                 {isError && (
                   <ErrorFallback refetch={searchResults === null ? refetch : fetchNextPage} />
                 )}

--- a/frontend/src/components/pages/search/__tests__/utils.test.ts
+++ b/frontend/src/components/pages/search/__tests__/utils.test.ts
@@ -105,7 +105,8 @@ const mockInfiniteQueryPage = {
     outdoorSitesCount: 0,
     touristicEventsCount: 0,
   },
-  nextPages: { treks: 2, touristicContents: 2, outdoorSites: 0, touristicEvents: 0 },
+  nextPages: { treks: 3, touristicContents: 3, outdoorSites: 0, touristicEvents: 0 },
+  previousPages: { treks: 1, touristicContents: 1, outdoorSites: 0, touristicEvents: 0 },
   results: [mockTrekResult, mockTrekResult],
 };
 
@@ -189,7 +190,8 @@ describe('concatResultsPages', () => {
         outdoorSitesCount: 0,
         touristicEventsCount: 0,
       },
-      nextPages: { treks: 2, touristicContents: 2, outdoorSites: 0, touristicEvents: 0 },
+      nextPages: { treks: 3, touristicContents: 3, outdoorSites: 0, touristicEvents: 0 },
+      previousPages: { treks: 1, touristicContents: 1, outdoorSites: 0, touristicEvents: 0 },
       results: [mockTrekResult, mockTrekResult, mockTrekResult, mockTrekResult],
     };
 
@@ -217,7 +219,8 @@ describe('formatInfiniteQuery', () => {
         outdoorSitesCount: 0,
         touristicEventsCount: 0,
       },
-      nextPages: { treks: 2, touristicContents: 2, outdoorSites: 0, touristicEvents: 0 },
+      nextPages: { treks: 3, touristicContents: 3, outdoorSites: 0, touristicEvents: 0 },
+      previousPages: { treks: 1, touristicContents: 1, outdoorSites: 0, touristicEvents: 0 },
       results: [mockTrekResult, mockTrekResult, mockTrekResult, mockTrekResult],
     };
 

--- a/frontend/src/components/pages/search/components/Pagination/Pagination.tsx
+++ b/frontend/src/components/pages/search/components/Pagination/Pagination.tsx
@@ -1,0 +1,59 @@
+import { Arrow } from 'components/Icons/Arrow';
+import { ArrowLeft } from 'components/Icons/ArrowLeft';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { FormattedMessage, useIntl } from 'react-intl';
+
+interface PaginationProps {
+  hasPreviousPage?: boolean;
+  hasNextPage?: boolean;
+}
+
+export const Pagination: React.FC<PaginationProps> = ({ hasPreviousPage, hasNextPage }) => {
+  const router = useRouter();
+  const intl = useIntl();
+  const page = Number(router.query.page ?? 1);
+
+  if (hasPreviousPage === false && hasNextPage === false) {
+    return null;
+  }
+
+  const queryForPreviousPage = { ...router.query, page: page - 1 };
+  if (queryForPreviousPage.page === 1) {
+    // @ts-ignore: Unreachable code error
+    delete queryForPreviousPage.page;
+  }
+
+  return (
+    <nav role="navigation" className="flex justify-center items-center gap-3">
+      {hasPreviousPage === true && (
+        <Link
+          className="flex items-center px-2 py-2 border border-solid border-greySoft hover:text-primary1 hover:border-primary1 rounded-md transition"
+          href={{
+            pathname: router.pathname,
+            query: queryForPreviousPage,
+          }}
+          shallow
+          title={intl.formatMessage({ id: 'search.pagination.goto' }, { count: page - 1 })}
+        >
+          <ArrowLeft size={20} className="mr-2" />
+          <FormattedMessage id="search.pagination.previous" />
+        </Link>
+      )}
+      {hasNextPage === true && (
+        <Link
+          className="flex items-center px-2 py-2 border border-solid border-greySoft hover:text-primary1 hover:border-primary1 rounded-md transition"
+          href={{
+            pathname: router.pathname,
+            query: { ...router.query, page: page + 1 },
+          }}
+          shallow
+          title={intl.formatMessage({ id: 'search.pagination.goto' }, { count: page + 1 })}
+        >
+          <FormattedMessage id="search.pagination.next" />
+          <Arrow size={20} className="ml-2" />
+        </Link>
+      )}
+    </nav>
+  );
+};

--- a/frontend/src/components/pages/search/components/Pagination/index.ts
+++ b/frontend/src/components/pages/search/components/Pagination/index.ts
@@ -1,0 +1,1 @@
+export { Pagination } from './Pagination';

--- a/frontend/src/components/pages/search/hooks/useTitle.ts
+++ b/frontend/src/components/pages/search/hooks/useTitle.ts
@@ -1,8 +1,10 @@
 import { FilterState } from 'modules/filters/interface';
+import { useRouter } from 'next/router';
 import { useIntl } from 'react-intl';
 
 export const useTitle = (filtersState: FilterState[], searchResults = 0) => {
   const intl = useIntl();
+  const { query } = useRouter();
   const filters = filtersState.flatMap(item => {
     if (item.selectedOptions.length > 0) {
       return {
@@ -15,19 +17,30 @@ export const useTitle = (filtersState: FilterState[], searchResults = 0) => {
 
   const categoryNumber = filters.length;
 
-  const category = categoryNumber ? intl.formatMessage({ id: filters[0].label }) : '';
+  const category = categoryNumber ? intl.formatMessage({ id: filters[0].label }) ?? '' : '';
   const options = categoryNumber
-    ? intl.formatList(filters[0].options, { type: 'conjunction' })
+    ? intl.formatList(filters[0].options, { type: 'conjunction' }) ?? ''
     : '';
 
   const getPageTitle = () => {
+    const localePage = intl.formatMessage(
+      { id: 'search.titlePagination' },
+      { count: Number(query.page ?? 1) },
+    );
+
     if (categoryNumber === 0) {
-      return intl.formatMessage({ id: 'search.title' });
+      return `${intl.formatMessage({ id: 'search.title' })}${localePage}`;
     }
     if (categoryNumber === 1) {
-      return intl.formatMessage({ id: 'search.titleWithOneCategory' }, { category, options });
+      return `${intl.formatMessage(
+        { id: 'search.titleWithOneCategory' },
+        { category, options: options as string },
+      )}${localePage}`;
     }
-    return intl.formatMessage({ id: 'search.resultsFound' }, { count: searchResults });
+    return `${intl.formatMessage(
+      { id: 'search.resultsFound' },
+      { count: searchResults },
+    )}${localePage}`;
   };
 
   const getResultsTitle = () => {
@@ -50,7 +63,7 @@ export const useTitle = (filtersState: FilterState[], searchResults = 0) => {
   };
 
   return {
-    pageTitle: getPageTitle() as string,
+    pageTitle: getPageTitle(),
     resultsTitle: getResultsTitle(),
   };
 };

--- a/frontend/src/components/pages/search/utils.ts
+++ b/frontend/src/components/pages/search/utils.ts
@@ -46,6 +46,7 @@ export const concatResultsPages = (resultsPages: SearchResults[]): SearchResults
   if (resultsPages.length === 0) return null;
 
   const resultsNumber = resultsPages[0].resultsNumber;
+  const previousPages = resultsPages[0].previousPages;
   const nextPages = resultsPages[0].nextPages;
   const results = resultsPages.reduce<
     (TrekResult | TouristicContentResult | OutdoorSiteResult | TouristicEventResult)[]
@@ -56,6 +57,7 @@ export const concatResultsPages = (resultsPages: SearchResults[]): SearchResults
     resultsNumberDetails: resultsPages[0].resultsNumberDetails,
     results,
     nextPages,
+    previousPages,
   };
 };
 

--- a/frontend/src/modules/results/__tests__/utils.test.ts
+++ b/frontend/src/modules/results/__tests__/utils.test.ts
@@ -103,7 +103,7 @@ describe('extractNextPageId', () => {
   });
 
   it('should throw an error if it cant find the next page id', () => {
-    expect(() => extractNextPageId('toto')).toThrow();
+    expect(() => extractNextPageId('')).toThrow();
   });
 
   describe('formatTextFilter', () => {

--- a/frontend/src/modules/results/connector.ts
+++ b/frontend/src/modules/results/connector.ts
@@ -292,6 +292,11 @@ export const getSearchResults = async (
     const nextOutdoorSitesPage = extractNextPageId(rawOutdoorSites.next);
     const nextTouristicEventsPage = extractNextPageId(rawTouristicEvents.next);
 
+    const previousTreksPage = extractNextPageId(rawTrekResults.previous);
+    const previousTouristicContentsPage = extractNextPageId(rawTouristicContents.previous);
+    const previousOutdoorSitesPage = extractNextPageId(rawOutdoorSites.previous);
+    const previousTouristicEventsPage = extractNextPageId(rawTouristicEvents.previous);
+
     return {
       resultsNumber: treksCount + touristicContentsCount + outdoorSitesCount + touristicEventsCount,
       resultsNumberDetails: {
@@ -305,6 +310,12 @@ export const getSearchResults = async (
         touristicContents: nextTouristicContentsPage,
         outdoorSites: nextOutdoorSitesPage,
         touristicEvents: nextTouristicEventsPage,
+      },
+      previousPages: {
+        treks: previousTreksPage,
+        touristicContents: previousTouristicContentsPage,
+        outdoorSites: previousOutdoorSitesPage,
+        touristicEvents: previousTouristicEventsPage,
       },
       results: [
         ...adaptedResultsList,

--- a/frontend/src/modules/results/interface.ts
+++ b/frontend/src/modules/results/interface.ts
@@ -51,6 +51,12 @@ export interface SearchResults {
     outdoorSites: number | null;
     touristicEvents: number | null;
   };
+  previousPages: {
+    treks: number | null;
+    touristicContents: number | null;
+    outdoorSites: number | null;
+    touristicEvents: number | null;
+  };
   results: (TrekResult | TouristicContentResult | OutdoorSiteResult | TouristicEventResult)[];
 }
 export interface TrekResult extends ResultCard {

--- a/frontend/src/modules/results/utils.ts
+++ b/frontend/src/modules/results/utils.ts
@@ -277,5 +277,9 @@ export const extractNextPageId = (nextPageUrl: string | null): number | null => 
   const matches = regex.exec(nextPageUrl);
   if (matches !== null) return parseInt(matches[0].replace('page=', ''), 10);
 
+  if (nextPageUrl.length > 0) {
+    return 1;
+  }
+
   throw Error('results adapter could not parse nextPageUrl to extract nextPageId');
 };

--- a/frontend/src/modules/touristicContent/api.ts
+++ b/frontend/src/modules/touristicContent/api.ts
@@ -40,7 +40,7 @@ const fieldsParamsResult = {
 export const fetchTouristicContentResult = (
   query: APIQuery,
 ): Promise<APIResponseForList<RawTouristicContentResult>> =>
-  GeotrekAPI.get(`/touristiccontent`, {
+  GeotrekAPI.get(`/touristiccontent/`, {
     params: { ...query, ...fieldsParamsResult, ...portalsFilter },
   }).then(r => r.data);
 

--- a/frontend/src/pages/search.tsx
+++ b/frontend/src/pages/search.tsx
@@ -17,6 +17,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
   const { initialFiltersStateWithSelectedOptions } = await getInitialFilters(locale, context.query);
   const parsedInitialFiltersState = parseFilters(initialFiltersStateWithSelectedOptions);
   const initialTextFilter = context.query.text?.toString() ?? null;
+  const page = Number(context.query.page ?? 1);
 
   try {
     await queryClient.prefetchQuery(['initialFilterState', locale], () =>
@@ -37,6 +38,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
         initialTextFilter,
         bboxFilter,
         dateFilter,
+        page,
       ],
       () =>
         getSearchResults(
@@ -47,10 +49,10 @@ export const getServerSideProps: GetServerSideProps = async context => {
             dateFilter: null,
           },
           {
-            treks: 1,
-            touristicContents: 1,
-            outdoorSites: getGlobalConfig().enableOutdoor ? 1 : null,
-            touristicEvents: getGlobalConfig().enableTouristicEvents ? 1 : null,
+            treks: page,
+            touristicContents: page,
+            outdoorSites: getGlobalConfig().enableOutdoor ? page : null,
+            touristicEvents: getGlobalConfig().enableTouristicEvents ? page : null,
           },
           locale,
         ),

--- a/frontend/src/services/api/cache.ts
+++ b/frontend/src/services/api/cache.ts
@@ -56,9 +56,10 @@ export const requestInterceptor = (config: any) => {
 
 export const responseInterceptor = (response: any) => {
   if (
+    response?.config !== undefined &&
     // eslint-disable-next-line
-    !response?.config._fromCache &&
-    response?.config.method === 'get' &&
+    !response.config._fromCache &&
+    response.config.method === 'get' &&
     cachedRoute.some(r => r.test(response.config.url))
   ) {
     // eslint-disable-next-line

--- a/frontend/src/services/api/client.ts
+++ b/frontend/src/services/api/client.ts
@@ -11,6 +11,16 @@ const instance = axios.create({
 instance.interceptors.response.use(
   response => response,
   error => {
+    const { page } = error.config?.params || {};
+    if (page !== undefined) {
+      return Promise.resolve({
+        data: {
+          results: [],
+          next: null,
+          previous: page === 1 ? null : `page=${Number(page) - 1}`,
+        },
+      });
+    }
     if (error) {
       captureException(error);
     }

--- a/frontend/src/translations/ca.json
+++ b/frontend/src/translations/ca.json
@@ -29,6 +29,7 @@
     "title": "Cerca",
     "titleWithOneCategory": "{category}: {options}",
     "description": "Descobreix les excursions que coincideixen amb els teus desitjos amb el nostre motor de cerca",
+    "titlePagination": "{count, plural, =0 {} one {} other { - Pàgina #}}",
     "book": "Reserva",
     "resultsFound": "{count, plural, =0 {# resultat trobat} one {# resultat trobat} other {# resultats trobats}}",
     "resultsFoundShort": "{count, plural, =0 {# resultat} one {# resultat} other {# resultats}}",

--- a/frontend/src/translations/ca.json
+++ b/frontend/src/translations/ca.json
@@ -94,6 +94,11 @@
         "service": "Others infos"
       },
       "resetView": "Recenter el mapa"
+    },
+    "pagination": {
+      "previous": "Pàgina anterior",
+      "next": "Pàgina següent",
+      "goto": "Vés a la pàgina {count}"
     }
   },
   "details": {

--- a/frontend/src/translations/de.json
+++ b/frontend/src/translations/de.json
@@ -94,6 +94,11 @@
         "service": "Others infos"
       },
       "resetView": "Karte zentrieren"
+    },
+    "pagination": {
+      "previous": "Vorherige Seite",
+      "next": "Nächste Seite",
+      "goto": "Gehen Sie zu Seite {count}"
     }
   },
   "details": {

--- a/frontend/src/translations/de.json
+++ b/frontend/src/translations/de.json
@@ -28,6 +28,7 @@
   "search": {
     "title": "Suche",
     "titleWithOneCategory": "{category}: {options}",
+    "titlePagination": "{count, plural, =0 {} one {} other { - Seite #}}",
     "description": "Entdecken Sie mit unserer Suchmaschine Wanderungen, die Ihren Wünschen entsprechen",
     "book": "Reservieren",
     "resultsFound": "{count, plural, =0 {# Ergebnis gefunden} one {# Ergebnis gefunden} other {# gefundene Ergebnisse}}",

--- a/frontend/src/translations/en.json
+++ b/frontend/src/translations/en.json
@@ -96,6 +96,11 @@
         "service": "Others infos"
       },
       "resetView": "Recenter map"
+    },
+    "pagination": {
+      "previous": "Previous page",
+      "next": "Next page",
+      "goto": "Go to the page {count}"
     }
   },
   "details": {

--- a/frontend/src/translations/en.json
+++ b/frontend/src/translations/en.json
@@ -25,11 +25,13 @@
   "loading": "Loading",
   "page": {
     "back": "Back",
-    "not-found": "This page was not found"
+    "not-found": "This page was not found",
+    "goToOffline": "Display offline content"
   },
   "search": {
     "title": "Search",
     "titleWithOneCategory": "{category}: {options}",
+    "titlePagination": "{count, plural, =0 {} one {} other { - Page #}}",
     "description": "Discover the hikes corresponding to your desires with our search engine",
     "book": "Book",
     "resultsFound": "{count, plural, =0 {# result found} one {# result found} other {# results found}}",

--- a/frontend/src/translations/es.json
+++ b/frontend/src/translations/es.json
@@ -28,6 +28,7 @@
   "search": {
     "title": "Busca",
     "titleWithOneCategory": "{category}: {options}",
+    "titlePagination": "{count, plural, =0 {} one {} other { - Página #}}",
     "description": "Descubre las excursiones que coinciden con tus deseos en nuestro motor de búsqueda",
     "book": "Reserva",
     "resultsFound": "{count, plural, =0 {# resultado encontrado} one {# resultado encontrado} other {# resultados encontrados}}",

--- a/frontend/src/translations/es.json
+++ b/frontend/src/translations/es.json
@@ -94,6 +94,11 @@
         "service": "Others infos"
       },
       "resetView": "Centrarse la mapa"
+    },
+    "pagination": {
+      "previous": "Página anterior",
+      "next": "Página anterior",
+      "goto": "Ir a la página {count}"
     }
   },
   "details": {

--- a/frontend/src/translations/fr.json
+++ b/frontend/src/translations/fr.json
@@ -97,6 +97,11 @@
         "service": "Autres infos"
       },
       "resetView": "Recentrer la carte"
+    },
+    "pagination": {
+      "previous": "Page précédente",
+      "next": "Page suivante",
+      "goto": "Aller à la page {count}"
     }
   },
   "details": {

--- a/frontend/src/translations/fr.json
+++ b/frontend/src/translations/fr.json
@@ -31,6 +31,7 @@
   "search": {
     "title": "Recherche",
     "titleWithOneCategory": "{category} : {options}",
+    "titlePagination": "{count, plural, =0 {} one {} other { - Page #}}",
     "description": "Découvrez les randonnées correspondant à vos envies avec notre moteur de recherche",
     "book": "Réserver",
     "resultsFound": "{count, plural, =0 {# résultat trouvé} one {# résultat trouvé} other {# résultats trouvés}}",

--- a/frontend/src/translations/it.json
+++ b/frontend/src/translations/it.json
@@ -25,11 +25,13 @@
   "loading": "Caricamento",
   "page": {
     "back": "Ritorno",
-    "not-found": "Questa pagina non è stata trovata"
+    "not-found": "Questa pagina non è stata trovata",
+    "goToOffline": "Visualizzazione di contenuti offline"
   },
   "search": {
     "title": "Ricerca",
     "titleWithOneCategory": "{category}: {options}",
+    "titlePagination": "{count, plural, =0 {} one {} other { - Pagina #}}",
     "description": "Scopri le escursioni che desideri sul nostro sito internet",
     "book": "Prenotare",
     "resultsFound": "{count, plural, =0 {# Nessun risultato trovato} one {# risultato trovato} other {# risultati trovati}}",

--- a/frontend/src/translations/it.json
+++ b/frontend/src/translations/it.json
@@ -96,6 +96,11 @@
         "service": "Others infos"
       },
       "resetView": "Rimettere a fuoco la mappa"
+    },
+    "pagination": {
+      "previous": "Pagina precedente",
+      "next": "Pagina successiva",
+      "goto": "Vai a pagina {count}"
     }
   },
   "details": {


### PR DESCRIPTION
## Check before merging

- [x] Complete Ticket : [#833](https://github.com/GeotrekCE/Geotrek-rando-v3/issues/833)

A pagination is set up to allow the search engine to parse the content of the search page.

Infinite scrolling is still used to discover the content (visually nothing changes). 
To see the pagination function, it is necessary to disable the browser's JavaScript. For each page, there is a `?page=xx` parameter in the url and the page number defined in the title page.

