### PR TITLE
Rework details card

### DIFF
--- a/frontend/src/components/Map/DetailsMap/PointsSecondary.tsx
+++ b/frontend/src/components/Map/DetailsMap/PointsSecondary.tsx
@@ -5,7 +5,6 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { SignageDictionary } from 'modules/signage/interface';
 import styled, { css } from 'styled-components';
 import { desktopOnly, getSpacing } from 'stylesheet';
-import { textEllipsisAfterNLines } from 'services/cssHelpers';
 import { RawCoordinate2D } from 'modules/interface';
 import { InfrastructureDictionary } from 'modules/infrastructure/interface';
 import { FormattedMessage } from 'react-intl';
@@ -63,7 +62,7 @@ export const PointsSecondary: React.FC<PointsSecondaryProps> = ({
               {location.imageUrl !== null && <CoverImage src={location.imageUrl} alt="" />}
               <div className="p-4">
                 <div className="text-P2 mb-1 text-greyDarkColored">{location.type}</div>
-                <Name className="text-Mobile-C1 text-primary1 font-bold desktop:text-H4">
+                <Name className="text-Mobile-C1 text-primary1 font-bold desktop:text-H4 line-clamp-2">
                   {location.name}
                 </Name>
                 {Boolean(location.description) && (
@@ -109,8 +108,6 @@ const StyledTooltip = styled(Tooltip)`
 `;
 
 const Name = styled.span`
-  ${textEllipsisAfterNLines(2)}
-
   ${desktopOnly(css`
     white-space: nowrap;
     text-overflow: ellipsis;

--- a/frontend/src/components/Map/components/Popup/index.tsx
+++ b/frontend/src/components/Map/components/Popup/index.tsx
@@ -6,7 +6,6 @@ import { FormattedMessage } from 'react-intl';
 import Loader from 'components/Loader';
 
 import { desktopOnly, getSpacing } from 'stylesheet';
-import { textEllipsisAfterNLines } from 'services/cssHelpers';
 import { Button as RawButton } from 'components/Button';
 import { generateResultDetailsUrl } from 'components/pages/search/utils';
 
@@ -47,7 +46,7 @@ const PopupContent: React.FC<PropsPC> = ({ showButton, id, type, parentId }) => 
             <span className="text-P2 mb-1 text-greyDarkColored hidden desktop:inline">
               {trekPopupResult.place}
             </span>
-            <Title className="text-Mobile-C1 text-primary1 font-bold desktop:text-H4">
+            <Title className="text-Mobile-C1 text-primary1 font-bold desktop:text-H4 line-clamp-2">
               {trekPopupResult.title}
             </Title>
             {showButton && (
@@ -108,8 +107,6 @@ const Button = styled(RawButton)`
 `;
 
 const Title = styled.span`
-  ${textEllipsisAfterNLines(2)}
-
   ${desktopOnly(css`
     white-space: nowrap;
     text-overflow: ellipsis;

--- a/frontend/src/components/Modal/Modal.tsx
+++ b/frontend/src/components/Modal/Modal.tsx
@@ -6,8 +6,10 @@ import { MapButton } from 'components/Map/components/MapButton';
 import ConditionallyRender from 'components/ConditionallyRender';
 import useHasMounted from 'hooks/useHasMounted';
 import { useIntl } from 'react-intl';
+import { cn } from 'services/utils/cn';
 
 type Props = {
+  className?: string;
   children: ({
     isFullscreen,
     toggleFullscreen,
@@ -17,7 +19,7 @@ type Props = {
   }) => any | ReactElement<any>;
 };
 
-const Inner: React.FC<Props> = ({ children }) => {
+const Inner: React.FC<Props> = ({ className, children }) => {
   const [isFullscreen, setIsFullscreen] = useState<boolean>(false);
   const intl = useIntl();
 
@@ -60,7 +62,7 @@ const Inner: React.FC<Props> = ({ children }) => {
           <div
             // @ts-ignore Wrong type in the lib
             ref={ref}
-            className="relative bg-dark"
+            className={cn('relative bg-dark', className)}
           >
             {isFullscreen && (
               <MapButton

--- a/frontend/src/components/pages/details/components/DetailsCard/DetailsCard.tsx
+++ b/frontend/src/components/pages/details/components/DetailsCard/DetailsCard.tsx
@@ -73,30 +73,32 @@ export const DetailsCard: React.FC<DetailsCardProps> = ({
       }}
     >
       <div className="flex shrink-0 desktop:w-2/5">
-        <Modal>
-          {({ isFullscreen, toggleFullscreen }) => (
-            <>
-              {type === 'TOURISTIC_CONTENT' &&
-                redirectionUrl &&
-                attachments.length > 0 &&
-                hasNavigator && (
+        <div className="w-full">
+          <Modal className="h-full">
+            {({ isFullscreen, toggleFullscreen }) => (
+              <>
+                {type === 'TOURISTIC_CONTENT' &&
+                  redirectionUrl &&
+                  attachments.length > 0 &&
+                  hasNavigator && (
+                    <DetailsCoverCarousel
+                      attachments={isFullscreen ? attachments : thumbnails}
+                      classNameImage={cn('object-center', isFullscreen && 'object-contain')}
+                      redirect={redirectionUrl}
+                    />
+                  )}
+                {type !== 'TOURISTIC_CONTENT' && attachments.length > 0 && hasNavigator && (
                   <DetailsCoverCarousel
                     attachments={isFullscreen ? attachments : thumbnails}
-                    classNameImage={isFullscreen ? 'object-contain' : ''}
-                    redirect={redirectionUrl}
+                    classNameImage={cn('object-center', isFullscreen && 'object-contain')}
+                    onClickImage={toggleFullscreen}
                   />
                 )}
-              {type !== 'TOURISTIC_CONTENT' && attachments.length > 0 && hasNavigator && (
-                <DetailsCoverCarousel
-                  attachments={isFullscreen ? attachments : thumbnails}
-                  classNameImage={isFullscreen ? 'object-contain' : ''}
-                  onClickImage={toggleFullscreen}
-                />
-              )}
-            </>
-          )}
-        </Modal>
-        <CardIcon iconUri={iconUri} iconName={iconName} color={getActivityColor(type)} />
+              </>
+            )}
+          </Modal>
+          <CardIcon iconUri={iconUri} iconName={iconName} color={getActivityColor(type)} />
+        </div>
       </div>
       <div
         ref={detailsCardRef}

--- a/frontend/src/components/pages/details/components/DetailsCard/DetailsCard.tsx
+++ b/frontend/src/components/pages/details/components/DetailsCard/DetailsCard.tsx
@@ -8,7 +8,6 @@ import useHasMounted from 'hooks/useHasMounted';
 import parse from 'html-react-parser';
 import { useListAndMapContext } from 'modules/map/ListAndMapContext';
 import { FormattedMessage } from 'react-intl';
-import { textEllipsisAfterNLines } from 'services/cssHelpers';
 import styled from 'styled-components';
 import { getSpacing, MAX_WIDTH_MOBILE } from 'stylesheet';
 import { Attachment } from '../../../../../modules/interface';
@@ -43,9 +42,9 @@ export const DetailsCard: React.FC<DetailsCardProps> = ({
   const { truncateState, toggleTruncateState, heightState, detailsCardRef } = useDetailsCard();
   const descriptionStyled =
     truncateState === 'TRUNCATE' ? (
-      <TruncatedHtmlText className="text-greyDarkColored">
+      <HtmlText className="line-clamp-2 text-greyDarkColored">
         <div>{parse(description ?? '')}</div>
-      </TruncatedHtmlText>
+      </HtmlText>
     ) : (
       <HtmlText className="text-greyDarkColored">{parse(description ?? '')}</HtmlText>
     );
@@ -159,8 +158,4 @@ const DetailsCardContainer = styled.div<{ height: number }>`
     flex-direction: row;
     margin-bottom: ${getSpacing(6)};
   }
-`;
-
-const TruncatedHtmlText = styled(HtmlText)`
-  ${textEllipsisAfterNLines(2)}
 `;

--- a/frontend/src/components/pages/details/components/DetailsCard/DetailsCard.tsx
+++ b/frontend/src/components/pages/details/components/DetailsCard/DetailsCard.tsx
@@ -9,7 +9,9 @@ import parse from 'html-react-parser';
 import { useListAndMapContext } from 'modules/map/ListAndMapContext';
 import { FormattedMessage } from 'react-intl';
 import styled from 'styled-components';
-import { getSpacing, MAX_WIDTH_MOBILE } from 'stylesheet';
+import { MAX_WIDTH_MOBILE } from 'stylesheet';
+import { cn } from 'services/utils/cn';
+import { Arrow } from 'components/Icons/Arrow';
 import { Attachment } from '../../../../../modules/interface';
 import { useDetailsCard } from './useDetailsCard';
 export interface DetailsCardProps {
@@ -42,7 +44,7 @@ export const DetailsCard: React.FC<DetailsCardProps> = ({
   const { truncateState, toggleTruncateState, heightState, detailsCardRef } = useDetailsCard();
   const descriptionStyled =
     truncateState === 'TRUNCATE' ? (
-      <HtmlText className="line-clamp-2 text-greyDarkColored">
+      <HtmlText className="line-clamp-2 desktop:line-clamp-5 text-greyDarkColored">
         <div>{parse(description ?? '')}</div>
       </HtmlText>
     ) : (
@@ -56,11 +58,13 @@ export const DetailsCard: React.FC<DetailsCardProps> = ({
   return (
     <DetailsCardContainer
       height={heightState}
-      className={`border border-solid border-greySoft rounded-card
+      className={cn(
+        `border border-solid border-greySoft rounded-card
       flex-none overflow-hidden relative
-      flex flex-col h-auto desktop:flex-row desktop:w-auto mx-1
-      cursor-pointer hover:border-blackSemiTransparent transition-all duration-500
-      ${className}`}
+      flex flex-col h-fit desktop:flex-row desktop:w-auto mx-1 desktop:mb-6
+      hover:border-blackSemiTransparent transition-all duration-500`,
+        className,
+      )}
       onMouseEnter={() => {
         setHoveredCardId(id);
       }}
@@ -68,7 +72,7 @@ export const DetailsCard: React.FC<DetailsCardProps> = ({
         setHoveredCardId(null);
       }}
     >
-      <div className="flex-none desktop:w-2/5">
+      <div className="flex shrink-0 desktop:w-2/5">
         <Modal>
           {({ isFullscreen, toggleFullscreen }) => (
             <>
@@ -105,7 +109,7 @@ export const DetailsCard: React.FC<DetailsCardProps> = ({
           </OptionalLink>
         )}
         <OptionalLink redirectionUrl={redirectionUrl}>
-          <p className="text-Mobile-C1 desktop:text-H4 text-primary1 font-bold">{name}</p>
+          <h3 className="text-Mobile-C1 desktop:text-H4 text-primary1 font-bold">{name}</h3>
         </OptionalLink>
         {Boolean(description) && (
           <div
@@ -114,14 +118,27 @@ export const DetailsCard: React.FC<DetailsCardProps> = ({
             text-Mobile-C2 desktop:text-P1 text-greyDarkColored"
           >
             <OptionalLink redirectionUrl={redirectionUrl}>{descriptionStyled}</OptionalLink>
-            <span
-              className="text-primary1 underline cursor-pointer shrink-0 desktop:ml-1"
-              onClick={toggleTruncateState}
-            >
-              <FormattedMessage
-                id={truncateState === 'TRUNCATE' ? 'details.readMore' : 'details.readLess'}
-              />
-            </span>
+            {truncateState !== 'NONE' && (
+              <button
+                className="flex items-center text-primary1 underline shrink-0 gap-1 desktop:ml-1"
+                onClick={toggleTruncateState}
+                type="button"
+                aria-hidden
+              >
+                <span className="shrink-0">
+                  <FormattedMessage
+                    id={truncateState === 'TRUNCATE' ? 'details.readMore' : 'details.readLess'}
+                  />
+                </span>
+                <Arrow
+                  size={20}
+                  className={cn(
+                    'shrink-0 transition',
+                    truncateState === 'TRUNCATE' ? 'rotate-90' : '-rotate-90',
+                  )}
+                />
+              </button>
+            )}
           </div>
         )}
       </div>
@@ -142,20 +159,8 @@ const OptionalLink: React.FC<OptionalLinkProps> = ({ redirectionUrl, children })
   );
 };
 
-const DetailsCardContainer = styled.div<{ height: number }>`
-  height: fit-content;
-  flex: none;
-  overflow: hidden;
-  display: flex;
-  // Fix for border radius + overflow hidden in Safari, see https://gist.github.com/ayamflow/b602ab436ac9f05660d9c15190f4fd7b
-  -webkit-mask-image: -webkit-radial-gradient(white, black);
-  mask-image: radial-gradient(white, black);
-  position: relative;
-  flex-direction: column;
+const DetailsCardContainer = styled.li<{ height: number }>`
   @media (min-width: ${MAX_WIDTH_MOBILE}px) {
     height: ${props => props.height}px;
-    width: auto;
-    flex-direction: row;
-    margin-bottom: ${getSpacing(6)};
   }
 `;

--- a/frontend/src/components/pages/details/components/DetailsCard/__tests__/__snapshots__/DetailsCard.test.tsx.snap
+++ b/frontend/src/components/pages/details/components/DetailsCard/__tests__/__snapshots__/DetailsCard.test.tsx.snap
@@ -13,7 +13,340 @@ Object {
           class="flex shrink-0 desktop:w-2/5"
         >
           <div
-            class="relative bg-dark"
+            class="w-full"
+          >
+            <div
+              class="relative bg-dark h-full"
+            >
+              <div
+                class="flex items-center justify-center w-full h-full"
+              >
+                <div
+                  class="w-full h-full"
+                >
+                  <span
+                    class="relative h-coverDetailsMobile desktop:h-coverDetailsDesktop"
+                  >
+                    <figure
+                      aria-labelledby=":r2:"
+                      class="relative "
+                      id="details_cover_image"
+                      role="figure"
+                    >
+                      <img
+                        alt="Lorem ipsum"
+                        class="overflow-hidden w-full h-full object-cover object-center"
+                        id=":r3:"
+                        loading="lazy"
+                        src="https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_400.jpg"
+                      />
+                      <figcaption
+                        id=":r2:"
+                      >
+                        <span
+                          class="w-full h-12 desktop:h-40
+  absolute top-0 flex items-start justify-center
+  pb-1 pt-3 px-2
+  bg-gradient-to-b from-blackSemiTransparent to-transparent
+  text-white text-opacity-90 text-Mobile-C3 desktop:text-P2"
+                        >
+                          <span
+                            class="mx-10percent px-10percent truncate"
+                          >
+                            Lorem ipsum - Lorem ipsum
+                          </span>
+                        </span>
+                        <button
+                          aria-describedby=":r3:"
+                          class="absolute inset-0 w-full h-full"
+                          type="button"
+                        >
+                          <span
+                            class="sr-only"
+                          >
+                            Voir l'image en plein écran
+                          </span>
+                        </button>
+                      </figcaption>
+                    </figure>
+                  </span>
+                </div>
+              </div>
+            </div>
+            <div
+              class="sc-bcXHqe hQbWpf absolute top-4 left-4 h-8 flex items-center rounded-full shadow-sm text-white border-2 border-white border-solid overflow-hidden"
+              color="#AA397D"
+            >
+              <div
+                class="pr-3 whitespace-nowrap"
+              >
+                Randonnée pédestre
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="flex flex-col relative
+        p-2 desktop:p-6 desktop:my-auto"
+        >
+          <h3
+            class="text-Mobile-C1 desktop:text-H4 text-primary1 font-bold"
+          >
+            Église St Louis
+          </h3>
+          <div
+            class="mt-1 desktop:mt-4 flex flex-col desktop:flex-row desktop:items-end text-Mobile-C2 desktop:text-P1 text-greyDarkColored"
+          >
+            <div
+              class="sc-kDvujY iXXQYE text-greyDarkColored"
+            >
+              <span>
+                Pour espérer apercevoir cet oiseau, partir la nuit au printemps, parcourir un grand dénivelé afin d'arriver sur son terrain de prédilection à plus de 2000 m voire 3000 m d'altitude avant le lever du jour et là, entendre le chant guttural caractéristique qui trahit sa présence. Mais pour le voir, il faudra bien ouvrir les yeux ou se munir d'une paire de jumelles. Et alors là, quel bonheur ! Le lagopède alpin est l'espèce arctique par excellence, menacée entre autre par le réchauffement climatique. Il fait partie des espèces à protéger dans le cœur du Parc national des Ecrins.
+              </span>
+            </div>
+          </div>
+        </div>
+      </li>
+    </div>
+    <div>
+      <li
+        class="sc-ipEyDJ fEmItQ border border-solid border-greySoft rounded-card flex-none overflow-hidden relative flex flex-col h-fit desktop:flex-row desktop:w-auto mx-1 desktop:mb-6 hover:border-blackSemiTransparent transition-all duration-500"
+        height="0"
+      >
+        <div
+          class="flex shrink-0 desktop:w-2/5"
+        >
+          <div
+            class="w-full"
+          >
+            <div
+              class="relative bg-dark h-full"
+            >
+              <div
+                class="flex items-center justify-center w-full h-full"
+              >
+                <div
+                  class="w-full h-full"
+                >
+                  <div
+                    class="slick-slider sc-dkrFOg elmwrv relative h-coverDetailsMobile desktop:h-coverDetailsDesktop slick-initialized"
+                    dir="ltr"
+                  >
+                    <button
+                      class="sc-hLBbgP sc-jSUZER sc-pyfCe fmYHPc gDGNxP kdsrVF slick-arrow slick-prev"
+                      type="button"
+                    />
+                    <div
+                      class="slick-list"
+                    >
+                      <div
+                        class="slick-track"
+                        style="opacity: 1; transform: translate3d(0px, 0px, 0px);"
+                      >
+                        <div
+                          aria-hidden="true"
+                          class="slick-slide slick-cloned"
+                          data-index="-1"
+                          style="width: 0px;"
+                          tabindex="-1"
+                        />
+                        <div
+                          aria-hidden="false"
+                          class="slick-slide slick-active slick-current"
+                          data-index="0"
+                          style="outline: none; width: 0px;"
+                          tabindex="-1"
+                        >
+                          <div>
+                            <figure
+                              aria-labelledby=":r8:"
+                              class="relative "
+                              id="details_cover_image"
+                              role="figure"
+                            >
+                              <img
+                                alt="Lorem ipsum"
+                                class="overflow-hidden w-full h-full object-cover object-center"
+                                id=":r9:"
+                                loading="lazy"
+                                src="https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_400.jpg"
+                              />
+                              <figcaption
+                                id=":r8:"
+                              >
+                                <span
+                                  class="w-full h-12 desktop:h-40
+  absolute top-0 flex items-start justify-center
+  pb-1 pt-3 px-2
+  bg-gradient-to-b from-blackSemiTransparent to-transparent
+  text-white text-opacity-90 text-Mobile-C3 desktop:text-P2"
+                                >
+                                  <span
+                                    class="mx-10percent px-10percent truncate"
+                                  >
+                                    Lorem ipsum - Lorem ipsum
+                                  </span>
+                                </span>
+                                <button
+                                  aria-describedby=":r9:"
+                                  class="absolute inset-0 w-full h-full"
+                                  type="button"
+                                >
+                                  <span
+                                    class="sr-only"
+                                  >
+                                    Voir l'image en plein écran
+                                  </span>
+                                </button>
+                              </figcaption>
+                            </figure>
+                          </div>
+                        </div>
+                        <div
+                          aria-hidden="true"
+                          class="slick-slide"
+                          data-index="1"
+                          style="outline: none; width: 0px;"
+                          tabindex="-1"
+                        />
+                        <div
+                          aria-hidden="true"
+                          class="slick-slide slick-cloned"
+                          data-index="2"
+                          style="width: 0px;"
+                          tabindex="-1"
+                        >
+                          <div>
+                            <figure
+                              aria-labelledby=":ra:"
+                              class="relative "
+                              id="details_cover_image"
+                              role="figure"
+                            >
+                              <img
+                                alt="Lorem ipsum"
+                                class="overflow-hidden w-full h-full object-cover object-center"
+                                id=":rb:"
+                                loading="lazy"
+                                src="https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_400.jpg"
+                              />
+                              <figcaption
+                                id=":ra:"
+                              >
+                                <span
+                                  class="w-full h-12 desktop:h-40
+  absolute top-0 flex items-start justify-center
+  pb-1 pt-3 px-2
+  bg-gradient-to-b from-blackSemiTransparent to-transparent
+  text-white text-opacity-90 text-Mobile-C3 desktop:text-P2"
+                                >
+                                  <span
+                                    class="mx-10percent px-10percent truncate"
+                                  >
+                                    Lorem ipsum - Lorem ipsum
+                                  </span>
+                                </span>
+                                <button
+                                  aria-describedby=":rb:"
+                                  class="absolute inset-0 w-full h-full"
+                                  type="button"
+                                >
+                                  <span
+                                    class="sr-only"
+                                  >
+                                    Voir l'image en plein écran
+                                  </span>
+                                </button>
+                              </figcaption>
+                            </figure>
+                          </div>
+                        </div>
+                        <div
+                          aria-hidden="true"
+                          class="slick-slide slick-cloned"
+                          data-index="3"
+                          style="width: 0px;"
+                          tabindex="-1"
+                        />
+                      </div>
+                    </div>
+                    <button
+                      class="sc-hLBbgP sc-jSUZER sc-ftTHYK fmYHPc gDGNxP gPrhgT slick-arrow slick-next"
+                      type="button"
+                    />
+                    <div
+                      class="sc-jrcTuL eNRqSA slick-dots"
+                    >
+                      <ul>
+                        <li
+                          class="slick-active"
+                        >
+                          <button>
+                            1
+                          </button>
+                        </li>
+                        <li
+                          class=""
+                        >
+                          <button>
+                            2
+                          </button>
+                        </li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="sc-bcXHqe hQbWpf absolute top-4 left-4 h-8 flex items-center rounded-full shadow-sm text-white border-2 border-white border-solid overflow-hidden"
+              color="#AA397D"
+            >
+              <div
+                class="pr-3 whitespace-nowrap"
+              >
+                Randonnée pédestre
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="flex flex-col relative
+        p-2 desktop:p-6 desktop:my-auto"
+        >
+          <h3
+            class="text-Mobile-C1 desktop:text-H4 text-primary1 font-bold"
+          >
+            Église St Louis
+          </h3>
+          <div
+            class="mt-1 desktop:mt-4 flex flex-col desktop:flex-row desktop:items-end text-Mobile-C2 desktop:text-P1 text-greyDarkColored"
+          >
+            <div
+              class="sc-kDvujY iXXQYE text-greyDarkColored"
+            >
+              <span>
+                Pour espérer apercevoir cet oiseau, partir la nuit au printemps, parcourir un grand dénivelé afin d'arriver sur son terrain de prédilection à plus de 2000 m voire 3000 m d'altitude avant le lever du jour et là, entendre le chant guttural caractéristique qui trahit sa présence. Mais pour le voir, il faudra bien ouvrir les yeux ou se munir d'une paire de jumelles. Et alors là, quel bonheur ! Le lagopède alpin est l'espèce arctique par excellence, menacée entre autre par le réchauffement climatique. Il fait partie des espèces à protéger dans le cœur du Parc national des Ecrins.
+              </span>
+            </div>
+          </div>
+        </div>
+      </li>
+    </div>
+  </body>,
+  "container": <div>
+    <li
+      class="sc-ipEyDJ fEmItQ border border-solid border-greySoft rounded-card flex-none overflow-hidden relative flex flex-col h-fit desktop:flex-row desktop:w-auto mx-1 desktop:mb-6 hover:border-blackSemiTransparent transition-all duration-500"
+      height="0"
+    >
+      <div
+        class="flex shrink-0 desktop:w-2/5"
+      >
+        <div
+          class="w-full"
+        >
+          <div
+            class="relative bg-dark h-full"
           >
             <div
               class="flex items-center justify-center w-full h-full"
@@ -32,7 +365,7 @@ Object {
                   >
                     <img
                       alt="Lorem ipsum"
-                      class="object-center overflow-hidden w-full h-full object-cover"
+                      class="overflow-hidden w-full h-full object-cover object-center"
                       id=":r3:"
                       loading="lazy"
                       src="https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_400.jpg"
@@ -79,327 +412,6 @@ Object {
             >
               Randonnée pédestre
             </div>
-          </div>
-        </div>
-        <div
-          class="flex flex-col relative
-        p-2 desktop:p-6 desktop:my-auto"
-        >
-          <h3
-            class="text-Mobile-C1 desktop:text-H4 text-primary1 font-bold"
-          >
-            Église St Louis
-          </h3>
-          <div
-            class="mt-1 desktop:mt-4 flex flex-col desktop:flex-row desktop:items-end text-Mobile-C2 desktop:text-P1 text-greyDarkColored"
-          >
-            <div
-              class="sc-kDvujY iXXQYE text-greyDarkColored"
-            >
-              <span>
-                Pour espérer apercevoir cet oiseau, partir la nuit au printemps, parcourir un grand dénivelé afin d'arriver sur son terrain de prédilection à plus de 2000 m voire 3000 m d'altitude avant le lever du jour et là, entendre le chant guttural caractéristique qui trahit sa présence. Mais pour le voir, il faudra bien ouvrir les yeux ou se munir d'une paire de jumelles. Et alors là, quel bonheur ! Le lagopède alpin est l'espèce arctique par excellence, menacée entre autre par le réchauffement climatique. Il fait partie des espèces à protéger dans le cœur du Parc national des Ecrins.
-              </span>
-            </div>
-          </div>
-        </div>
-      </li>
-    </div>
-    <div>
-      <li
-        class="sc-ipEyDJ fEmItQ border border-solid border-greySoft rounded-card flex-none overflow-hidden relative flex flex-col h-fit desktop:flex-row desktop:w-auto mx-1 desktop:mb-6 hover:border-blackSemiTransparent transition-all duration-500"
-        height="0"
-      >
-        <div
-          class="flex shrink-0 desktop:w-2/5"
-        >
-          <div
-            class="relative bg-dark"
-          >
-            <div
-              class="flex items-center justify-center w-full h-full"
-            >
-              <div
-                class="w-full h-full"
-              >
-                <div
-                  class="slick-slider sc-dkrFOg elmwrv relative h-coverDetailsMobile desktop:h-coverDetailsDesktop slick-initialized"
-                  dir="ltr"
-                >
-                  <button
-                    class="sc-hLBbgP sc-jSUZER sc-pyfCe fmYHPc gDGNxP kdsrVF slick-arrow slick-prev"
-                    type="button"
-                  />
-                  <div
-                    class="slick-list"
-                  >
-                    <div
-                      class="slick-track"
-                      style="opacity: 1; transform: translate3d(0px, 0px, 0px);"
-                    >
-                      <div
-                        aria-hidden="true"
-                        class="slick-slide slick-cloned"
-                        data-index="-1"
-                        style="width: 0px;"
-                        tabindex="-1"
-                      />
-                      <div
-                        aria-hidden="false"
-                        class="slick-slide slick-active slick-current"
-                        data-index="0"
-                        style="outline: none; width: 0px;"
-                        tabindex="-1"
-                      >
-                        <div>
-                          <figure
-                            aria-labelledby=":r8:"
-                            class="relative "
-                            id="details_cover_image"
-                            role="figure"
-                          >
-                            <img
-                              alt="Lorem ipsum"
-                              class="object-center overflow-hidden w-full h-full object-cover"
-                              id=":r9:"
-                              loading="lazy"
-                              src="https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_400.jpg"
-                            />
-                            <figcaption
-                              id=":r8:"
-                            >
-                              <span
-                                class="w-full h-12 desktop:h-40
-  absolute top-0 flex items-start justify-center
-  pb-1 pt-3 px-2
-  bg-gradient-to-b from-blackSemiTransparent to-transparent
-  text-white text-opacity-90 text-Mobile-C3 desktop:text-P2"
-                              >
-                                <span
-                                  class="mx-10percent px-10percent truncate"
-                                >
-                                  Lorem ipsum - Lorem ipsum
-                                </span>
-                              </span>
-                              <button
-                                aria-describedby=":r9:"
-                                class="absolute inset-0 w-full h-full"
-                                type="button"
-                              >
-                                <span
-                                  class="sr-only"
-                                >
-                                  Voir l'image en plein écran
-                                </span>
-                              </button>
-                            </figcaption>
-                          </figure>
-                        </div>
-                      </div>
-                      <div
-                        aria-hidden="true"
-                        class="slick-slide"
-                        data-index="1"
-                        style="outline: none; width: 0px;"
-                        tabindex="-1"
-                      />
-                      <div
-                        aria-hidden="true"
-                        class="slick-slide slick-cloned"
-                        data-index="2"
-                        style="width: 0px;"
-                        tabindex="-1"
-                      >
-                        <div>
-                          <figure
-                            aria-labelledby=":ra:"
-                            class="relative "
-                            id="details_cover_image"
-                            role="figure"
-                          >
-                            <img
-                              alt="Lorem ipsum"
-                              class="object-center overflow-hidden w-full h-full object-cover"
-                              id=":rb:"
-                              loading="lazy"
-                              src="https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_400.jpg"
-                            />
-                            <figcaption
-                              id=":ra:"
-                            >
-                              <span
-                                class="w-full h-12 desktop:h-40
-  absolute top-0 flex items-start justify-center
-  pb-1 pt-3 px-2
-  bg-gradient-to-b from-blackSemiTransparent to-transparent
-  text-white text-opacity-90 text-Mobile-C3 desktop:text-P2"
-                              >
-                                <span
-                                  class="mx-10percent px-10percent truncate"
-                                >
-                                  Lorem ipsum - Lorem ipsum
-                                </span>
-                              </span>
-                              <button
-                                aria-describedby=":rb:"
-                                class="absolute inset-0 w-full h-full"
-                                type="button"
-                              >
-                                <span
-                                  class="sr-only"
-                                >
-                                  Voir l'image en plein écran
-                                </span>
-                              </button>
-                            </figcaption>
-                          </figure>
-                        </div>
-                      </div>
-                      <div
-                        aria-hidden="true"
-                        class="slick-slide slick-cloned"
-                        data-index="3"
-                        style="width: 0px;"
-                        tabindex="-1"
-                      />
-                    </div>
-                  </div>
-                  <button
-                    class="sc-hLBbgP sc-jSUZER sc-ftTHYK fmYHPc gDGNxP gPrhgT slick-arrow slick-next"
-                    type="button"
-                  />
-                  <div
-                    class="sc-jrcTuL eNRqSA slick-dots"
-                  >
-                    <ul>
-                      <li
-                        class="slick-active"
-                      >
-                        <button>
-                          1
-                        </button>
-                      </li>
-                      <li
-                        class=""
-                      >
-                        <button>
-                          2
-                        </button>
-                      </li>
-                    </ul>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="sc-bcXHqe hQbWpf absolute top-4 left-4 h-8 flex items-center rounded-full shadow-sm text-white border-2 border-white border-solid overflow-hidden"
-            color="#AA397D"
-          >
-            <div
-              class="pr-3 whitespace-nowrap"
-            >
-              Randonnée pédestre
-            </div>
-          </div>
-        </div>
-        <div
-          class="flex flex-col relative
-        p-2 desktop:p-6 desktop:my-auto"
-        >
-          <h3
-            class="text-Mobile-C1 desktop:text-H4 text-primary1 font-bold"
-          >
-            Église St Louis
-          </h3>
-          <div
-            class="mt-1 desktop:mt-4 flex flex-col desktop:flex-row desktop:items-end text-Mobile-C2 desktop:text-P1 text-greyDarkColored"
-          >
-            <div
-              class="sc-kDvujY iXXQYE text-greyDarkColored"
-            >
-              <span>
-                Pour espérer apercevoir cet oiseau, partir la nuit au printemps, parcourir un grand dénivelé afin d'arriver sur son terrain de prédilection à plus de 2000 m voire 3000 m d'altitude avant le lever du jour et là, entendre le chant guttural caractéristique qui trahit sa présence. Mais pour le voir, il faudra bien ouvrir les yeux ou se munir d'une paire de jumelles. Et alors là, quel bonheur ! Le lagopède alpin est l'espèce arctique par excellence, menacée entre autre par le réchauffement climatique. Il fait partie des espèces à protéger dans le cœur du Parc national des Ecrins.
-              </span>
-            </div>
-          </div>
-        </div>
-      </li>
-    </div>
-  </body>,
-  "container": <div>
-    <li
-      class="sc-ipEyDJ fEmItQ border border-solid border-greySoft rounded-card flex-none overflow-hidden relative flex flex-col h-fit desktop:flex-row desktop:w-auto mx-1 desktop:mb-6 hover:border-blackSemiTransparent transition-all duration-500"
-      height="0"
-    >
-      <div
-        class="flex shrink-0 desktop:w-2/5"
-      >
-        <div
-          class="relative bg-dark"
-        >
-          <div
-            class="flex items-center justify-center w-full h-full"
-          >
-            <div
-              class="w-full h-full"
-            >
-              <span
-                class="relative h-coverDetailsMobile desktop:h-coverDetailsDesktop"
-              >
-                <figure
-                  aria-labelledby=":r2:"
-                  class="relative "
-                  id="details_cover_image"
-                  role="figure"
-                >
-                  <img
-                    alt="Lorem ipsum"
-                    class="object-center overflow-hidden w-full h-full object-cover"
-                    id=":r3:"
-                    loading="lazy"
-                    src="https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_400.jpg"
-                  />
-                  <figcaption
-                    id=":r2:"
-                  >
-                    <span
-                      class="w-full h-12 desktop:h-40
-  absolute top-0 flex items-start justify-center
-  pb-1 pt-3 px-2
-  bg-gradient-to-b from-blackSemiTransparent to-transparent
-  text-white text-opacity-90 text-Mobile-C3 desktop:text-P2"
-                    >
-                      <span
-                        class="mx-10percent px-10percent truncate"
-                      >
-                        Lorem ipsum - Lorem ipsum
-                      </span>
-                    </span>
-                    <button
-                      aria-describedby=":r3:"
-                      class="absolute inset-0 w-full h-full"
-                      type="button"
-                    >
-                      <span
-                        class="sr-only"
-                      >
-                        Voir l'image en plein écran
-                      </span>
-                    </button>
-                  </figcaption>
-                </figure>
-              </span>
-            </div>
-          </div>
-        </div>
-        <div
-          class="sc-bcXHqe hQbWpf absolute top-4 left-4 h-8 flex items-center rounded-full shadow-sm text-white border-2 border-white border-solid overflow-hidden"
-          color="#AA397D"
-        >
-          <div
-            class="pr-3 whitespace-nowrap"
-          >
-            Randonnée pédestre
           </div>
         </div>
       </div>
@@ -493,71 +505,75 @@ Object {
           class="flex shrink-0 desktop:w-2/5"
         >
           <div
-            class="relative bg-dark"
+            class="w-full"
           >
             <div
-              class="flex items-center justify-center w-full h-full"
+              class="relative bg-dark h-full"
             >
               <div
-                class="w-full h-full"
+                class="flex items-center justify-center w-full h-full"
               >
-                <span
-                  class="relative h-coverDetailsMobile desktop:h-coverDetailsDesktop"
+                <div
+                  class="w-full h-full"
                 >
-                  <figure
-                    aria-labelledby=":r2:"
-                    class="relative "
-                    id="details_cover_image"
-                    role="figure"
+                  <span
+                    class="relative h-coverDetailsMobile desktop:h-coverDetailsDesktop"
                   >
-                    <img
-                      alt="Lorem ipsum"
-                      class="object-center overflow-hidden w-full h-full object-cover"
-                      id=":r3:"
-                      loading="lazy"
-                      src="https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_400.jpg"
-                    />
-                    <figcaption
-                      id=":r2:"
+                    <figure
+                      aria-labelledby=":r2:"
+                      class="relative "
+                      id="details_cover_image"
+                      role="figure"
                     >
-                      <span
-                        class="w-full h-12 desktop:h-40
+                      <img
+                        alt="Lorem ipsum"
+                        class="overflow-hidden w-full h-full object-cover object-center"
+                        id=":r3:"
+                        loading="lazy"
+                        src="https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_400.jpg"
+                      />
+                      <figcaption
+                        id=":r2:"
+                      >
+                        <span
+                          class="w-full h-12 desktop:h-40
   absolute top-0 flex items-start justify-center
   pb-1 pt-3 px-2
   bg-gradient-to-b from-blackSemiTransparent to-transparent
   text-white text-opacity-90 text-Mobile-C3 desktop:text-P2"
-                      >
-                        <span
-                          class="mx-10percent px-10percent truncate"
                         >
-                          Lorem ipsum - Lorem ipsum
+                          <span
+                            class="mx-10percent px-10percent truncate"
+                          >
+                            Lorem ipsum - Lorem ipsum
+                          </span>
                         </span>
-                      </span>
-                      <button
-                        aria-describedby=":r3:"
-                        class="absolute inset-0 w-full h-full"
-                        type="button"
-                      >
-                        <span
-                          class="sr-only"
+                        <button
+                          aria-describedby=":r3:"
+                          class="absolute inset-0 w-full h-full"
+                          type="button"
                         >
-                          Voir l'image en plein écran
-                        </span>
-                      </button>
-                    </figcaption>
-                  </figure>
-                </span>
+                          <span
+                            class="sr-only"
+                          >
+                            Voir l'image en plein écran
+                          </span>
+                        </button>
+                      </figcaption>
+                    </figure>
+                  </span>
+                </div>
               </div>
             </div>
-          </div>
-          <div
-            class="sc-bcXHqe hQbWpf absolute top-4 left-4 h-8 flex items-center rounded-full shadow-sm text-white border-2 border-white border-solid overflow-hidden"
-            color="#AA397D"
-          >
             <div
-              class="pr-3 whitespace-nowrap"
+              class="sc-bcXHqe hQbWpf absolute top-4 left-4 h-8 flex items-center rounded-full shadow-sm text-white border-2 border-white border-solid overflow-hidden"
+              color="#AA397D"
             >
-              Randonnée pédestre
+              <div
+                class="pr-3 whitespace-nowrap"
+              >
+                Randonnée pédestre
+              </div>
             </div>
           </div>
         </div>
@@ -593,7 +609,236 @@ Object {
           class="flex shrink-0 desktop:w-2/5"
         >
           <div
-            class="relative bg-dark"
+            class="w-full"
+          >
+            <div
+              class="relative bg-dark h-full"
+            >
+              <div
+                class="flex items-center justify-center w-full h-full"
+              >
+                <div
+                  class="w-full h-full"
+                >
+                  <div
+                    class="slick-slider sc-dkrFOg elmwrv relative h-coverDetailsMobile desktop:h-coverDetailsDesktop slick-initialized"
+                    dir="ltr"
+                  >
+                    <button
+                      class="sc-hLBbgP sc-jSUZER sc-pyfCe fmYHPc gDGNxP kdsrVF slick-arrow slick-prev"
+                      type="button"
+                    />
+                    <div
+                      class="slick-list"
+                    >
+                      <div
+                        class="slick-track"
+                        style="opacity: 1; transform: translate3d(0px, 0px, 0px);"
+                      >
+                        <div
+                          aria-hidden="true"
+                          class="slick-slide slick-cloned"
+                          data-index="-1"
+                          style="width: 0px;"
+                          tabindex="-1"
+                        />
+                        <div
+                          aria-hidden="false"
+                          class="slick-slide slick-active slick-current"
+                          data-index="0"
+                          style="outline: none; width: 0px;"
+                          tabindex="-1"
+                        >
+                          <div>
+                            <figure
+                              aria-labelledby=":r8:"
+                              class="relative "
+                              id="details_cover_image"
+                              role="figure"
+                            >
+                              <img
+                                alt="Lorem ipsum"
+                                class="overflow-hidden w-full h-full object-cover object-center"
+                                id=":r9:"
+                                loading="lazy"
+                                src="https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_400.jpg"
+                              />
+                              <figcaption
+                                id=":r8:"
+                              >
+                                <span
+                                  class="w-full h-12 desktop:h-40
+  absolute top-0 flex items-start justify-center
+  pb-1 pt-3 px-2
+  bg-gradient-to-b from-blackSemiTransparent to-transparent
+  text-white text-opacity-90 text-Mobile-C3 desktop:text-P2"
+                                >
+                                  <span
+                                    class="mx-10percent px-10percent truncate"
+                                  >
+                                    Lorem ipsum - Lorem ipsum
+                                  </span>
+                                </span>
+                                <button
+                                  aria-describedby=":r9:"
+                                  class="absolute inset-0 w-full h-full"
+                                  type="button"
+                                >
+                                  <span
+                                    class="sr-only"
+                                  >
+                                    Voir l'image en plein écran
+                                  </span>
+                                </button>
+                              </figcaption>
+                            </figure>
+                          </div>
+                        </div>
+                        <div
+                          aria-hidden="true"
+                          class="slick-slide"
+                          data-index="1"
+                          style="outline: none; width: 0px;"
+                          tabindex="-1"
+                        />
+                        <div
+                          aria-hidden="true"
+                          class="slick-slide slick-cloned"
+                          data-index="2"
+                          style="width: 0px;"
+                          tabindex="-1"
+                        >
+                          <div>
+                            <figure
+                              aria-labelledby=":ra:"
+                              class="relative "
+                              id="details_cover_image"
+                              role="figure"
+                            >
+                              <img
+                                alt="Lorem ipsum"
+                                class="overflow-hidden w-full h-full object-cover object-center"
+                                id=":rb:"
+                                loading="lazy"
+                                src="https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_400.jpg"
+                              />
+                              <figcaption
+                                id=":ra:"
+                              >
+                                <span
+                                  class="w-full h-12 desktop:h-40
+  absolute top-0 flex items-start justify-center
+  pb-1 pt-3 px-2
+  bg-gradient-to-b from-blackSemiTransparent to-transparent
+  text-white text-opacity-90 text-Mobile-C3 desktop:text-P2"
+                                >
+                                  <span
+                                    class="mx-10percent px-10percent truncate"
+                                  >
+                                    Lorem ipsum - Lorem ipsum
+                                  </span>
+                                </span>
+                                <button
+                                  aria-describedby=":rb:"
+                                  class="absolute inset-0 w-full h-full"
+                                  type="button"
+                                >
+                                  <span
+                                    class="sr-only"
+                                  >
+                                    Voir l'image en plein écran
+                                  </span>
+                                </button>
+                              </figcaption>
+                            </figure>
+                          </div>
+                        </div>
+                        <div
+                          aria-hidden="true"
+                          class="slick-slide slick-cloned"
+                          data-index="3"
+                          style="width: 0px;"
+                          tabindex="-1"
+                        />
+                      </div>
+                    </div>
+                    <button
+                      class="sc-hLBbgP sc-jSUZER sc-ftTHYK fmYHPc gDGNxP gPrhgT slick-arrow slick-next"
+                      type="button"
+                    />
+                    <div
+                      class="sc-jrcTuL eNRqSA slick-dots"
+                    >
+                      <ul>
+                        <li
+                          class="slick-active"
+                        >
+                          <button>
+                            1
+                          </button>
+                        </li>
+                        <li
+                          class=""
+                        >
+                          <button>
+                            2
+                          </button>
+                        </li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="sc-bcXHqe hQbWpf absolute top-4 left-4 h-8 flex items-center rounded-full shadow-sm text-white border-2 border-white border-solid overflow-hidden"
+              color="#AA397D"
+            >
+              <div
+                class="pr-3 whitespace-nowrap"
+              >
+                Randonnée pédestre
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="flex flex-col relative
+        p-2 desktop:p-6 desktop:my-auto"
+        >
+          <h3
+            class="text-Mobile-C1 desktop:text-H4 text-primary1 font-bold"
+          >
+            Église St Louis
+          </h3>
+          <div
+            class="mt-1 desktop:mt-4 flex flex-col desktop:flex-row desktop:items-end text-Mobile-C2 desktop:text-P1 text-greyDarkColored"
+          >
+            <div
+              class="sc-kDvujY iXXQYE text-greyDarkColored"
+            >
+              <span>
+                Pour espérer apercevoir cet oiseau, partir la nuit au printemps, parcourir un grand dénivelé afin d'arriver sur son terrain de prédilection à plus de 2000 m voire 3000 m d'altitude avant le lever du jour et là, entendre le chant guttural caractéristique qui trahit sa présence. Mais pour le voir, il faudra bien ouvrir les yeux ou se munir d'une paire de jumelles. Et alors là, quel bonheur ! Le lagopède alpin est l'espèce arctique par excellence, menacée entre autre par le réchauffement climatique. Il fait partie des espèces à protéger dans le cœur du Parc national des Ecrins.
+              </span>
+            </div>
+          </div>
+        </div>
+      </li>
+    </div>
+  </body>,
+  "container": <div>
+    <li
+      class="sc-ipEyDJ fEmItQ border border-solid border-greySoft rounded-card flex-none overflow-hidden relative flex flex-col h-fit desktop:flex-row desktop:w-auto mx-1 desktop:mb-6 hover:border-blackSemiTransparent transition-all duration-500"
+      height="0"
+    >
+      <div
+        class="flex shrink-0 desktop:w-2/5"
+      >
+        <div
+          class="w-full"
+        >
+          <div
+            class="relative bg-dark h-full"
           >
             <div
               class="flex items-center justify-center w-full h-full"
@@ -639,7 +884,7 @@ Object {
                           >
                             <img
                               alt="Lorem ipsum"
-                              class="object-center overflow-hidden w-full h-full object-cover"
+                              class="overflow-hidden w-full h-full object-cover object-center"
                               id=":r9:"
                               loading="lazy"
                               src="https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_400.jpg"
@@ -698,7 +943,7 @@ Object {
                           >
                             <img
                               alt="Lorem ipsum"
-                              class="object-center overflow-hidden w-full h-full object-cover"
+                              class="overflow-hidden w-full h-full object-cover object-center"
                               id=":rb:"
                               loading="lazy"
                               src="https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_400.jpg"
@@ -780,227 +1025,6 @@ Object {
             >
               Randonnée pédestre
             </div>
-          </div>
-        </div>
-        <div
-          class="flex flex-col relative
-        p-2 desktop:p-6 desktop:my-auto"
-        >
-          <h3
-            class="text-Mobile-C1 desktop:text-H4 text-primary1 font-bold"
-          >
-            Église St Louis
-          </h3>
-          <div
-            class="mt-1 desktop:mt-4 flex flex-col desktop:flex-row desktop:items-end text-Mobile-C2 desktop:text-P1 text-greyDarkColored"
-          >
-            <div
-              class="sc-kDvujY iXXQYE text-greyDarkColored"
-            >
-              <span>
-                Pour espérer apercevoir cet oiseau, partir la nuit au printemps, parcourir un grand dénivelé afin d'arriver sur son terrain de prédilection à plus de 2000 m voire 3000 m d'altitude avant le lever du jour et là, entendre le chant guttural caractéristique qui trahit sa présence. Mais pour le voir, il faudra bien ouvrir les yeux ou se munir d'une paire de jumelles. Et alors là, quel bonheur ! Le lagopède alpin est l'espèce arctique par excellence, menacée entre autre par le réchauffement climatique. Il fait partie des espèces à protéger dans le cœur du Parc national des Ecrins.
-              </span>
-            </div>
-          </div>
-        </div>
-      </li>
-    </div>
-  </body>,
-  "container": <div>
-    <li
-      class="sc-ipEyDJ fEmItQ border border-solid border-greySoft rounded-card flex-none overflow-hidden relative flex flex-col h-fit desktop:flex-row desktop:w-auto mx-1 desktop:mb-6 hover:border-blackSemiTransparent transition-all duration-500"
-      height="0"
-    >
-      <div
-        class="flex shrink-0 desktop:w-2/5"
-      >
-        <div
-          class="relative bg-dark"
-        >
-          <div
-            class="flex items-center justify-center w-full h-full"
-          >
-            <div
-              class="w-full h-full"
-            >
-              <div
-                class="slick-slider sc-dkrFOg elmwrv relative h-coverDetailsMobile desktop:h-coverDetailsDesktop slick-initialized"
-                dir="ltr"
-              >
-                <button
-                  class="sc-hLBbgP sc-jSUZER sc-pyfCe fmYHPc gDGNxP kdsrVF slick-arrow slick-prev"
-                  type="button"
-                />
-                <div
-                  class="slick-list"
-                >
-                  <div
-                    class="slick-track"
-                    style="opacity: 1; transform: translate3d(0px, 0px, 0px);"
-                  >
-                    <div
-                      aria-hidden="true"
-                      class="slick-slide slick-cloned"
-                      data-index="-1"
-                      style="width: 0px;"
-                      tabindex="-1"
-                    />
-                    <div
-                      aria-hidden="false"
-                      class="slick-slide slick-active slick-current"
-                      data-index="0"
-                      style="outline: none; width: 0px;"
-                      tabindex="-1"
-                    >
-                      <div>
-                        <figure
-                          aria-labelledby=":r8:"
-                          class="relative "
-                          id="details_cover_image"
-                          role="figure"
-                        >
-                          <img
-                            alt="Lorem ipsum"
-                            class="object-center overflow-hidden w-full h-full object-cover"
-                            id=":r9:"
-                            loading="lazy"
-                            src="https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_400.jpg"
-                          />
-                          <figcaption
-                            id=":r8:"
-                          >
-                            <span
-                              class="w-full h-12 desktop:h-40
-  absolute top-0 flex items-start justify-center
-  pb-1 pt-3 px-2
-  bg-gradient-to-b from-blackSemiTransparent to-transparent
-  text-white text-opacity-90 text-Mobile-C3 desktop:text-P2"
-                            >
-                              <span
-                                class="mx-10percent px-10percent truncate"
-                              >
-                                Lorem ipsum - Lorem ipsum
-                              </span>
-                            </span>
-                            <button
-                              aria-describedby=":r9:"
-                              class="absolute inset-0 w-full h-full"
-                              type="button"
-                            >
-                              <span
-                                class="sr-only"
-                              >
-                                Voir l'image en plein écran
-                              </span>
-                            </button>
-                          </figcaption>
-                        </figure>
-                      </div>
-                    </div>
-                    <div
-                      aria-hidden="true"
-                      class="slick-slide"
-                      data-index="1"
-                      style="outline: none; width: 0px;"
-                      tabindex="-1"
-                    />
-                    <div
-                      aria-hidden="true"
-                      class="slick-slide slick-cloned"
-                      data-index="2"
-                      style="width: 0px;"
-                      tabindex="-1"
-                    >
-                      <div>
-                        <figure
-                          aria-labelledby=":ra:"
-                          class="relative "
-                          id="details_cover_image"
-                          role="figure"
-                        >
-                          <img
-                            alt="Lorem ipsum"
-                            class="object-center overflow-hidden w-full h-full object-cover"
-                            id=":rb:"
-                            loading="lazy"
-                            src="https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_400.jpg"
-                          />
-                          <figcaption
-                            id=":ra:"
-                          >
-                            <span
-                              class="w-full h-12 desktop:h-40
-  absolute top-0 flex items-start justify-center
-  pb-1 pt-3 px-2
-  bg-gradient-to-b from-blackSemiTransparent to-transparent
-  text-white text-opacity-90 text-Mobile-C3 desktop:text-P2"
-                            >
-                              <span
-                                class="mx-10percent px-10percent truncate"
-                              >
-                                Lorem ipsum - Lorem ipsum
-                              </span>
-                            </span>
-                            <button
-                              aria-describedby=":rb:"
-                              class="absolute inset-0 w-full h-full"
-                              type="button"
-                            >
-                              <span
-                                class="sr-only"
-                              >
-                                Voir l'image en plein écran
-                              </span>
-                            </button>
-                          </figcaption>
-                        </figure>
-                      </div>
-                    </div>
-                    <div
-                      aria-hidden="true"
-                      class="slick-slide slick-cloned"
-                      data-index="3"
-                      style="width: 0px;"
-                      tabindex="-1"
-                    />
-                  </div>
-                </div>
-                <button
-                  class="sc-hLBbgP sc-jSUZER sc-ftTHYK fmYHPc gDGNxP gPrhgT slick-arrow slick-next"
-                  type="button"
-                />
-                <div
-                  class="sc-jrcTuL eNRqSA slick-dots"
-                >
-                  <ul>
-                    <li
-                      class="slick-active"
-                    >
-                      <button>
-                        1
-                      </button>
-                    </li>
-                    <li
-                      class=""
-                    >
-                      <button>
-                        2
-                      </button>
-                    </li>
-                  </ul>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          class="sc-bcXHqe hQbWpf absolute top-4 left-4 h-8 flex items-center rounded-full shadow-sm text-white border-2 border-white border-solid overflow-hidden"
-          color="#AA397D"
-        >
-          <div
-            class="pr-3 whitespace-nowrap"
-          >
-            Randonnée pédestre
           </div>
         </div>
       </div>

--- a/frontend/src/components/pages/details/components/DetailsCard/__tests__/__snapshots__/DetailsCard.test.tsx.snap
+++ b/frontend/src/components/pages/details/components/DetailsCard/__tests__/__snapshots__/DetailsCard.test.tsx.snap
@@ -5,16 +5,12 @@ Object {
   "asFragment": [Function],
   "baseElement": <body>
     <div>
-      <div
-        class="sc-ipEyDJ fkiwq border border-solid border-greySoft rounded-card
-      flex-none overflow-hidden relative
-      flex flex-col h-auto desktop:flex-row desktop:w-auto mx-1
-      cursor-pointer hover:border-blackSemiTransparent transition-all duration-500
-      "
-        height="200"
+      <li
+        class="sc-ipEyDJ fEmItQ border border-solid border-greySoft rounded-card flex-none overflow-hidden relative flex flex-col h-fit desktop:flex-row desktop:w-auto mx-1 desktop:mb-6 hover:border-blackSemiTransparent transition-all duration-500"
+        height="0"
       >
         <div
-          class="flex-none desktop:w-2/5"
+          class="flex shrink-0 desktop:w-2/5"
         >
           <div
             class="relative bg-dark"
@@ -89,43 +85,32 @@ Object {
           class="flex flex-col relative
         p-2 desktop:p-6 desktop:my-auto"
         >
-          <p
+          <h3
             class="text-Mobile-C1 desktop:text-H4 text-primary1 font-bold"
           >
             Église St Louis
-          </p>
+          </h3>
           <div
             class="mt-1 desktop:mt-4 flex flex-col desktop:flex-row desktop:items-end text-Mobile-C2 desktop:text-P1 text-greyDarkColored"
           >
             <div
-              class="sc-kDvujY sc-csuSiG iXXQYE jfeXWc text-greyDarkColored"
+              class="sc-kDvujY iXXQYE text-greyDarkColored"
             >
-              <div>
-                <span>
-                  Pour espérer apercevoir cet oiseau, partir la nuit au printemps, parcourir un grand dénivelé afin d'arriver sur son terrain de prédilection à plus de 2000 m voire 3000 m d'altitude avant le lever du jour et là, entendre le chant guttural caractéristique qui trahit sa présence. Mais pour le voir, il faudra bien ouvrir les yeux ou se munir d'une paire de jumelles. Et alors là, quel bonheur ! Le lagopède alpin est l'espèce arctique par excellence, menacée entre autre par le réchauffement climatique. Il fait partie des espèces à protéger dans le cœur du Parc national des Ecrins.
-                </span>
-              </div>
+              <span>
+                Pour espérer apercevoir cet oiseau, partir la nuit au printemps, parcourir un grand dénivelé afin d'arriver sur son terrain de prédilection à plus de 2000 m voire 3000 m d'altitude avant le lever du jour et là, entendre le chant guttural caractéristique qui trahit sa présence. Mais pour le voir, il faudra bien ouvrir les yeux ou se munir d'une paire de jumelles. Et alors là, quel bonheur ! Le lagopède alpin est l'espèce arctique par excellence, menacée entre autre par le réchauffement climatique. Il fait partie des espèces à protéger dans le cœur du Parc national des Ecrins.
+              </span>
             </div>
-            <span
-              class="text-primary1 underline cursor-pointer shrink-0 desktop:ml-1"
-            >
-              lire la suite
-            </span>
           </div>
         </div>
-      </div>
+      </li>
     </div>
     <div>
-      <div
-        class="sc-ipEyDJ fkiwq border border-solid border-greySoft rounded-card
-      flex-none overflow-hidden relative
-      flex flex-col h-auto desktop:flex-row desktop:w-auto mx-1
-      cursor-pointer hover:border-blackSemiTransparent transition-all duration-500
-      "
-        height="200"
+      <li
+        class="sc-ipEyDJ fEmItQ border border-solid border-greySoft rounded-card flex-none overflow-hidden relative flex flex-col h-fit desktop:flex-row desktop:w-auto mx-1 desktop:mb-6 hover:border-blackSemiTransparent transition-all duration-500"
+        height="0"
       >
         <div
-          class="flex-none desktop:w-2/5"
+          class="flex shrink-0 desktop:w-2/5"
         >
           <div
             class="relative bg-dark"
@@ -321,44 +306,33 @@ Object {
           class="flex flex-col relative
         p-2 desktop:p-6 desktop:my-auto"
         >
-          <p
+          <h3
             class="text-Mobile-C1 desktop:text-H4 text-primary1 font-bold"
           >
             Église St Louis
-          </p>
+          </h3>
           <div
             class="mt-1 desktop:mt-4 flex flex-col desktop:flex-row desktop:items-end text-Mobile-C2 desktop:text-P1 text-greyDarkColored"
           >
             <div
-              class="sc-kDvujY sc-csuSiG iXXQYE jfeXWc text-greyDarkColored"
+              class="sc-kDvujY iXXQYE text-greyDarkColored"
             >
-              <div>
-                <span>
-                  Pour espérer apercevoir cet oiseau, partir la nuit au printemps, parcourir un grand dénivelé afin d'arriver sur son terrain de prédilection à plus de 2000 m voire 3000 m d'altitude avant le lever du jour et là, entendre le chant guttural caractéristique qui trahit sa présence. Mais pour le voir, il faudra bien ouvrir les yeux ou se munir d'une paire de jumelles. Et alors là, quel bonheur ! Le lagopède alpin est l'espèce arctique par excellence, menacée entre autre par le réchauffement climatique. Il fait partie des espèces à protéger dans le cœur du Parc national des Ecrins.
-                </span>
-              </div>
+              <span>
+                Pour espérer apercevoir cet oiseau, partir la nuit au printemps, parcourir un grand dénivelé afin d'arriver sur son terrain de prédilection à plus de 2000 m voire 3000 m d'altitude avant le lever du jour et là, entendre le chant guttural caractéristique qui trahit sa présence. Mais pour le voir, il faudra bien ouvrir les yeux ou se munir d'une paire de jumelles. Et alors là, quel bonheur ! Le lagopède alpin est l'espèce arctique par excellence, menacée entre autre par le réchauffement climatique. Il fait partie des espèces à protéger dans le cœur du Parc national des Ecrins.
+              </span>
             </div>
-            <span
-              class="text-primary1 underline cursor-pointer shrink-0 desktop:ml-1"
-            >
-              lire la suite
-            </span>
           </div>
         </div>
-      </div>
+      </li>
     </div>
   </body>,
   "container": <div>
-    <div
-      class="sc-ipEyDJ fkiwq border border-solid border-greySoft rounded-card
-      flex-none overflow-hidden relative
-      flex flex-col h-auto desktop:flex-row desktop:w-auto mx-1
-      cursor-pointer hover:border-blackSemiTransparent transition-all duration-500
-      "
-      height="200"
+    <li
+      class="sc-ipEyDJ fEmItQ border border-solid border-greySoft rounded-card flex-none overflow-hidden relative flex flex-col h-fit desktop:flex-row desktop:w-auto mx-1 desktop:mb-6 hover:border-blackSemiTransparent transition-all duration-500"
+      height="0"
     >
       <div
-        class="flex-none desktop:w-2/5"
+        class="flex shrink-0 desktop:w-2/5"
       >
         <div
           class="relative bg-dark"
@@ -433,31 +407,24 @@ Object {
         class="flex flex-col relative
         p-2 desktop:p-6 desktop:my-auto"
       >
-        <p
+        <h3
           class="text-Mobile-C1 desktop:text-H4 text-primary1 font-bold"
         >
           Église St Louis
-        </p>
+        </h3>
         <div
           class="mt-1 desktop:mt-4 flex flex-col desktop:flex-row desktop:items-end text-Mobile-C2 desktop:text-P1 text-greyDarkColored"
         >
           <div
-            class="sc-kDvujY sc-csuSiG iXXQYE jfeXWc text-greyDarkColored"
+            class="sc-kDvujY iXXQYE text-greyDarkColored"
           >
-            <div>
-              <span>
-                Pour espérer apercevoir cet oiseau, partir la nuit au printemps, parcourir un grand dénivelé afin d'arriver sur son terrain de prédilection à plus de 2000 m voire 3000 m d'altitude avant le lever du jour et là, entendre le chant guttural caractéristique qui trahit sa présence. Mais pour le voir, il faudra bien ouvrir les yeux ou se munir d'une paire de jumelles. Et alors là, quel bonheur ! Le lagopède alpin est l'espèce arctique par excellence, menacée entre autre par le réchauffement climatique. Il fait partie des espèces à protéger dans le cœur du Parc national des Ecrins.
-              </span>
-            </div>
+            <span>
+              Pour espérer apercevoir cet oiseau, partir la nuit au printemps, parcourir un grand dénivelé afin d'arriver sur son terrain de prédilection à plus de 2000 m voire 3000 m d'altitude avant le lever du jour et là, entendre le chant guttural caractéristique qui trahit sa présence. Mais pour le voir, il faudra bien ouvrir les yeux ou se munir d'une paire de jumelles. Et alors là, quel bonheur ! Le lagopède alpin est l'espèce arctique par excellence, menacée entre autre par le réchauffement climatique. Il fait partie des espèces à protéger dans le cœur du Parc national des Ecrins.
+            </span>
           </div>
-          <span
-            class="text-primary1 underline cursor-pointer shrink-0 desktop:ml-1"
-          >
-            lire la suite
-          </span>
         </div>
       </div>
-    </div>
+    </li>
   </div>,
   "debug": [Function],
   "findAllByAltText": [Function],
@@ -518,16 +485,12 @@ Object {
   "asFragment": [Function],
   "baseElement": <body>
     <div>
-      <div
-        class="sc-ipEyDJ fkiwq border border-solid border-greySoft rounded-card
-      flex-none overflow-hidden relative
-      flex flex-col h-auto desktop:flex-row desktop:w-auto mx-1
-      cursor-pointer hover:border-blackSemiTransparent transition-all duration-500
-      "
-        height="200"
+      <li
+        class="sc-ipEyDJ fEmItQ border border-solid border-greySoft rounded-card flex-none overflow-hidden relative flex flex-col h-fit desktop:flex-row desktop:w-auto mx-1 desktop:mb-6 hover:border-blackSemiTransparent transition-all duration-500"
+        height="0"
       >
         <div
-          class="flex-none desktop:w-2/5"
+          class="flex shrink-0 desktop:w-2/5"
         >
           <div
             class="relative bg-dark"
@@ -602,43 +565,32 @@ Object {
           class="flex flex-col relative
         p-2 desktop:p-6 desktop:my-auto"
         >
-          <p
+          <h3
             class="text-Mobile-C1 desktop:text-H4 text-primary1 font-bold"
           >
             Église St Louis
-          </p>
+          </h3>
           <div
             class="mt-1 desktop:mt-4 flex flex-col desktop:flex-row desktop:items-end text-Mobile-C2 desktop:text-P1 text-greyDarkColored"
           >
             <div
-              class="sc-kDvujY sc-csuSiG iXXQYE jfeXWc text-greyDarkColored"
+              class="sc-kDvujY iXXQYE text-greyDarkColored"
             >
-              <div>
-                <span>
-                  Pour espérer apercevoir cet oiseau, partir la nuit au printemps, parcourir un grand dénivelé afin d'arriver sur son terrain de prédilection à plus de 2000 m voire 3000 m d'altitude avant le lever du jour et là, entendre le chant guttural caractéristique qui trahit sa présence. Mais pour le voir, il faudra bien ouvrir les yeux ou se munir d'une paire de jumelles. Et alors là, quel bonheur ! Le lagopède alpin est l'espèce arctique par excellence, menacée entre autre par le réchauffement climatique. Il fait partie des espèces à protéger dans le cœur du Parc national des Ecrins.
-                </span>
-              </div>
+              <span>
+                Pour espérer apercevoir cet oiseau, partir la nuit au printemps, parcourir un grand dénivelé afin d'arriver sur son terrain de prédilection à plus de 2000 m voire 3000 m d'altitude avant le lever du jour et là, entendre le chant guttural caractéristique qui trahit sa présence. Mais pour le voir, il faudra bien ouvrir les yeux ou se munir d'une paire de jumelles. Et alors là, quel bonheur ! Le lagopède alpin est l'espèce arctique par excellence, menacée entre autre par le réchauffement climatique. Il fait partie des espèces à protéger dans le cœur du Parc national des Ecrins.
+              </span>
             </div>
-            <span
-              class="text-primary1 underline cursor-pointer shrink-0 desktop:ml-1"
-            >
-              lire la suite
-            </span>
           </div>
         </div>
-      </div>
+      </li>
     </div>
     <div>
-      <div
-        class="sc-ipEyDJ fkiwq border border-solid border-greySoft rounded-card
-      flex-none overflow-hidden relative
-      flex flex-col h-auto desktop:flex-row desktop:w-auto mx-1
-      cursor-pointer hover:border-blackSemiTransparent transition-all duration-500
-      "
-        height="200"
+      <li
+        class="sc-ipEyDJ fEmItQ border border-solid border-greySoft rounded-card flex-none overflow-hidden relative flex flex-col h-fit desktop:flex-row desktop:w-auto mx-1 desktop:mb-6 hover:border-blackSemiTransparent transition-all duration-500"
+        height="0"
       >
         <div
-          class="flex-none desktop:w-2/5"
+          class="flex shrink-0 desktop:w-2/5"
         >
           <div
             class="relative bg-dark"
@@ -834,44 +786,33 @@ Object {
           class="flex flex-col relative
         p-2 desktop:p-6 desktop:my-auto"
         >
-          <p
+          <h3
             class="text-Mobile-C1 desktop:text-H4 text-primary1 font-bold"
           >
             Église St Louis
-          </p>
+          </h3>
           <div
             class="mt-1 desktop:mt-4 flex flex-col desktop:flex-row desktop:items-end text-Mobile-C2 desktop:text-P1 text-greyDarkColored"
           >
             <div
-              class="sc-kDvujY sc-csuSiG iXXQYE jfeXWc text-greyDarkColored"
+              class="sc-kDvujY iXXQYE text-greyDarkColored"
             >
-              <div>
-                <span>
-                  Pour espérer apercevoir cet oiseau, partir la nuit au printemps, parcourir un grand dénivelé afin d'arriver sur son terrain de prédilection à plus de 2000 m voire 3000 m d'altitude avant le lever du jour et là, entendre le chant guttural caractéristique qui trahit sa présence. Mais pour le voir, il faudra bien ouvrir les yeux ou se munir d'une paire de jumelles. Et alors là, quel bonheur ! Le lagopède alpin est l'espèce arctique par excellence, menacée entre autre par le réchauffement climatique. Il fait partie des espèces à protéger dans le cœur du Parc national des Ecrins.
-                </span>
-              </div>
+              <span>
+                Pour espérer apercevoir cet oiseau, partir la nuit au printemps, parcourir un grand dénivelé afin d'arriver sur son terrain de prédilection à plus de 2000 m voire 3000 m d'altitude avant le lever du jour et là, entendre le chant guttural caractéristique qui trahit sa présence. Mais pour le voir, il faudra bien ouvrir les yeux ou se munir d'une paire de jumelles. Et alors là, quel bonheur ! Le lagopède alpin est l'espèce arctique par excellence, menacée entre autre par le réchauffement climatique. Il fait partie des espèces à protéger dans le cœur du Parc national des Ecrins.
+              </span>
             </div>
-            <span
-              class="text-primary1 underline cursor-pointer shrink-0 desktop:ml-1"
-            >
-              lire la suite
-            </span>
           </div>
         </div>
-      </div>
+      </li>
     </div>
   </body>,
   "container": <div>
-    <div
-      class="sc-ipEyDJ fkiwq border border-solid border-greySoft rounded-card
-      flex-none overflow-hidden relative
-      flex flex-col h-auto desktop:flex-row desktop:w-auto mx-1
-      cursor-pointer hover:border-blackSemiTransparent transition-all duration-500
-      "
-      height="200"
+    <li
+      class="sc-ipEyDJ fEmItQ border border-solid border-greySoft rounded-card flex-none overflow-hidden relative flex flex-col h-fit desktop:flex-row desktop:w-auto mx-1 desktop:mb-6 hover:border-blackSemiTransparent transition-all duration-500"
+      height="0"
     >
       <div
-        class="flex-none desktop:w-2/5"
+        class="flex shrink-0 desktop:w-2/5"
       >
         <div
           class="relative bg-dark"
@@ -1067,31 +1008,24 @@ Object {
         class="flex flex-col relative
         p-2 desktop:p-6 desktop:my-auto"
       >
-        <p
+        <h3
           class="text-Mobile-C1 desktop:text-H4 text-primary1 font-bold"
         >
           Église St Louis
-        </p>
+        </h3>
         <div
           class="mt-1 desktop:mt-4 flex flex-col desktop:flex-row desktop:items-end text-Mobile-C2 desktop:text-P1 text-greyDarkColored"
         >
           <div
-            class="sc-kDvujY sc-csuSiG iXXQYE jfeXWc text-greyDarkColored"
+            class="sc-kDvujY iXXQYE text-greyDarkColored"
           >
-            <div>
-              <span>
-                Pour espérer apercevoir cet oiseau, partir la nuit au printemps, parcourir un grand dénivelé afin d'arriver sur son terrain de prédilection à plus de 2000 m voire 3000 m d'altitude avant le lever du jour et là, entendre le chant guttural caractéristique qui trahit sa présence. Mais pour le voir, il faudra bien ouvrir les yeux ou se munir d'une paire de jumelles. Et alors là, quel bonheur ! Le lagopède alpin est l'espèce arctique par excellence, menacée entre autre par le réchauffement climatique. Il fait partie des espèces à protéger dans le cœur du Parc national des Ecrins.
-              </span>
-            </div>
+            <span>
+              Pour espérer apercevoir cet oiseau, partir la nuit au printemps, parcourir un grand dénivelé afin d'arriver sur son terrain de prédilection à plus de 2000 m voire 3000 m d'altitude avant le lever du jour et là, entendre le chant guttural caractéristique qui trahit sa présence. Mais pour le voir, il faudra bien ouvrir les yeux ou se munir d'une paire de jumelles. Et alors là, quel bonheur ! Le lagopède alpin est l'espèce arctique par excellence, menacée entre autre par le réchauffement climatique. Il fait partie des espèces à protéger dans le cœur du Parc national des Ecrins.
+            </span>
           </div>
-          <span
-            class="text-primary1 underline cursor-pointer shrink-0 desktop:ml-1"
-          >
-            lire la suite
-          </span>
         </div>
       </div>
-    </div>
+    </li>
   </div>,
   "debug": [Function],
   "findAllByAltText": [Function],

--- a/frontend/src/components/pages/details/components/DetailsCard/useDetailsCard.tsx
+++ b/frontend/src/components/pages/details/components/DetailsCard/useDetailsCard.tsx
@@ -1,11 +1,16 @@
-import { useEffect, useRef, useState } from 'react';
+import debounce from 'debounce';
+import useIsomorphicLayoutEffect from 'hooks/useIsomorphicLayoutEffect';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 const DETAILS_CARD_DEFAULT_HEIGHT = 200;
 
 export const useDetailsCard = () => {
-  const [truncateState, setTruncateState] = useState<'TRUNCATE' | 'FULL'>('TRUNCATE');
   const detailsCardRef = useRef<HTMLDivElement>(null);
   const [heightState, setHeightState] = useState(DETAILS_CARD_DEFAULT_HEIGHT);
+  const [truncateState, setTruncateState] = useState<'NONE' | 'TRUNCATE' | 'FULL'>(
+    () => 'TRUNCATE',
+  );
+
   const toggleTruncateState = () =>
     setTruncateState(currentTruncateState =>
       currentTruncateState === 'TRUNCATE' ? 'FULL' : 'TRUNCATE',
@@ -19,6 +24,58 @@ export const useDetailsCard = () => {
         setHeightState(newHeight);
       }
     }
-  }, [truncateState]);
+  }, [truncateState, setHeightState]);
+
+  useEffect(() => {
+    if (
+      detailsCardRef.current &&
+      detailsCardRef.current.querySelector<HTMLElement>('.line-clamp-2')?.offsetHeight ===
+        detailsCardRef.current.querySelector<HTMLElement>('.line-clamp-2')?.scrollHeight
+    ) {
+      setTruncateState('NONE');
+    }
+  }, []);
+
+  const handleResize = useCallback(
+    debounce(
+      () => {
+        setTruncateState(prevState => {
+          if (detailsCardRef.current === null) {
+            return prevState;
+          }
+          if (
+            prevState === 'TRUNCATE' &&
+            detailsCardRef.current.querySelector<HTMLElement>('.line-clamp-2')?.offsetHeight ===
+              detailsCardRef.current.querySelector<HTMLElement>('.line-clamp-2')?.scrollHeight
+          ) {
+            return 'NONE';
+          } else if (
+            prevState === 'FULL' &&
+            heightState >= detailsCardRef.current?.getBoundingClientRect().height
+          ) {
+            return 'NONE';
+          } else if (
+            prevState === 'NONE' &&
+            heightState < detailsCardRef.current?.getBoundingClientRect().height
+          ) {
+            setHeightState(DETAILS_CARD_DEFAULT_HEIGHT);
+            return 'TRUNCATE';
+          }
+          return prevState;
+        });
+      },
+      1000,
+      false,
+    ),
+    [setTruncateState, setHeightState, detailsCardRef],
+  );
+
+  useIsomorphicLayoutEffect(() => {
+    global.addEventListener('resize', handleResize);
+    return () => {
+      global.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
   return { truncateState, toggleTruncateState, heightState, detailsCardRef };
 };

--- a/frontend/src/components/pages/details/components/DetailsCardSection/DetailsCardSection.tsx
+++ b/frontend/src/components/pages/details/components/DetailsCardSection/DetailsCardSection.tsx
@@ -24,18 +24,19 @@ export const DetailsCardSection: React.FC<DetailsCardSectionProps> = ({
 }) => {
   return (
     <div id={htmlId} className="pt-6 desktop:pt-12 scroll-mt-20 desktop:scroll-mt-30">
-      <div
+      <h2
         id="details_cardSectionTitle"
         className={`text-Mobile-H1 desktop:text-H2 font-bold ${marginDetailsChild} flex items-center`}
       >
         {title}
         {displayBadge && <Badge label={detailsCards.length} color={getActivityColor(type)} />}
-      </div>
+      </h2>
       <ScrollContainer
         id="details_cardSectionScrollContainer"
         className="flex desktop:flex-col items-stretch
-        overflow-x-scroll desktop:overflow-x-hidden
-        overflow-y-hidden desktop:overflow-y-scroll flex-nowrap
+        overflow-x-auto desktop:overflow-x-hidden
+        overflow-y-hidden desktop:overflow-y-auto
+        scroll-smooth snap-x
         pb-5 mt-4 mb-2 desktop:mb-0
         px-4 desktop:pl-18 desktop:pr-9 desktop:mr-9"
       >
@@ -91,7 +92,7 @@ export const Badge: React.FC<BadgeProps> = ({ label, color }) => {
 
 const offsetTopForTitle = 70;
 
-const ScrollContainer = styled.div`
+const ScrollContainer = styled.ul`
   &::-webkit-scrollbar {
     ${scrollBar.root}
   }

--- a/frontend/src/components/pages/details/components/DetailsInformationDesk/DetailsInformationDesk.tsx
+++ b/frontend/src/components/pages/details/components/DetailsInformationDesk/DetailsInformationDesk.tsx
@@ -1,8 +1,6 @@
 import { InformationDesk } from 'modules/informationDesk/interface';
 import SVG from 'react-inlinesvg';
 import parse from 'html-react-parser';
-import { textEllipsisAfterNLines } from 'services/cssHelpers';
-import styled from 'styled-components';
 import { FormattedMessage } from 'react-intl';
 import { useListAndMapContext } from 'modules/map/ListAndMapContext';
 import Image from 'next/image';
@@ -81,9 +79,9 @@ export const DetailsInformationDesk: React.FC<DetailsInformationDeskProps> = ({
         {description && (
           <div className="flex flex-col desktop:flex-row desktop:items-end mt-4">
             {truncateState === 'TRUNCATE' ? (
-              <TruncatedHtmlText>
+              <HtmlText className="line-clamp-2">
                 <div>{parse(description)}</div>
-              </TruncatedHtmlText>
+              </HtmlText>
             ) : (
               <HtmlText>{parse(description)}</HtmlText>
             )}
@@ -126,7 +124,3 @@ const InformationDeskIcon: React.FC<{ pictogramUri: string }> = ({ pictogramUri 
     />
   );
 };
-
-const TruncatedHtmlText = styled(HtmlText)`
-  ${textEllipsisAfterNLines(2)}
-`;

--- a/frontend/src/services/cssHelpers.ts
+++ b/frontend/src/services/cssHelpers.ts
@@ -33,10 +33,3 @@ export const buttonCssResets = css`
     outline: 0;
   }
 `;
-
-export const textEllipsisAfterNLines = (lines: number): FlattenSimpleInterpolation => css`
-  display: -webkit-box;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: ${lines};
-  overflow: hidden;
-`;


### PR DESCRIPTION
- The featured image takes up all the available space, even if the card is taller than the image.
- The description is truncated after 2 lines in the mobile version, and after 5 lines in the desktop version.
- If the text is not truncated, the "read more" button is no longer displayed.
- The "Read more" button is dynamically added/removed according to the number of lines of content (effective when resizing the viewport).
 - Add of a vertical arrow icon to indicate to the user that the "read more" link does not point to an internal link
 - Remove the cursor pointer from the card
 - Add some semantic tags

