### PR TITLE
Minor bugfixes for trek marker

### DIFF
--- a/frontend/src/components/Map/Markers/TrekChildMarker.tsx
+++ b/frontend/src/components/Map/Markers/TrekChildMarker.tsx
@@ -1,35 +1,32 @@
 import { TrekChildrenMarker } from 'components/Icons/TrekChildrenMarker';
 import { DivIcon } from 'leaflet';
 import { renderToStaticMarkup } from 'react-dom/server';
-import styled from 'styled-components';
-import { colorPalette, typography } from 'stylesheet';
+import { colorPalette, SPACING_UNIT } from 'stylesheet';
 
 const markerHeight = 44;
 const markerWidth = 36;
 // We emulate a padding on the pictogram by centering it thanks to the "horizontal padding"
-const markerHorizontalPadding = 13;
-const markerTopPadding = 6;
-
-const ChildLabel = styled.span<{ zoomRatio: number }>`
-  color: ${colorPalette.primary1};
-  ${props => (props.zoomRatio > 1 ? typography.h3 : typography.h4)}
-  width: ${props => (markerWidth - 2 * markerHorizontalPadding) * props.zoomRatio}px;
-  top: ${props => markerTopPadding * props.zoomRatio}px;
-  position: absolute;
-  text-align: center;
-`;
+const markerHorizontalPadding = 6;
+const markerTopPadding = 8;
 
 const ChildMarker: React.FC<{ label: string; zoomRatio: number; color: string }> = ({
   label,
   zoomRatio,
   color,
 }) => {
+  const width = `w-${
+    (markerWidth / SPACING_UNIT - 2 * (markerHorizontalPadding / SPACING_UNIT)) * zoomRatio
+  }`;
+  const top = `top-${(markerTopPadding / SPACING_UNIT) * zoomRatio}`;
+  const fontSize = zoomRatio === 1 ? 'text-xl' : 'text-2xl';
   return (
     <div className="relative flex justify-center">
       <TrekChildrenMarker color={color ?? colorPalette.primary1} size={markerWidth * zoomRatio} />
-      <ChildLabel className="z-leafletSvg" zoomRatio={zoomRatio}>
+      <span
+        className={`absolute z-leafletSvg text-primary font-bold text-center leading-5 ${width} ${top} ${fontSize}`}
+      >
         {label}
-      </ChildLabel>
+      </span>
     </div>
   );
 };

--- a/frontend/src/components/Map/components/HoverableMarker.tsx
+++ b/frontend/src/components/Map/components/HoverableMarker.tsx
@@ -38,8 +38,8 @@ export const HoverableMarker: React.FC<TrekOrTouristicContentProps | TrekChildPr
       <Marker
         position={props.position}
         eventHandlers={{
-          mouseover: props.onMouseOver,
-          mouseout: props.onMouseOut,
+          ...(props.onMouseOver && { mouseover: props.onMouseOver }),
+          ...(props.onMouseOut && { mouseout: props.onMouseOut }),
         }}
         icon={
           isTrekChild(props)


### PR DESCRIPTION
- Avoid attach useless events on trek marker
- Center the step markers with the tens

Before:
![image](https://user-images.githubusercontent.com/1926041/228865792-61a21a30-4b51-4b49-b0f9-40eb176e3492.png)

After:
![image](https://user-images.githubusercontent.com/1926041/228865936-639a82bd-0d05-4154-8789-1ba74de8226b.png)

NB: Colors and basemap are differents because i did not copy all the customization.
