### PR TITLE
Structures styles around meteo widget

### DIFF
--- a/frontend/src/components/pages/details/Details.tsx
+++ b/frontend/src/components/pages/details/Details.tsx
@@ -238,7 +238,7 @@ export const DetailsUIWithoutContext: React.FC<Props> = ({ detailsId, parentId, 
                     {getGlobalConfig().enableMeteoWidget &&
                       details.cities_raw?.[0] &&
                       hasNavigator && (
-                        <DetailsSection>
+                        <DetailsSection className={marginDetailsChild}>
                           <DetailsMeteoWidget code={details.cities_raw[0]} />
                         </DetailsSection>
                       )}

--- a/frontend/src/components/pages/details/components/DetailsDescription/DetailsDescription.tsx
+++ b/frontend/src/components/pages/details/components/DetailsDescription/DetailsDescription.tsx
@@ -25,59 +25,69 @@ export const DetailsDescription: React.FC<DetailsDescriptionProps> = ({
   email,
   website,
 }) => {
+  const hasDeparture = departure !== undefined && departure.length > 0;
+  const hasArrival = arrival !== undefined && arrival.length > 0;
+  const hasCities = Array.isArray(cities) && cities.length > 0;
+  const hasEmail = Boolean(email);
+  const hasWebsite = Boolean(website);
+
   return (
     <div
       id="details_description"
       className={`flex flex-col
-      pt-6 desktop:pt-12
+      py-6 desktop:py-12
       border-solid border-greySoft border-b
       ${className ?? ''}`}
     >
       <h2 id="details_descriptionTitle" className="text-Mobile-H1 desktop:text-H2 font-bold">
         {title}
       </h2>
-      <div id="details_descriptionContent" className="mt-3 desktop:mt-4 mb-6 desktop:mb-12">
+      <div id="details_descriptionContent" className="mt-3 desktop:mt-4">
         <StyledListWithSteps>{parse(descriptionHtml)}</StyledListWithSteps>
       </div>
 
-      {departure && (
-        <div>
-          <span className={'font-bold'}>
-            <FormattedMessage id="details.departure" />
-          </span>{' '}
-          : {departure}
-        </div>
-      )}
-      {arrival && (
-        <div>
-          <span className={'font-bold'}>
-            <FormattedMessage id="details.arrival" />
-          </span>{' '}
-          : {arrival}
-        </div>
-      )}
-      {cities && cities.length > 0 && (
-        <div>
-          <span className={'font-bold'}>
-            <FormattedMessage id="details.cities" />
-          </span>{' '}
-          : {cities.join(', ')}
-        </div>
-      )}
+      {(hasDeparture || hasArrival || hasCities || hasCities || hasEmail || hasWebsite) && (
+        <ul className="mt-3 desktop:mt-4">
+          {hasDeparture && (
+            <li>
+              <span className={'font-bold'}>
+                <FormattedMessage id="details.departure" />
+              </span>{' '}
+              : {departure}
+            </li>
+          )}
+          {hasArrival && (
+            <li>
+              <span className={'font-bold'}>
+                <FormattedMessage id="details.arrival" />
+              </span>{' '}
+              : {arrival}
+            </li>
+          )}
+          {hasCities && (
+            <li>
+              <span className={'font-bold'}>
+                <FormattedMessage id="details.cities" />
+              </span>{' '}
+              : {cities.join(', ')}
+            </li>
+          )}
 
-      {Boolean(email) && (
-        <div>
-          <a href={`mailto:${email as string}`} className="underline">
-            {email}
-          </a>
-        </div>
-      )}
-      {Boolean(website) && (
-        <div>
-          <a href={website} target="_blank" rel="noopener noreferrer">
-            {website}
-          </a>
-        </div>
+          {hasEmail && (
+            <li>
+              <a href={`mailto:${email as string}`} className="underline">
+                {email}
+              </a>
+            </li>
+          )}
+          {hasWebsite && (
+            <li>
+              <a href={website} target="_blank" rel="noopener noreferrer">
+                {website}
+              </a>
+            </li>
+          )}
+        </ul>
       )}
     </div>
   );

--- a/frontend/src/components/pages/details/components/DetailsDescription/__tests__/__snapshots__/DetailsDescription.test.tsx.snap
+++ b/frontend/src/components/pages/details/components/DetailsDescription/__tests__/__snapshots__/DetailsDescription.test.tsx.snap
@@ -7,7 +7,7 @@ Object {
     <div>
       <div
         class="flex flex-col
-      pt-6 desktop:pt-12
+      py-6 desktop:py-12
       border-solid border-greySoft border-b
       "
         id="details_description"
@@ -19,7 +19,7 @@ Object {
           Description
         </h2>
         <div
-          class="mt-3 desktop:mt-4 mb-6 desktop:mb-12"
+          class="mt-3 desktop:mt-4"
           id="details_descriptionContent"
         >
           <div
@@ -56,7 +56,7 @@ Object {
   "container": <div>
     <div
       class="flex flex-col
-      pt-6 desktop:pt-12
+      py-6 desktop:py-12
       border-solid border-greySoft border-b
       "
       id="details_description"
@@ -68,7 +68,7 @@ Object {
         Description
       </h2>
       <div
-        class="mt-3 desktop:mt-4 mb-6 desktop:mb-12"
+        class="mt-3 desktop:mt-4"
         id="details_descriptionContent"
       >
         <div

--- a/frontend/src/components/pages/details/components/DetailsMeteoWidget/DetailsMeteoWidget.tsx
+++ b/frontend/src/components/pages/details/components/DetailsMeteoWidget/DetailsMeteoWidget.tsx
@@ -8,7 +8,7 @@ const Wrapper = styled.div`
   padding-top: 25px;
   height: 0;
 
-  max-width: 85%;
+  max-width: 100%;
   margin: auto;
 
   & iframe {


### PR DESCRIPTION
Structuring of the details page around the meteo widget.
- If one of departure, arrival, cities, website, or email field is filled, a padding was missing at the bottom of the description section
- Meteo Widget wasn't aligned with the grid

## Screenshots:
Before:  
![image](https://user-images.githubusercontent.com/1926041/228306515-2c70b6f1-d7f5-4cdb-97c9-9479cfd6aed1.png)


After:  
![image](https://user-images.githubusercontent.com/1926041/228306258-4b1360c8-38e4-4b3b-9c4a-c85c785c0b06.png)



