### PR TITLE
Use node from nvmrc file for install and test Github actions

### DIFF
--- a/.github/workflows/action-intall-and-test.yml
+++ b/.github/workflows/action-intall-and-test.yml
@@ -6,13 +6,14 @@ jobs:
   install-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Cache Node Modules
+      - uses: actions/checkout@v3
+      - name: Setup node
         id: cache-node-modules
-        uses: actions/cache@v2
+        uses: actions/setup-node@v3
         with:
-          path: ./frontend/node_modules
-          key: node-modules-${{ hashFiles('./frontend/yarn.lock') }}
+          node-version-file: ./frontend/.nvmrc
+          cache: "yarn"
+          cache-dependency-path: "**/yarn.lock"
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: yarn

--- a/.github/workflows/action-intall-and-test.yml
+++ b/.github/workflows/action-intall-and-test.yml
@@ -16,7 +16,7 @@ jobs:
           cache-dependency-path: "**/yarn.lock"
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'
-        run: yarn
+        run: yarn install --frozen-lockfile
         working-directory: ./frontend
       - name: Check types
         run: yarn tsc


### PR DESCRIPTION
By default, GH actions uses node12. See https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
