### PR TITLE
Avoid unnecessary fetch for obtaining dictionaries

### DIFF
--- a/frontend/src/modules/city/connector.ts
+++ b/frontend/src/modules/city/connector.ts
@@ -15,14 +15,16 @@ export const getCities = async (language: string): Promise<CityDictionnary> => {
     return adaptCitiesSinglePage(cities.results);
   }
   // Second call with loop to load all the necessary pages to reach the count
-  const citiesAllPages = await Promise.all(
-    generatePageNumbersArray(resultsNumber, cities.count).map(pageNumber =>
-      fetchCities({
-        language,
-        page_size: resultsNumber,
-        page: pageNumber,
-      }),
-    ),
+  const citiesOtherPages = await Promise.all(
+    generatePageNumbersArray(resultsNumber, cities.count)
+      .slice(1)
+      .map(pageNumber =>
+        fetchCities({
+          language,
+          page_size: resultsNumber,
+          page: pageNumber,
+        }),
+      ),
   );
-  return adaptCities(citiesAllPages);
+  return adaptCities([cities, ...citiesOtherPages]);
 };

--- a/frontend/src/modules/filters/city/connector.ts
+++ b/frontend/src/modules/filters/city/connector.ts
@@ -16,17 +16,19 @@ export const getCityFilter = async (language: string): Promise<FilterWithoutType
     return adaptCityFilter(cities.results);
   }
   // Second call with loop to load all the necessary pages to reach the count
-  const citiesAllPages = await Promise.all(
-    generatePageNumbersArray(resultsNumber, cities.count).map(pageNumber =>
-      fetchCities({
-        language,
-        page_size: resultsNumber,
-        page: pageNumber,
-      }),
-    ),
+  const citiesOtherPages = await Promise.all(
+    generatePageNumbersArray(resultsNumber, cities.count)
+      .slice(1)
+      .map(pageNumber =>
+        fetchCities({
+          language,
+          page_size: resultsNumber,
+          page: pageNumber,
+        }),
+      ),
   );
   const initialCities: RawCity[] = [];
-  const aggregatedCities = citiesAllPages.reduce(
+  const aggregatedCities = [cities, ...citiesOtherPages].reduce(
     (currentlyAggregatedCities, currentCities) => [
       ...currentlyAggregatedCities,
       ...currentCities.results,

--- a/frontend/src/modules/informationDesk/connector.ts
+++ b/frontend/src/modules/informationDesk/connector.ts
@@ -21,17 +21,19 @@ export const getInformationDesks = async (
     }
 
     // Second call with loop to load all the necessary pages to reach the count
-    const rawInformationDesksAllPages = await Promise.all(
-      generatePageNumbersArray(defaultPageSize, rawInformationDesks.count).map(pageNumber =>
-        fetchInformationDesks({
-          language,
-          page_size: defaultPageSize,
-          page: pageNumber,
-        }),
-      ),
+    const rawInformationDesksOtherPages = await Promise.all(
+      generatePageNumbersArray(defaultPageSize, rawInformationDesks.count)
+        .slice(1)
+        .map(pageNumber =>
+          fetchInformationDesks({
+            language,
+            page_size: defaultPageSize,
+            page: pageNumber,
+          }),
+        ),
     );
 
-    return adaptInformationDeskList(rawInformationDesksAllPages);
+    return adaptInformationDeskList([rawInformationDesks, ...rawInformationDesksOtherPages]);
   } catch (e) {
     console.error('Error in informationDesk/connector', e);
     throw e;

--- a/frontend/src/modules/mapResults/connector.ts
+++ b/frontend/src/modules/mapResults/connector.ts
@@ -95,7 +95,9 @@ export const getMapResults = async (
         ),
       );
       const activities = await getActivities(language);
-      mapResults.push(...adaptTrekMapResults({ mapResults: mapTrekResults, activities }));
+      mapResults.push(
+        ...adaptTrekMapResults({ mapResults: [rawMapResults, ...mapTrekResults], activities }),
+      );
     }
 
     if (shouldFetchTouristicContents) {
@@ -119,7 +121,7 @@ export const getMapResults = async (
       const touristicContentCategories = await getTouristicContentCategories(language);
       mapResults.push(
         ...adaptTouristicContentMapResults({
-          mapResults: mapTouristicContentResults,
+          mapResults: [rawMapResults, ...mapTouristicContentResults],
           touristicContentCategories,
         }),
       );
@@ -146,7 +148,7 @@ export const getMapResults = async (
       const outdoorPracticeDictionnary = await getOutdoorPractices(language);
       mapResults.push(
         ...adaptOutdoorSitesMapResults({
-          mapResults: mapOutdoorSiteResults,
+          mapResults: [rawMapResults, ...mapOutdoorSiteResults],
           outdoorPracticeDictionnary,
         }),
       );
@@ -179,7 +181,7 @@ export const getMapResults = async (
 
       mapResults.push(
         ...adaptTouristicEventsMapResults({
-          mapResults: mapTouristicEventsResults,
+          mapResults: [rawMapResults, ...mapTouristicEventsResults],
           touristicEventTypes,
         }),
       );


### PR DESCRIPTION
The contents are linked to dictionaries such as cities, different types of categories, etc.  
The application needs to get all elements at once whatever the count of items.

To do this, it fetches the first page of the list and retrieves the total count of items with the result.

If there are no others pages, it returns this result.
If not, it parallelizes the fetch of all pages to return the new result.

This PR concerns the "if not" part and avoids to re-fetch the first page, and concatenate its result with the news ones.
