### PR TITLE
Set config to display or not objects related to itinerant treks

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -39,7 +39,7 @@ In json files, you can just override the primary keys you need. You have to over
   - `maxLengthTrekAllowedFor3DRando`: Maximum length of meters allowed to enable 3D mode in the current trek. Adjust this setting carefully as too long a trek could freeze your browser. If this setting is defined to `0` (or `mapSatelliteLayers` from `map.json` is defined to `null`) the 3D mode feature is disabled for the whole application
   - `minAltitudeDifferenceToDisplayElevationProfile`: Minimum altitude difference in meters required to display the elevation profile in the current trek
   - `accessibilityCodeNumber`: emergency number. Default set to `114`.
-  - `displayObjectsRelatedToItinerantTreks`: An object containing many booleans to displaygin/hiding objects related to itinerant treks. The keys are `POIs`,`touristicContents`,`sensitiveAreas`,`infrastructures`,`signages`,`service` and are all set to `true` by default.
+  - `displayObjectsRelatedToItinerantTreks`: An object containing many booleans to display/hide objects related to itinerant treks. The keys are `POIs`,`touristicContents`,`sensitiveAreas`,`infrastructures`,`signages`,`service` and are all set to `true` by default. Indeed multi-days treks can be long and have a lot a related objects which is very long to display and not really readable. That's why you can disable some related objects that will not be displayed on itinerant main detail page, but will be displayed on steps detail pages and any other treks detail pages.
 
 - `header.json` to define logo URL, default and available languages, number items to flatpages to display in navbar (see default values in https://github.com/GeotrekCE/Geotrek-rando-v3/blob/main/frontend/config/header.json)
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -39,6 +39,7 @@ In json files, you can just override the primary keys you need. You have to over
   - `maxLengthTrekAllowedFor3DRando`: Maximum length of meters allowed to enable 3D mode in the current trek. Adjust this setting carefully as too long a trek could freeze your browser. If this setting is defined to `0` (or `mapSatelliteLayers` from `map.json` is defined to `null`) the 3D mode feature is disabled for the whole application
   - `minAltitudeDifferenceToDisplayElevationProfile`: Minimum altitude difference in meters required to display the elevation profile in the current trek
   - `accessibilityCodeNumber`: emergency number. Default set to `114`.
+  - `displayObjectsRelatedToItinerantTreks`: An object containing many booleans to displaygin/hiding objects related to itinerant treks. The keys are `POIs`,`touristicContents`,`sensitiveAreas`,`infrastructures`,`signages`,`service` and are all set to `true` by default.
 
 - `header.json` to define logo URL, default and available languages, number items to flatpages to display in navbar (see default values in https://github.com/GeotrekCE/Geotrek-rando-v3/blob/main/frontend/config/header.json)
 

--- a/frontend/config/global.json
+++ b/frontend/config/global.json
@@ -25,5 +25,13 @@
   "minAltitudeDifferenceToDisplayElevationProfile": 0,
   "accessibilityCodeNumber": "114",
   "groupTreksAndOutdoorFilters": false,
-  "hCaptchaKey": null
+  "hCaptchaKey": null,
+  "displayObjectsRelatedToItinerantTreks": {
+    "POIs": true,
+    "touristicContents": true,
+    "sensitiveAreas": true,
+    "infrastructures": true,
+    "signages": true,
+    "services": true
+  }
 }

--- a/frontend/src/modules/details/utils.ts
+++ b/frontend/src/modules/details/utils.ts
@@ -1,0 +1,38 @@
+import getNextConfig from 'next/config';
+
+const {
+  publicRuntimeConfig: {
+    global: {
+      displayObjectsRelatedToItinerantTreks: {
+        POIs = true,
+        touristicContents = true,
+        sensitiveAreas = true,
+        infrastructures = true,
+        signages = true,
+        services = true,
+      } = {},
+    },
+  },
+} = getNextConfig();
+
+export const getObjectsRelatedToItinerantTreksToDisplay = (childrenIds: number[]) => {
+  // The limitation concerns Itinerant treks
+  if (childrenIds === null || childrenIds === undefined || childrenIds.length === 0) {
+    return {
+      displayRelatedPOIs: true,
+      displayRelatedTouristicContents: true,
+      displayRelatedSensitiveAreas: true,
+      displayRelatedInfrastructures: true,
+      displayRelatedSignages: true,
+      displayRelatedServices: true,
+    };
+  }
+  return {
+    displayRelatedPOIs: POIs,
+    displayRelatedTouristicContents: touristicContents,
+    displayRelatedSensitiveAreas: sensitiveAreas,
+    displayRelatedInfrastructures: infrastructures,
+    displayRelatedSignages: signages,
+    displayRelatedServices: services,
+  };
+};


### PR DESCRIPTION
- [x] Ticket: [Ne pas afficher les objets liés (Patrimoines, contenus touristiques...) sur les itinérances #847](https://github.com/GeotrekCE/Geotrek-rando-v3/issues/847)
