### PR TITLE
Set anchors to navigate between sections of details pages

### DIFF
--- a/frontend/src/components/Map/DetailsMap/MapChildren.tsx
+++ b/frontend/src/components/Map/DetailsMap/MapChildren.tsx
@@ -104,7 +104,7 @@ export const MapChildren: React.FC<Props> = props => {
         <GeometryList contents={props.touristicContentPoints} />
       )}
 
-      {visibleSection === 'sensitiveAreasRef' && (
+      {visibleSection === 'sensitiveAreas' && (
         <SensitiveAreas contents={props.sensitiveAreasGeometry} />
       )}
 

--- a/frontend/src/components/pages/details/Details.tsx
+++ b/frontend/src/components/pages/details/Details.tsx
@@ -96,8 +96,8 @@ export const DetailsUIWithoutContext: React.FC<Props> = ({ detailsId, parentId, 
       sizes.detailsHeaderDesktop,
   });
 
-  const positiveElevation = parseInt(details?.informations.elevation ?? '0', 10);
-  const negativeElevation = parseInt(details?.informations.negativeElevation ?? '0', 10);
+  const positiveElevation = Number(details?.informations.elevation ?? 0);
+  const negativeElevation = Number(details?.informations.negativeElevation ?? 0);
 
   const higherDifferenceElevation = Math.max(positiveElevation, Math.abs(negativeElevation));
 
@@ -240,7 +240,7 @@ export const DetailsUIWithoutContext: React.FC<Props> = ({ detailsId, parentId, 
                     {getGlobalConfig().enableMeteoWidget &&
                       details.cities_raw?.[0] &&
                       hasNavigator && (
-                        <DetailsSection className={marginDetailsChild}>
+                        <DetailsSection htmlId="details_forecast" className={marginDetailsChild}>
                           <DetailsMeteoWidget code={details.cities_raw[0]} />
                         </DetailsSection>
                       )}
@@ -259,11 +259,11 @@ export const DetailsUIWithoutContext: React.FC<Props> = ({ detailsId, parentId, 
                       <div ref={setSensitiveAreasRef} id="details_sensitiveAreas_ref">
                         <DetailsSection
                           htmlId="details_sensitiveAreas"
-                          titleId="details.sensitiveAreas.title"
+                          titleId="details.sensitiveAreasTitle"
                           className={marginDetailsChild}
                         >
                           <span className="mb-4 desktop:mb-8">
-                            <FormattedMessage id="details.sensitiveAreas.intro" />
+                            <FormattedMessage id="details.sensitiveAreasIntro" />
                           </span>
                           {details.sensitiveAreas.map((sensitiveArea, i) => (
                             <DetailsSensitiveArea
@@ -308,7 +308,7 @@ export const DetailsUIWithoutContext: React.FC<Props> = ({ detailsId, parentId, 
                       <div ref={setPracticalInformationsRef} id="details_practicalInformationRef">
                         {details.informationDesks.length > 0 && (
                           <DetailsSection
-                            htmlId="details_informationDesks"
+                            htmlId="details_practicalInformations"
                             titleId="details.informationDesks"
                             className={marginDetailsChild}
                           >
@@ -484,7 +484,7 @@ export const DetailsUIWithoutContext: React.FC<Props> = ({ detailsId, parentId, 
                           if (currentChild.geometry) {
                             children.push({
                               ...currentChild.geometry,
-                              id: `DETAILS-TREK_CHILDREN-${currentChild.geometry.id}`,
+                              id: `TREK-${currentChild.geometry.id}`,
                             });
                           }
                           return children;

--- a/frontend/src/components/pages/details/components/DetailsCardSection/DetailsCardSection.tsx
+++ b/frontend/src/components/pages/details/components/DetailsCardSection/DetailsCardSection.tsx
@@ -23,7 +23,7 @@ export const DetailsCardSection: React.FC<DetailsCardSectionProps> = ({
   type,
 }) => {
   return (
-    <div id={htmlId} className="mt-6 desktop:mt-12">
+    <div id={htmlId} className="pt-6 desktop:pt-12 scroll-mt-20 desktop:scroll-mt-30">
       <div
         id="details_cardSectionTitle"
         className={`text-Mobile-H1 desktop:text-H2 font-bold ${marginDetailsChild} flex items-center`}

--- a/frontend/src/components/pages/details/components/DetailsDescription/DetailsDescription.tsx
+++ b/frontend/src/components/pages/details/components/DetailsDescription/DetailsDescription.tsx
@@ -2,6 +2,7 @@ import { FormattedMessage } from 'react-intl';
 import styled, { css } from 'styled-components';
 import { colorPalette, desktopOnly, getSpacing, shadow } from 'stylesheet';
 import parse from 'html-react-parser';
+import { cn } from 'services/utils/cn';
 import { HtmlText } from '../../utils';
 
 interface DetailsDescriptionProps {
@@ -34,10 +35,10 @@ export const DetailsDescription: React.FC<DetailsDescriptionProps> = ({
   return (
     <div
       id="details_description"
-      className={`flex flex-col
-      py-6 desktop:py-12
-      border-solid border-greySoft border-b
-      ${className ?? ''}`}
+      className={cn(
+        'flex flex-col py-6 desktop:py-12 border-solid border-greySoft border-b scroll-mt-20 desktop:scroll-mt-30',
+        className,
+      )}
     >
       <h2 id="details_descriptionTitle" className="text-Mobile-H1 desktop:text-H2 font-bold">
         {title}

--- a/frontend/src/components/pages/details/components/DetailsDescription/__tests__/__snapshots__/DetailsDescription.test.tsx.snap
+++ b/frontend/src/components/pages/details/components/DetailsDescription/__tests__/__snapshots__/DetailsDescription.test.tsx.snap
@@ -6,10 +6,7 @@ Object {
   "baseElement": <body>
     <div>
       <div
-        class="flex flex-col
-      py-6 desktop:py-12
-      border-solid border-greySoft border-b
-      "
+        class="flex flex-col py-6 desktop:py-12 border-solid border-greySoft border-b scroll-mt-20 desktop:scroll-mt-30"
         id="details_description"
       >
         <h2
@@ -55,10 +52,7 @@ Object {
   </body>,
   "container": <div>
     <div
-      class="flex flex-col
-      py-6 desktop:py-12
-      border-solid border-greySoft border-b
-      "
+      class="flex flex-col py-6 desktop:py-12 border-solid border-greySoft border-b scroll-mt-20 desktop:scroll-mt-30"
       id="details_description"
     >
       <h2

--- a/frontend/src/components/pages/details/components/DetailsHeader/DetailsHeader.tsx
+++ b/frontend/src/components/pages/details/components/DetailsHeader/DetailsHeader.tsx
@@ -1,7 +1,8 @@
 import { DetailsDownloadIcons } from 'components/pages/details/components/DetailsDownloadIcons';
 import React, { MutableRefObject } from 'react';
 import { FormattedMessage } from 'react-intl';
-import { sizes } from 'stylesheet';
+import { cn } from 'services/utils/cn';
+import useHasMounted from 'hooks/useHasMounted';
 import { Details } from '../../../../../modules/details/interface';
 import { OutdoorCourseDetails } from '../../../../../modules/outdoorCourse/interface';
 import { OutdoorSiteDetails } from '../../../../../modules/outdoorSite/interface';
@@ -15,55 +16,43 @@ interface DetailsHeaderProps {
   type: 'TREK' | 'OUTDOOR_SITE' | 'OUTDOOR_COURSE' | 'TOURISTIC_EVENT';
 }
 
-const scrollTo = (element: HTMLDivElement | undefined | null) => {
-  if (element !== null && element !== undefined) {
-    // offsetTop : offset to the closest relative parent
-    const adjustedPosition =
-      element.offsetTop +
-      sizes.coverDetailsDesktop +
-      sizes.desktopHeader -
-      sizes.detailsHeaderDesktop -
-      sizes.topIconsDetailsDesktop;
-    window.scrollTo({ top: adjustedPosition, behavior: 'smooth' });
-  }
-};
-
 export const DetailsHeader: React.FC<DetailsHeaderProps> = ({
   sectionsReferences,
   details,
   type,
 }) => {
   const { detailsHeaderSection, currentSectionId } = useDetailsHeader(sectionsReferences);
+  const isMounted = useHasMounted();
   return (
-    <div
+    <nav
       id="details_headerDesktop"
       className="hidden desktop:flex
       sticky top-desktopHeader z-subHeader
-      shadow-md bg-white"
-      style={{ height: 55 }}
+      shadow-md bg-white h-14"
+      role="navigation"
     >
-      <div id="details_headerDesktop_inlineMenu" className="flex flex-1 pb-2.5 pt-4 ml-3">
+      <ul
+        id="details_headerDesktop_inlineMenu"
+        className="flex flex-1 pb-2.5 pt-4 ml-3 text-center"
+      >
         {(Object.keys(detailsHeaderSection) as Array<keyof DetailsHeaderSection>)
+          // Report anchor is in <DetailsDownloadIcons /> below
           .filter(sectionId => sectionId !== 'report')
           .map(sectionId => (
-            <div
-              onClick={() => scrollTo(detailsHeaderSection[sectionId])}
-              key={sectionId}
-              className="text-center"
-            >
-              <span
-                className={`hover:text-primary1 mx-5
-                pb-1 border-b-2 hover:border-primary1 border-transparent border-solid
-                cursor-pointer transition-all duration-300 ${
-                  currentSectionId === sectionId ? 'text-primary1 border-primary1' : ''
-                }`}
+            <li key={sectionId}>
+              <a
+                className={cn(
+                  'mx-5 pb-1 border-b-2 border-transparent border-solid transition-all duration-300  hover:text-primary1 hover:border-primary1  focus:text-primary1 focus:border-primary1',
+                  currentSectionId === sectionId && isMounted && 'text-primary1 border-primary1',
+                )}
+                href={`#details_${sectionId}`}
               >
                 <FormattedMessage id={`details.${sectionId}`} />
-              </span>
-            </div>
+              </a>
+            </li>
           ))}
-      </div>
+      </ul>
       <DetailsDownloadIcons details={details} hideReport={type !== 'TREK'} />
-    </div>
+    </nav>
   );
 };

--- a/frontend/src/components/pages/details/components/DetailsPreview/DetailsPreview.tsx
+++ b/frontend/src/components/pages/details/components/DetailsPreview/DetailsPreview.tsx
@@ -22,6 +22,7 @@ import {
 import React from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import ToolTip from 'components/ToolTip';
+import { cn } from 'services/utils/cn';
 import { OutdoorCourseDetails } from '../../../../../modules/outdoorCourse/interface';
 import { OutdoorSiteDetails } from '../../../../../modules/outdoorSite/interface';
 import { dataUnits } from '../../../../../modules/results/adapter';
@@ -87,7 +88,7 @@ export const DetailsPreview: React.FC<DetailsPreviewProps> = ({
   return (
     <div
       id="details_preview"
-      className={`${className ?? ''} flex flex-col mt-2 desktop:mt-10 relative`}
+      className={cn(className, 'flex flex-col mt-2 desktop:mt-10 relative desktop:scroll-mt-20')}
     >
       <DetailsBreadcrumb
         title={title}

--- a/frontend/src/components/pages/details/components/DetailsSection/DetailsSection.tsx
+++ b/frontend/src/components/pages/details/components/DetailsSection/DetailsSection.tsx
@@ -1,7 +1,8 @@
 import { Separator } from 'components/Separator';
 import { FormattedMessage } from 'react-intl';
+import { cn } from 'services/utils/cn';
 import styled from 'styled-components';
-import { MAX_WIDTH_MOBILE, scrollBar } from 'stylesheet';
+import { scrollBar } from 'stylesheet';
 
 export interface DetailsSectionProps {
   titleId?: string;
@@ -17,7 +18,7 @@ export const DetailsSection: React.FC<DetailsSectionProps> = ({
   htmlId,
 }) => {
   return (
-    <Container className={className} id={htmlId}>
+    <div className={cn('scroll-mt-20 desktop:scroll-mt-30', className)} id={htmlId}>
       <ScrollContainer
         id="details_section"
         className={`flex flex-col
@@ -40,16 +41,9 @@ export const DetailsSection: React.FC<DetailsSectionProps> = ({
         </div>
       </ScrollContainer>
       <Separator />
-    </Container>
+    </div>
   );
 };
-
-const Container = styled.div`
-  scroll-margin-top: 80px;
-  @media (min-width: ${MAX_WIDTH_MOBILE}px) {
-    scroll-margin-top: 150px;
-  }
-`;
 
 const ScrollContainer = styled.div`
   &::-webkit-scrollbar {

--- a/frontend/src/components/pages/details/components/DetailsSensitiveArea/DetailsSensitiveArea.tsx
+++ b/frontend/src/components/pages/details/components/DetailsSensitiveArea/DetailsSensitiveArea.tsx
@@ -30,12 +30,12 @@ export const DetailsSensitiveArea: React.FC<DetailsSensitiveAreaProps> = ({
         </SensitiveAreaSection>
       )}
       {practices.length > 0 && (
-        <SensitiveAreaSection labelId="practices">
+        <SensitiveAreaSection labelId="details.sensitiveAreasPractices">
           <div>{practices.map(practice => practice.name).join(', ')}</div>
         </SensitiveAreaSection>
       )}
       {period !== null && hasPeriodAtLeastOneMonthValid && (
-        <SensitiveAreaSection labelId="period">
+        <SensitiveAreaSection labelId="details.sensitiveAreasPeriod">
           <div>
             {period.map((monthlyValidity, i) =>
               monthlyValidity ? <StyledMonth monthNumber={i} key={i} /> : undefined,
@@ -44,7 +44,7 @@ export const DetailsSensitiveArea: React.FC<DetailsSensitiveAreaProps> = ({
         </SensitiveAreaSection>
       )}
       {contact !== null && (
-        <SensitiveAreaSection labelId="contact">
+        <SensitiveAreaSection labelId="details.sensitiveAreasContact">
           <HtmlText>{parse(contact)}</HtmlText>
         </SensitiveAreaSection>
       )}
@@ -76,7 +76,7 @@ const SensitiveAreaSection: React.FC<SensitiveAreaSectionProps> = ({ labelId, ch
     <div className="mt-1 desktop:mt-2">
       {labelId !== undefined && (
         <div className="font-bold">
-          <FormattedMessage id={`details.sensitiveAreas.${labelId}`} />
+          <FormattedMessage id={labelId} />
         </div>
       )}
       {children}

--- a/frontend/src/components/pages/details/components/DetailsSensitiveArea/DetailsSensitiveArea.tsx
+++ b/frontend/src/components/pages/details/components/DetailsSensitiveArea/DetailsSensitiveArea.tsx
@@ -22,7 +22,7 @@ export const DetailsSensitiveArea: React.FC<DetailsSensitiveAreaProps> = ({
     <div id="details_sensitiveArea" className={className}>
       <div className="flex items-center space-x-2" id="details_sensitiveAreaTitle">
         <ColorLegendIcon color={color} />
-        {name !== null && <span className="font-bold text-H4 space-y-2">{name}</span>}
+        {name !== null && <h3 className="font-bold text-H4 space-y-2">{name}</h3>}
       </div>
       {description !== null && (
         <SensitiveAreaSection>
@@ -48,7 +48,7 @@ export const DetailsSensitiveArea: React.FC<DetailsSensitiveAreaProps> = ({
           <HtmlText>{parse(contact)}</HtmlText>
         </SensitiveAreaSection>
       )}
-      {infoUrl !== null && (
+      {infoUrl !== null && infoUrl !== '' && (
         <SensitiveAreaSection>
           <a className="text-primary1 hover:text-primary3 transition-colors" href={infoUrl}>
             <FormattedMessage id={'details.knowMore'} />
@@ -72,15 +72,16 @@ interface SensitiveAreaSectionProps {
 }
 
 const SensitiveAreaSection: React.FC<SensitiveAreaSectionProps> = ({ labelId, children }) => {
+  if (labelId === undefined) {
+    return <div className="mt-1 desktop:mt-2">{children}</div>;
+  }
   return (
-    <div className="mt-1 desktop:mt-2">
-      {labelId !== undefined && (
-        <div className="font-bold">
-          <FormattedMessage id={labelId} />
-        </div>
-      )}
-      {children}
-    </div>
+    <dl className="mt-1 desktop:mt-2">
+      <dt className="font-bold">
+        <FormattedMessage id={labelId} />
+      </dt>
+      <dd>{children}</dd>
+    </dl>
   );
 };
 

--- a/frontend/src/components/pages/details/components/DetailsSensitiveArea/__tests__/__snapshots__/DetailsSensitiveArea.test.tsx.snap
+++ b/frontend/src/components/pages/details/components/DetailsSensitiveArea/__tests__/__snapshots__/DetailsSensitiveArea.test.tsx.snap
@@ -16,11 +16,11 @@ Object {
             class="sc-gswNZR kgVgmZ"
             color="#AAAAA"
           />
-          <span
+          <h3
             class="font-bold text-H4 space-y-2"
           >
             Zone sensible de test
-          </span>
+          </h3>
         </div>
         <div
           class="mt-1 desktop:mt-2"
@@ -33,55 +33,61 @@ Object {
             </p>
           </div>
         </div>
-        <div
+        <dl
           class="mt-1 desktop:mt-2"
         >
-          <div
+          <dt
             class="font-bold"
           >
             Domaines d'activités concernés :
-          </div>
-          <div>
-            Terrestre, Aquatique
-          </div>
-        </div>
-        <div
+          </dt>
+          <dd>
+            <div>
+              Terrestre, Aquatique
+            </div>
+          </dd>
+        </dl>
+        <dl
           class="mt-1 desktop:mt-2"
         >
-          <div
+          <dt
             class="font-bold"
           >
             Périodes de sensibilité :
-          </div>
-          <div>
-            <span
-              class="mr-2"
-            >
-              janv.
-            </span>
-            <span
-              class="mr-2"
-            >
-              févr.
-            </span>
-          </div>
-        </div>
-        <div
+          </dt>
+          <dd>
+            <div>
+              <span
+                class="mr-2"
+              >
+                janv.
+              </span>
+              <span
+                class="mr-2"
+              >
+                févr.
+              </span>
+            </div>
+          </dd>
+        </dl>
+        <dl
           class="mt-1 desktop:mt-2"
         >
-          <div
+          <dt
             class="font-bold"
           >
             Contact :
-          </div>
-          <div
-            class="sc-bcXHqe hwfUBG"
-          >
-            <h2>
-              Une personne a contacter
-            </h2>
-          </div>
-        </div>
+          </dt>
+          <dd>
+            <div
+              class="sc-bcXHqe hwfUBG"
+            >
+              <h2>
+                Une personne a contacter
+              </h2>
+            </div>
+          </dd>
+        </dl>
         <div
           class="mt-1 desktop:mt-2"
         >
@@ -107,11 +113,11 @@ Object {
           class="sc-gswNZR kgVgmZ"
           color="#AAAAA"
         />
-        <span
+        <h3
           class="font-bold text-H4 space-y-2"
         >
           Zone sensible de test
-        </span>
+        </h3>
       </div>
       <div
         class="mt-1 desktop:mt-2"
@@ -124,55 +130,61 @@ Object {
           </p>
         </div>
       </div>
-      <div
+      <dl
         class="mt-1 desktop:mt-2"
       >
-        <div
+        <dt
           class="font-bold"
         >
           Domaines d'activités concernés :
-        </div>
-        <div>
-          Terrestre, Aquatique
-        </div>
-      </div>
-      <div
+        </dt>
+        <dd>
+          <div>
+            Terrestre, Aquatique
+          </div>
+        </dd>
+      </dl>
+      <dl
         class="mt-1 desktop:mt-2"
       >
-        <div
+        <dt
           class="font-bold"
         >
           Périodes de sensibilité :
-        </div>
-        <div>
-          <span
-            class="mr-2"
-          >
-            janv.
-          </span>
-          <span
-            class="mr-2"
-          >
-            févr.
-          </span>
-        </div>
-      </div>
-      <div
+        </dt>
+        <dd>
+          <div>
+            <span
+              class="mr-2"
+            >
+              janv.
+            </span>
+            <span
+              class="mr-2"
+            >
+              févr.
+            </span>
+          </div>
+        </dd>
+      </dl>
+      <dl
         class="mt-1 desktop:mt-2"
       >
-        <div
+        <dt
           class="font-bold"
         >
           Contact :
-        </div>
-        <div
-          class="sc-bcXHqe hwfUBG"
-        >
-          <h2>
-            Une personne a contacter
-          </h2>
-        </div>
-      </div>
+        </dt>
+        <dd>
+          <div
+            class="sc-bcXHqe hwfUBG"
+          >
+            <h2>
+              Une personne a contacter
+            </h2>
+          </div>
+        </dd>
+      </dl>
       <div
         class="mt-1 desktop:mt-2"
       >

--- a/frontend/src/components/pages/details/useDetails.tsx
+++ b/frontend/src/components/pages/details/useDetails.tsx
@@ -21,7 +21,7 @@ export type DetailsSections =
   | 'practicalInformations'
   | 'accessibility'
   | 'touristicContent'
-  | 'sensitiveAreasRef'
+  | 'sensitiveAreas'
   | 'courses'
   | 'report'
   | 'experiences';
@@ -77,7 +77,7 @@ export const useDetails = (
   const setPracticalInformationsRef = useSectionReferenceCallback('practicalInformations');
   const setTouristicContentsRef = useSectionReferenceCallback('touristicContent');
   const setAccessibilityRef = useSectionReferenceCallback('accessibility');
-  const setSensitiveAreasRef = useSectionReferenceCallback('sensitiveAreasRef');
+  const setSensitiveAreasRef = useSectionReferenceCallback('sensitiveAreas');
   const setReportRef = useSectionReferenceCallback('report');
 
   const intl = useIntl();

--- a/frontend/src/components/pages/site/OutdoorCourseUI.tsx
+++ b/frontend/src/components/pages/site/OutdoorCourseUI.tsx
@@ -231,11 +231,11 @@ export const OutdoorCourseUIWithoutContext: React.FC<Props> = ({ outdoorCourseUr
                       <div ref={setSensitiveAreasRef} id="details_sensitiveAreas_ref">
                         <DetailsSection
                           htmlId="details_sensitiveAreas"
-                          titleId="details.sensitiveAreas.title"
+                          titleId="details.sensitiveAreasTitle"
                           className={marginDetailsChild}
                         >
                           <span className="mb-4 desktop:mb-8">
-                            <FormattedMessage id="details.sensitiveAreas.intro" />
+                            <FormattedMessage id="details.sensitiveAreasIntro" />
                           </span>
                           {outdoorCourseContent.sensitiveAreas.map((sensitiveArea, i) => (
                             <DetailsSensitiveArea

--- a/frontend/src/components/pages/site/OutdoorSiteUI.tsx
+++ b/frontend/src/components/pages/site/OutdoorSiteUI.tsx
@@ -248,11 +248,11 @@ const OutdoorSiteUIWithoutContext: React.FC<Props> = ({ outdoorSiteUrl, language
                       <div ref={setSensitiveAreasRef} id="details_sensitiveAreas_ref">
                         <DetailsSection
                           htmlId="details_sensitiveAreas"
-                          titleId="details.sensitiveAreas.title"
+                          titleId="details.sensitiveAreasTitle"
                           className={marginDetailsChild}
                         >
                           <span className="mb-4 desktop:mb-8">
-                            <FormattedMessage id="details.sensitiveAreas.intro" />
+                            <FormattedMessage id="details.sensitiveAreasIntro" />
                           </span>
                           {outdoorSiteContent.sensitiveAreas.map((sensitiveArea, i) => (
                             <DetailsSensitiveArea
@@ -321,7 +321,7 @@ const OutdoorSiteUIWithoutContext: React.FC<Props> = ({ outdoorSiteUrl, language
                     {Number(outdoorSiteContent?.informationDesks?.length) > 0 && (
                       <div ref={setPracticalInformationsRef} id="details_practicalInformationRef">
                         <DetailsSection
-                          htmlId="details_informationDesks"
+                          htmlId="details_practicalInformations"
                           titleId="details.informationDesks"
                           className={marginDetailsChild}
                         >

--- a/frontend/src/components/pages/site/useOutdoorCourse.tsx
+++ b/frontend/src/components/pages/site/useOutdoorCourse.tsx
@@ -25,7 +25,7 @@ export const useOutdoorCourse = (
   const setPreviewRef = useSectionReferenceCallback('preview');
   const setPoisRef = useSectionReferenceCallback('poi');
   const setTouristicContentsRef = useSectionReferenceCallback('touristicContent');
-  const setSensitiveAreasRef = useSectionReferenceCallback('sensitiveAreasRef');
+  const setSensitiveAreasRef = useSectionReferenceCallback('sensitiveAreas');
 
   const [mobileMapState, setMobileMapState] = useState<'DISPLAYED' | 'HIDDEN'>('HIDDEN');
   const displayMobileMap = () => setMobileMapState('DISPLAYED');

--- a/frontend/src/components/pages/site/useOutdoorSite.tsx
+++ b/frontend/src/components/pages/site/useOutdoorSite.tsx
@@ -29,7 +29,7 @@ export const useOutdoorSite = (outdoorSiteUrl: string | string[] | undefined, la
   const setDescriptionRef = useSectionReferenceCallback('description');
   const setPracticalInformationsRef = useSectionReferenceCallback('practicalInformations');
   const setTouristicContentsRef = useSectionReferenceCallback('touristicContent');
-  const setSensitiveAreasRef = useSectionReferenceCallback('sensitiveAreasRef');
+  const setSensitiveAreasRef = useSectionReferenceCallback('sensitiveAreas');
 
   const [mobileMapState, setMobileMapState] = useState<'DISPLAYED' | 'HIDDEN'>('HIDDEN');
   const displayMobileMap = () => setMobileMapState('DISPLAYED');

--- a/frontend/src/stylesheet.ts
+++ b/frontend/src/stylesheet.ts
@@ -174,7 +174,7 @@ export const sizes = {
   button: 48,
   filterBar: 72,
   mobileDetailsTitle: 230,
-  detailsHeaderDesktop: 55,
+  detailsHeaderDesktop: 56,
   coverDetailsDesktop: 550,
   topIconsDetailsDesktop: 72,
   scrollOffsetBeforeElement: 36,

--- a/frontend/src/translations/ca.json
+++ b/frontend/src/translations/ca.json
@@ -133,14 +133,12 @@
     "transport": "Transport",
     "stationnement": "Estacionament",
     "access_parking": "Accés per carretera i aparcaments",
-    "sensitiveAreasRef": "Arees sensibles",
-    "sensitiveAreas": {
-      "title": "Zones de sensibilitat mediambiental",
-      "intro": "Al llarg de la seva ruta, travessarà zones de sensibilitat vinculades a la presència d'una espècie o d'un medi particular. En aquestes zones, un comportament adaptat permet contribuir a la seva preservació. Per a més informació detallada, es poden accedir a fitxes específiques per a cada àrea.",
-      "period": "Períodes de sensibilitat :",
-      "practices": "Ambits d’activitats afectats :",
-      "contact": "Contacte :"
-    },
+    "sensitiveAreas": "Arees sensibles",
+    "sensitiveAreasTitle": "Zones de sensibilitat mediambiental",
+    "sensitiveAreasIntro": "Al llarg de la seva ruta, travessarà zones de sensibilitat vinculades a la presència d'una espècie o d'un medi particular. En aquestes zones, un comportament adaptat permet contribuir a la seva preservació. Per a més informació detallada, es poden accedir a fitxes específiques per a cada àrea.",
+    "sensitiveAreasPeriod": "Períodes de sensibilitat :",
+    "sensitiveAreasPractices": "Ambits d’activitats afectats :",
+    "sensitiveAreasContact": "Contacte :",
     "altimetricProfile": {
       "title": "Perfil altiomètric",
       "totalLength": "Longitud total",

--- a/frontend/src/translations/de.json
+++ b/frontend/src/translations/de.json
@@ -133,14 +133,12 @@
     "transport": "Transport",
     "stationnement": "Parken",
     "access_parking": "Zufahrt und Parkplätze",
-    "sensitiveAreasRef": "Sensible Bereiche",
-    "sensitiveAreas": {
-      "title": "Umweltempfindliche Zonen",
-      "intro": "Auf Ihrem Weg durchqueren Sie Gebiete, die aufgrund des Vorkommens einer bestimmten Art oder eines bestimmten Lebensraums besonders empfindlich sind. In diesen Zonen können Sie durch angepasstes Verhalten zu deren Erhaltung beitragen. Für weitere Informationen stehen für jedes Gebiet spezielle Informationsblätter zur Verfügung.",
-      "period": "Sensibilitätsperioden:",
-      "practices": "Betroffene Tätigkeitsbereiche:",
-      "contact": "Kontakt:"
-    },
+    "sensitiveAreas": "Sensible Bereiche",
+    "sensitiveAreasTitle": "Umweltempfindliche Zonen",
+    "sensitiveAreasIntro": "Auf Ihrem Weg durchqueren Sie Gebiete, die aufgrund des Vorkommens einer bestimmten Art oder eines bestimmten Lebensraums besonders empfindlich sind. In diesen Zonen können Sie durch angepasstes Verhalten zu deren Erhaltung beitragen. Für weitere Informationen stehen für jedes Gebiet spezielle Informationsblätter zur Verfügung.",
+    "sensitiveAreasPeriod": "Sensibilitätsperioden:",
+    "sensitiveAreasPractices": "Betroffene Tätigkeitsbereiche:",
+    "sensitiveAreasContact": "Kontakt:",
     "altimetricProfile": {
       "title": "Höhenprofil",
       "totalLength": "Gesamtlänge",

--- a/frontend/src/translations/en.json
+++ b/frontend/src/translations/en.json
@@ -137,14 +137,12 @@
     "stationnement": "Parking",
     "access_parking": "Access and parking",
     "reservation": "Booking",
-    "sensitiveAreasRef": "Sensitive areas",
-    "sensitiveAreas": {
-      "title": "Sensitive areas",
-      "intro": "Along your trek, you will go through sensitive areas related to the presence of a specific species or environment. In these areas, an appropriate behaviour allows to contribute to their preservation. For detailed information, specific forms are accessible for each area.",
-      "period": "Sensitivity periods:",
-      "practices": "Impacted practices:",
-      "contact": "Contact:"
-    },
+    "sensitiveAreas": "Sensitive areas",
+    "sensitiveAreasTitle": "Sensitive areas",
+    "sensitiveAreasIntro": "Along your trek, you will go through sensitive areas related to the presence of a specific species or environment. In these areas, an appropriate behaviour allows to contribute to their preservation. For detailed information, specific forms are accessible for each area.",
+    "sensitiveAreasPeriod": "Sensitivity periods:",
+    "sensitiveAreasPractices": "Impacted practices:",
+    "sensitiveAreasContact": "Contact:",
     "altimetricProfile": {
       "title": "Altimetric profile",
       "totalLength": "Total length",

--- a/frontend/src/translations/es.json
+++ b/frontend/src/translations/es.json
@@ -133,14 +133,12 @@
     "transport": "Transporte",
     "stationnement": "Estacionamiento",
     "access_parking": "Acceso por carretera y aparcamientos",
-    "sensitiveAreasRef": "Areas sensibles",
-    "sensitiveAreas": {
-      "title": "Zonas de sensibilidad ecológicas",
-      "intro": "A lo largo de su ruta, cruzará zonas de sensibilidad vinculadas con la presencia de una especie o de un medio particular. En estas zonas, un comportamiento adaptado permite contribuir a su preservación. Para más información detallada, se puede acceder a hojas específicas de cada área.",
-      "period": "Periodo de sensibilidad :",
-      "practices": "Ambitos de actividades afectados :",
-      "contact": "Contacto :"
-    },
+    "sensitiveAreas": "Areas sensibles",
+    "sensitiveAreasTitle": "Zonas de sensibilidad ecológicas",
+    "sensitiveAreasIntro": "A lo largo de su ruta, cruzará zonas de sensibilidad vinculadas con la presencia de una especie o de un medio particular. En estas zonas, un comportamiento adaptado permite contribuir a su preservación. Para más información detallada, se puede acceder a hojas específicas de cada área.",
+    "sensitiveAreasPeriod": "Periodo de sensibilidad :",
+    "sensitiveAreasPractices": "Ambitos de actividades afectados :",
+    "sensitiveAreasContact": "Contacto :",
     "altimetricProfile": {
       "title": "Perfil de elevación",
       "totalLength": "Longitud total",

--- a/frontend/src/translations/fr.json
+++ b/frontend/src/translations/fr.json
@@ -137,14 +137,12 @@
     "stationnement": "Stationnement",
     "access_parking": "Accès routiers et parkings",
     "reservation": "Réservation",
-    "sensitiveAreasRef": "Zones sensibles",
-    "sensitiveAreas": {
-      "title": "Zones de sensibilité environnementale",
-      "intro": "Le long de votre itinéraire, vous allez traverser des zones de sensibilité liées à la présence d’une espèce ou d’un milieu particulier. Dans ces zones, un comportement adapté permet de contribuer à leur préservation. Pour plus d’informations détaillées, des fiches spécifiques sont accessibles pour chaque zone.",
-      "period": "Périodes de sensibilité :",
-      "practices": "Domaines d'activités concernés :",
-      "contact": "Contact :"
-    },
+    "sensitiveAreas": "Zones sensibles",
+    "sensitiveAreasTitle": "Zones de sensibilité environnementale",
+    "sensitiveAreasIntro": "Le long de votre itinéraire, vous allez traverser des zones de sensibilité liées à la présence d’une espèce ou d’un milieu particulier. Dans ces zones, un comportement adapté permet de contribuer à leur préservation. Pour plus d’informations détaillées, des fiches spécifiques sont accessibles pour chaque zone.",
+    "sensitiveAreasPeriod": "Périodes de sensibilité :",
+    "sensitiveAreasPractices": "Domaines d'activités concernés :",
+    "sensitiveAreasContact": "Contact :",
     "altimetricProfile": {
       "title": "Profil altimétrique",
       "totalLength": "Longueur totale",

--- a/frontend/src/translations/it.json
+++ b/frontend/src/translations/it.json
@@ -137,14 +137,12 @@
     "stationnement": "Parcheggio",
     "access_parking": "Accesso stradale e parcheggi",
     "reservation": "Prenotazione",
-    "sensitiveAreasRef": "Zone sensibili",
-    "sensitiveAreas": {
-      "title": "Zone di sensibilità ambientale",
-      "intro": "Lungo il percorso, attraverserai, legate alla presenza di una specie o di un ambiente particolare. In queste zone, un comportamento adeguato può contribuire alla loro conservazione. ",
-      "period": "Periodi di sensibilità :",
-      "practices": "Aree di attività interessate :",
-      "contact": "Contatto :"
-    },
+    "sensitiveAreas": "Zone sensibili",
+    "sensitiveAreasTitle": "Zone di sensibilità ambientale",
+    "sensitiveAreasIntro": "Lungo il percorso, attraverserai, legate alla presenza di una specie o di un ambiente particolare. In queste zone, un comportamento adeguato può contribuire alla loro conservazione. ",
+    "sensitiveAreasPeriod": "Periodi di sensibilità :",
+    "sensitiveAreasPractices": "Aree di attività interessate :",
+    "sensitiveAreasContact": "Contatto :",
     "altimetricProfile": {
       "title": "Profilo altimetro",
       "totalLength": "Lunghezza totale",


### PR DESCRIPTION
Define navigation between sections with anchors:
It allows to:
- Use previous/next history navigation from the browser to jump from one section to another
- Share a page focused on a particular section

:warning: There are small breaking changes with translations related to `sensitiveAreas`.
