### PR TITLE
Use near_trek instead of trek filter for POIs and sensitiveAreas

### DIFF
--- a/frontend/src/modules/poi/connector.ts
+++ b/frontend/src/modules/poi/connector.ts
@@ -4,7 +4,7 @@ import { adaptPoi } from './adapter';
 import { fetchPois } from './api';
 import { Poi } from './interface';
 
-export const getPois = async (id: number, language: string, key = 'trek'): Promise<Poi[]> => {
+export const getPois = async (id: number, language: string, key = 'near_trek'): Promise<Poi[]> => {
   const pageSize = getGlobalConfig().maxPoiPerPage;
   const [rawPois, poiTypes] = await Promise.all([
     fetchPois({ language, [key]: id, page_size: pageSize }),

--- a/frontend/src/modules/poi/interface.ts
+++ b/frontend/src/modules/poi/interface.ts
@@ -6,7 +6,6 @@ export interface RawPoi {
   name: string;
   description: string;
   type: number;
-  trek: number;
   attachments: RawAttachment[];
   geometry: RawPointGeometry3D;
 }

--- a/frontend/src/modules/poi/mocks/index.ts
+++ b/frontend/src/modules/poi/mocks/index.ts
@@ -14,7 +14,6 @@ export const mockPois = (): PoisResponse => ({
   previous: null,
   results: [
     {
-      trek: 3,
       description:
         "<span>Pour esp&eacute;rer apercevoir cet oiseau, partir la nuit au printemps, parcourir un grand d&eacute;nivel&eacute; afin d'arriver sur son terrain de pr&eacute;dilection &agrave; plus de 2000 m voire 3000 m d'altitude avant le lever du jour et l&agrave;, entendre le chant guttural&nbsp;caract&eacute;ristique qui trahit sa pr&eacute;sence. Mais pour le voir, il faudra bien ouvrir les yeux ou se munir d'une paire de jumelles. Et alors l&agrave;, quel bonheur&nbsp;! Le lagop&egrave;de alpin est l'esp&egrave;ce arctique par excellence, menac&eacute;e entre autre par le r&eacute;chauffement climatique. Il fait partie des esp&egrave;ces &agrave; prot&eacute;ger dans le c&oelig;ur du Parc national des Ecrins.</span>",
       name: 'Lagopède alpin',
@@ -48,7 +47,6 @@ export const mockPois = (): PoisResponse => ({
       },
     },
     {
-      trek: 4,
       description: 'Test refuge',
       name: 'Refuge de la Lavey',
       id: 3,
@@ -67,7 +65,7 @@ export const mockPoiRoute = (times: number, trekId: number): void =>
     route: '/poi/',
     mockData: mockPois(),
     additionalQueries: {
-      trek: trekId,
+      near_trek: trekId,
       fields: 'id,name,description,attachments,type,geometry',
       page_size: getGlobalConfig().maxPoiPerPage,
     },

--- a/frontend/src/modules/sensitiveArea/api.ts
+++ b/frontend/src/modules/sensitiveArea/api.ts
@@ -7,7 +7,7 @@ export const fetchSensitiveAreas = (
   id: number,
   query: APIQuery,
 ): Promise<APIResponseForList<RawSensitiveArea>> => {
-  const typeKey = type.startsWith('outdoor') ? `near_${type.toLowerCase()}` : 'trek';
+  const typeKey = `near_${type.toLowerCase()}`;
   const params = { ...query, period: 'ignore', [typeKey]: id };
   return GeotrekAPI.get('/sensitivearea/', { params }).then(r => r.data);
 };

--- a/frontend/src/modules/sensitiveArea/mocks/index.ts
+++ b/frontend/src/modules/sensitiveArea/mocks/index.ts
@@ -40,7 +40,7 @@ export const mockSensitiveAreaRoute = (times: number): void =>
     mockData: mockSensitiveAreasResponse(),
     additionalQueries: {
       period: 'ignore',
-      trek: 2,
+      near_trek: 2,
     },
     times,
   });

--- a/frontend/src/services/api/interface.ts
+++ b/frontend/src/services/api/interface.ts
@@ -11,7 +11,6 @@ export interface APIQuery {
   omit?: string;
   page?: number;
   page_size?: number;
-  trek?: number;
   near_trek?: number;
   period?: string;
   q?: string;


### PR DESCRIPTION
- [x] Ticket : [GTR - Vérifier et utiliser les bons filtres "near_trek" et pas "trek" #890 ](https://github.com/GeotrekCE/Geotrek-rando-v3/issues/890)
