### PR TITLE
Define default placeholder to SelectableDropdown

### DIFF
--- a/frontend/src/components/pages/search/components/FilterBar/SelectableDropdown.tsx
+++ b/frontend/src/components/pages/search/components/FilterBar/SelectableDropdown.tsx
@@ -93,6 +93,7 @@ const computeAction = (action: OnChangeValue<Option, true>): Option[] => {
 };
 
 export const SelectableDropdown = (props: SelectableDropdownProps) => {
+  const placeholderText = props.placeholder || 'form.selectPlaceholder';
   const intl = useIntl();
   return (
     <Select
@@ -100,7 +101,7 @@ export const SelectableDropdown = (props: SelectableDropdownProps) => {
       {...props}
       isClearable={props.filterType === 'SINGLE'}
       isSearchable={false}
-      placeholder={intl.formatMessage({ id: props.placeholder })}
+      placeholder={intl.formatMessage({ id: placeholderText })}
       classNamePrefix="select"
       isMulti={props.filterType === 'MULTIPLE' ? true : undefined}
       instanceId={props.name}


### PR DESCRIPTION
Fix the display of SelectableDropdown if placeholder props is set to `null`.

The problem may occur during the following steps in GTA: 
- Defining a touristicContent category
- Creating an **unnamed** list
- Creating more than 9 types linked to this list (in this case, label filters become drop-down lists in GTR).

This PR corrects this behavior by defining a default "Select" placeholder if the list has no name.