### PR TITLE
Encode id params send to the API

### DIFF
--- a/frontend/src/components/pages/search/utils.ts
+++ b/frontend/src/components/pages/search/utils.ts
@@ -79,7 +79,7 @@ export const generateResultDetailsUrl = (
   parentId?: number,
 ): string => {
   const titleWithNoSpace = convertStringForSitemap(title);
-  const detailsPageUrl = `${route}/${id}-${encodeURI(titleWithNoSpace)}${
+  const detailsPageUrl = `${route}/${encodeURIComponent(id)}-${encodeURI(titleWithNoSpace)}${
     parentId ? `?parentId=${parentId}` : ''
   }`;
 

--- a/frontend/src/modules/accessibility/api.ts
+++ b/frontend/src/modules/accessibility/api.ts
@@ -11,4 +11,4 @@ export const fetchAccessibilities = (
   );
 
 export const fetchAccessibilityLevel = (id: number): Promise<AccessibilityLevel> =>
-  GeotrekAPI.get(`/trek_accessibility_level/${id}/`).then(r => r.data);
+  GeotrekAPI.get(`/trek_accessibility_level/${encodeURIComponent(id)}/`).then(r => r.data);

--- a/frontend/src/modules/activities/api.ts
+++ b/frontend/src/modules/activities/api.ts
@@ -4,7 +4,9 @@ import { APIQuery, APIResponseForList } from 'services/api/interface';
 import { RawListActivity } from './interface';
 
 export const fetchActivity = (query: APIQuery, id: number): Promise<RawListActivity> => {
-  return GeotrekAPI.get(`/trek_practice/${id}/`, { params: query }).then(r => r.data);
+  return GeotrekAPI.get(`/trek_practice/${encodeURIComponent(id)}/`, { params: query }).then(
+    r => r.data,
+  );
 };
 
 export const fetchActivities = (

--- a/frontend/src/modules/details/api.ts
+++ b/frontend/src/modules/details/api.ts
@@ -11,7 +11,7 @@ const fieldsParams = {
 
 export const fetchDetails = (query: APIQuery, id: string): Promise<RawDetails> => {
   try {
-    return GeotrekAPI.get(`/trek/${id}/`, {
+    return GeotrekAPI.get(`/trek/${encodeURIComponent(id)}/`, {
       params: { ...query, ...fieldsParams, ...portalsFilter },
     }).then(r => r.data);
   } catch (e) {
@@ -21,17 +21,19 @@ export const fetchDetails = (query: APIQuery, id: string): Promise<RawDetails> =
 };
 
 export const fetchTrekChildren = (query: APIQuery, id: string): Promise<RawTrekChildIds> => {
-  return GeotrekAPI.get(`/trek/${id}/`, { params: { ...query, fields: 'children' } }).then(
-    r => r.data,
-  );
+  return GeotrekAPI.get(`/trek/${encodeURIComponent(id)}/`, {
+    params: { ...query, fields: 'children' },
+  }).then(r => r.data);
 };
 
 export const fetchTrekName = (query: APIQuery, id: string): Promise<RawTrekName> => {
-  return GeotrekAPI.get(`/trek/${id}/`, { params: { ...query, fields: 'name' } }).then(r => r.data);
+  return GeotrekAPI.get(`/trek/${encodeURIComponent(id)}/`, {
+    params: { ...query, fields: 'name' },
+  }).then(r => r.data);
 };
 
 export const fetchTrekGeometry = (query: APIQuery, id: string): Promise<RawTrekChildGeometry> => {
-  return GeotrekAPI.get(`/trek/${id}/`, { params: { ...query, format: 'geojson' } }).then(
-    r => r.data,
-  );
+  return GeotrekAPI.get(`/trek/${encodeURIComponent(id)}/`, {
+    params: { ...query, format: 'geojson' },
+  }).then(r => r.data);
 };

--- a/frontend/src/modules/filters/courseType/api.ts
+++ b/frontend/src/modules/filters/courseType/api.ts
@@ -7,4 +7,4 @@ export const fetchCourseTypes = (query: APIQuery): Promise<APIResponseForList<Ra
   GeotrekAPI.get('/trek_route/', { params: { ...query, ...portalsFilter } }).then(r => r.data);
 
 export const fetchCourseType = (query: APIQuery, id: number): Promise<RawCourseType> =>
-  GeotrekAPI.get(`/trek_route/${id}/`, { params: query }).then(r => r.data);
+  GeotrekAPI.get(`/trek_route/${encodeURIComponent(id)}/`, { params: query }).then(r => r.data);

--- a/frontend/src/modules/filters/difficulties/api.ts
+++ b/frontend/src/modules/filters/difficulties/api.ts
@@ -9,4 +9,6 @@ export const fetchDifficulties = (
   GeotrekAPI.get('/trek_difficulty/', { params: { ...query, ...portalsFilter } }).then(r => r.data);
 
 export const fetchDifficulty = (query: APIQuery, id: number): Promise<RawDifficulty> =>
-  GeotrekAPI.get(`/trek_difficulty/${id}/`, { params: query }).then(r => r.data);
+  GeotrekAPI.get(`/trek_difficulty/${encodeURIComponent(id)}/`, { params: query }).then(
+    r => r.data,
+  );

--- a/frontend/src/modules/filters/theme/api.ts
+++ b/frontend/src/modules/filters/theme/api.ts
@@ -7,4 +7,4 @@ export const fetchThemes = (query: APIQuery): Promise<APIResponseForList<Partial
   GeotrekAPI.get('/theme/', { params: { ...query, ...portalsFilter } }).then(r => r.data);
 
 export const fetchTheme = (query: APIQuery, id: number): Promise<RawTheme> =>
-  GeotrekAPI.get(`/theme/${id}/`, { params: query }).then(r => r.data);
+  GeotrekAPI.get(`/theme/${encodeURIComponent(id)}/`, { params: query }).then(r => r.data);

--- a/frontend/src/modules/flatpage/api.ts
+++ b/frontend/src/modules/flatpage/api.ts
@@ -17,6 +17,6 @@ const fieldsParamFlatPageDetails = {
 };
 
 export const fetchFlatPageDetails = (query: APIQuery, id: string): Promise<RawFlatPageDetails> =>
-  GeotrekAPI.get(`/flatpage/${id}/`, { params: { ...query, ...fieldsParamFlatPageDetails } }).then(
-    r => r.data,
-  );
+  GeotrekAPI.get(`/flatpage/${encodeURIComponent(id)}/`, {
+    params: { ...query, ...fieldsParamFlatPageDetails },
+  }).then(r => r.data);

--- a/frontend/src/modules/outdoorCourse/api.ts
+++ b/frontend/src/modules/outdoorCourse/api.ts
@@ -23,6 +23,6 @@ export const fetchOutdoorCourseDetails = (
   query: APIQuery,
   id: string,
 ): Promise<RawOutdoorCourseDetails> =>
-  GeotrekAPI.get(`/outdoor_course/${id}/`, { params: { ...query, ...fieldsParamsDetails } }).then(
-    r => r.data,
-  );
+  GeotrekAPI.get(`/outdoor_course/${encodeURIComponent(id)}/`, {
+    params: { ...query, ...fieldsParamsDetails },
+  }).then(r => r.data);

--- a/frontend/src/modules/outdoorSite/api.ts
+++ b/frontend/src/modules/outdoorSite/api.ts
@@ -23,7 +23,7 @@ export const fetchOutdoorSiteDetails = (
   query: APIQuery,
   id: string,
 ): Promise<RawOutdoorSiteDetails> => {
-  return GeotrekAPI.get(`/outdoor_site/${id}/`, {
+  return GeotrekAPI.get(`/outdoor_site/${encodeURIComponent(id)}/`, {
     params: { ...fieldsParamsDetails, ...query, ...portalsFilter },
   }).then(r => r.data);
 };
@@ -32,6 +32,6 @@ export const fetchOutdoorSiteResult = (
   query: APIQuery,
   id: string,
 ): Promise<{ geometry: RawGeometryObject }> =>
-  GeotrekAPI.get(`/outdoor_site/${id}/`, { params: { ...query, fields: 'geometry' } }).then(
-    r => r.data,
-  );
+  GeotrekAPI.get(`/outdoor_site/${encodeURIComponent(id)}/`, {
+    params: { ...query, fields: 'geometry' },
+  }).then(r => r.data);

--- a/frontend/src/modules/results/api.ts
+++ b/frontend/src/modules/results/api.ts
@@ -16,7 +16,9 @@ export const fetchTrekResults = (
   );
 
 export const fetchTrekResult = (query: APIQuery, id: number | string): Promise<RawTrekResult> =>
-  GeotrekAPI.get(`/trek/${id}/`, { params: { ...query, ...fieldsParams } }).then(r => r.data);
+  GeotrekAPI.get(`/trek/${encodeURIComponent(id)}/`, {
+    params: { ...query, ...fieldsParams },
+  }).then(r => r.data);
 
 export const fetchTrekResultsNumber = (
   query: APIQuery,

--- a/frontend/src/modules/touristicContent/api.ts
+++ b/frontend/src/modules/touristicContent/api.ts
@@ -29,7 +29,7 @@ export const fetchTouristicContentDetails = (
   query: APIQuery,
   id: string,
 ): Promise<RawTouristicContentDetails> =>
-  GeotrekAPI.get(`/touristiccontent/${id}/`, {
+  GeotrekAPI.get(`/touristiccontent/${encodeURIComponent(id)}/`, {
     params: { ...fieldsParamsDetails, ...query, ...portalsFilter },
   }).then(r => r.data);
 
@@ -52,7 +52,7 @@ export const fetchTouristicContentPopupResult = (
   query: APIQuery,
   id: string,
 ): Promise<RawTouristicContentPopupResult> =>
-  GeotrekAPI.get(`/touristiccontent/${id}/`, {
+  GeotrekAPI.get(`/touristiccontent/${encodeURIComponent(id)}/`, {
     params: { ...query, ...fieldsParamsPopupResult },
   }).then(r => r.data);
 
@@ -60,6 +60,6 @@ export const fetchTouristicContentGeometryResult = (
   query: APIQuery,
   id: string,
 ): Promise<{ geometry: RawGeometryObject }> =>
-  GeotrekAPI.get(`/touristiccontent/${id}/`, { params: { ...query, fields: 'geometry' } }).then(
-    r => r.data,
-  );
+  GeotrekAPI.get(`/touristiccontent/${encodeURIComponent(id)}/`, {
+    params: { ...query, fields: 'geometry' },
+  }).then(r => r.data);

--- a/frontend/src/modules/touristicContentCategory/api.ts
+++ b/frontend/src/modules/touristicContentCategory/api.ts
@@ -14,4 +14,6 @@ export const fetchTouristicContentCategory = (
   query: APIQuery,
   id: number,
 ): Promise<RawTouristicContentCategory> =>
-  GeotrekAPI.get(`/touristiccontent_category/${id}/`, { params: query }).then(r => r.data);
+  GeotrekAPI.get(`/touristiccontent_category/${encodeURIComponent(id)}/`, { params: query }).then(
+    r => r.data,
+  );

--- a/frontend/src/modules/touristicEvent/api.ts
+++ b/frontend/src/modules/touristicEvent/api.ts
@@ -29,7 +29,7 @@ export const fetchTouristicEventDetails = (
   query: APIQuery,
   id: string,
 ): Promise<RawTouristicEventDetails> =>
-  GeotrekAPI.get(`/touristicevent/${id}/`, {
+  GeotrekAPI.get(`/touristicevent/${encodeURIComponent(id)}/`, {
     params: { ...query, ...fieldsParamsDetails, ...portalsFilter },
   }).then(r => r.data);
 
@@ -37,6 +37,6 @@ export const fetchTouristicEventResult = (
   query: APIQuery,
   id: string,
 ): Promise<{ geometry: RawGeometryObject }> =>
-  GeotrekAPI.get(`/touristicevent/${id}/`, { params: { ...query, fields: 'geometry' } }).then(
-    r => r.data,
-  );
+  GeotrekAPI.get(`/touristicevent/${encodeURIComponent(id)}/`, {
+    params: { ...query, fields: 'geometry' },
+  }).then(r => r.data);

--- a/frontend/src/modules/trekResult/api.ts
+++ b/frontend/src/modules/trekResult/api.ts
@@ -8,10 +8,14 @@ const fieldsParams = {
 };
 
 export const fetchTrekPopupResult = (query: APIQuery, id: string): Promise<RawTrekPopupResult> =>
-  GeotrekAPI.get(`/trek/${id}/`, { params: { ...query, ...fieldsParams } }).then(r => r.data);
+  GeotrekAPI.get(`/trek/${encodeURIComponent(id)}/`, {
+    params: { ...query, ...fieldsParams },
+  }).then(r => r.data);
 
 export const fetchTrekGeometryResult = (
   query: APIQuery,
   id: string,
 ): Promise<{ geometry: RawGeometryObject }> =>
-  GeotrekAPI.get(`/trek/${id}/`, { params: { ...query, fields: 'geometry' } }).then(r => r.data);
+  GeotrekAPI.get(`/trek/${encodeURIComponent(id)}/`, {
+    params: { ...query, fields: 'geometry' },
+  }).then(r => r.data);


### PR DESCRIPTION
To fetch API endpoints, some parameters come from the current URL.
For example:
`https://mygeotrekrando.com/trek/1-name-of-my-rando` retrieves the `trek` keyword and the `1` id from the url to fetch `https://mygeotrekadmin.com/api/v2/trek/1` and begin to build the page to render to the user.

If a user **writes** by himself a false URL like `https://mygeotrekrando.com/trek/name-of-my-rando`, the `id` is missing and returns a 404 page to the user.

But, in this case, we cannot be sure that the URL is correct with respect to the application and we have to encode the URL.
Without the encoding, the app could crash if the URL contains special characters.

