### PR TITLE
Cache queries

### DIFF
--- a/frontend/src/components/Map/hooks/usePopupResult.ts
+++ b/frontend/src/components/Map/hooks/usePopupResult.ts
@@ -5,8 +5,11 @@ import { PopupResult } from 'modules/trekResult/interface';
 import { getTouristicContentPopupResult } from 'modules/touristicContent/connector';
 import { useRouter } from 'next/router';
 import { getDefaultLanguage } from 'modules/header/utills';
-import { getOutdoorSitePopupResult } from '../../../modules/outdoorSite/connector';
+import { CommonDictionaries } from 'modules/dictionaries/interface';
+import { getCommonDictionaries } from 'modules/dictionaries/connector';
+import { ONE_DAY } from 'services/constants/staleTime';
 import { getTouristicEventPopupResult } from '../../../modules/touristicEvent/connector';
+import { getOutdoorSitePopupResult } from '../../../modules/outdoorSite/connector';
 
 export const usePopupResult = (
   id: string,
@@ -15,11 +18,21 @@ export const usePopupResult = (
 ) => {
   const language = useRouter().locale ?? getDefaultLanguage();
 
+  const { data: commonDictionaries } = useQuery<CommonDictionaries, Error>(
+    ['commonDictionaries', language],
+    () => getCommonDictionaries(language),
+    {
+      staleTime: ONE_DAY,
+    },
+  );
+
   const fetchData = () => {
     if (type === 'TREK') return getTrekPopupResult(id, language);
-    if (type === 'TOURISTIC_CONTENT') return getTouristicContentPopupResult(id, language);
-    if (type === 'OUTDOOR_SITE') return getOutdoorSitePopupResult(id, language);
-    if (type === 'TOURISTIC_EVENT') return getTouristicEventPopupResult(id, language);
+    if (type === 'TOURISTIC_CONTENT')
+      return getTouristicContentPopupResult(id, language, commonDictionaries);
+    if (type === 'OUTDOOR_SITE') return getOutdoorSitePopupResult(id, language, commonDictionaries);
+    if (type === 'TOURISTIC_EVENT')
+      return getTouristicEventPopupResult(id, language, commonDictionaries);
 
     throw new Error('Incorrect type');
   };
@@ -27,7 +40,7 @@ export const usePopupResult = (
   const { data: trekPopupResult, isLoading } = useQuery<PopupResult, Error>(
     ['popupResult', id, language],
     fetchData,
-    { enabled: shouldFetch },
+    { enabled: shouldFetch && commonDictionaries !== undefined },
   );
 
   return {

--- a/frontend/src/components/Map/hooks/usePopupResult.ts
+++ b/frontend/src/components/Map/hooks/usePopupResult.ts
@@ -5,9 +5,7 @@ import { PopupResult } from 'modules/trekResult/interface';
 import { getTouristicContentPopupResult } from 'modules/touristicContent/connector';
 import { useRouter } from 'next/router';
 import { getDefaultLanguage } from 'modules/header/utills';
-import { CommonDictionaries } from 'modules/dictionaries/interface';
-import { getCommonDictionaries } from 'modules/dictionaries/connector';
-import { ONE_DAY } from 'services/constants/staleTime';
+import { queryCommonDictionaries } from 'modules/dictionaries/api';
 import { getTouristicEventPopupResult } from '../../../modules/touristicEvent/connector';
 import { getOutdoorSitePopupResult } from '../../../modules/outdoorSite/connector';
 
@@ -17,14 +15,7 @@ export const usePopupResult = (
   type: 'TREK' | 'TOURISTIC_CONTENT' | 'OUTDOOR_SITE' | 'TOURISTIC_EVENT',
 ) => {
   const language = useRouter().locale ?? getDefaultLanguage();
-
-  const { data: commonDictionaries } = useQuery<CommonDictionaries, Error>(
-    ['commonDictionaries', language],
-    () => getCommonDictionaries(language),
-    {
-      staleTime: ONE_DAY / 2,
-    },
-  );
+  const commonDictionaries = queryCommonDictionaries(language);
 
   const fetchData = () => {
     if (type === 'TREK') return getTrekPopupResult(id, language);

--- a/frontend/src/components/Map/hooks/usePopupResult.ts
+++ b/frontend/src/components/Map/hooks/usePopupResult.ts
@@ -22,7 +22,7 @@ export const usePopupResult = (
     ['commonDictionaries', language],
     () => getCommonDictionaries(language),
     {
-      staleTime: ONE_DAY,
+      staleTime: ONE_DAY / 2,
     },
   );
 

--- a/frontend/src/components/pages/details/components/DetailsDescription/DetailsDescription.tsx
+++ b/frontend/src/components/pages/details/components/DetailsDescription/DetailsDescription.tsx
@@ -1,4 +1,4 @@
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, useIntl } from 'react-intl';
 import styled, { css } from 'styled-components';
 import { colorPalette, desktopOnly, getSpacing, shadow } from 'stylesheet';
 import parse from 'html-react-parser';
@@ -33,6 +33,7 @@ export const DetailsDescription: React.FC<DetailsDescriptionProps> = ({
   const hasCities = Array.isArray(cities) && cities.length > 0;
   const hasEmail = Boolean(email);
   const hasWebsite = Boolean(website);
+  const intl = useIntl();
 
   return (
     <div
@@ -72,7 +73,7 @@ export const DetailsDescription: React.FC<DetailsDescriptionProps> = ({
               <span className={'font-bold'}>
                 <FormattedMessage id="details.cities" />
               </span>{' '}
-              : {cities.join(', ')}
+              : {intl.formatList(cities, { type: 'conjunction' })}
             </li>
           )}
 

--- a/frontend/src/components/pages/details/useDetails.tsx
+++ b/frontend/src/components/pages/details/useDetails.tsx
@@ -55,7 +55,7 @@ export const useDetails = (
           await router.push(routes.HOME);
         }
       },
-      staleTime: ONE_DAY,
+      staleTime: ONE_DAY / 2,
     },
   );
 

--- a/frontend/src/components/pages/details/useDetails.tsx
+++ b/frontend/src/components/pages/details/useDetails.tsx
@@ -10,8 +10,7 @@ import { useRouter } from 'next/router';
 import { routes } from 'services/routes';
 import { useMediaPredicate } from 'react-media-hook';
 import useSectionsReferences from 'hooks/useSectionsReferences';
-import { getCommonDictionaries } from 'modules/dictionaries/connector';
-import { CommonDictionaries } from 'modules/dictionaries/interface';
+import { queryCommonDictionaries } from 'modules/dictionaries/api';
 import { getDetailsConfig } from './config';
 import {
   DetailsSectionOutdoorCourseNames,
@@ -46,18 +45,7 @@ export const useDetails = (
   const path = isUrlString(slug) ? decodeURI(slug) : '';
   const router = useRouter();
 
-  const { data: commonDictionaries } = useQuery<CommonDictionaries, Error>(
-    ['commonDictionaries', language],
-    () => getCommonDictionaries(language),
-    {
-      onError: async error => {
-        if (isRessourceMissing(error)) {
-          await router.push(routes.HOME);
-        }
-      },
-      staleTime: ONE_DAY / 2,
-    },
-  );
+  const commonDictionaries = queryCommonDictionaries(language);
 
   const {
     data: details,

--- a/frontend/src/components/pages/home/useHome.ts
+++ b/frontend/src/components/pages/home/useHome.ts
@@ -5,9 +5,7 @@ import { HomePageConfig } from 'modules/home/interface';
 import { adaptSuggestions, getHomePageConfig } from 'modules/home/utils';
 import { useRouter } from 'next/router';
 import { useQuery } from '@tanstack/react-query';
-import { CommonDictionaries } from 'modules/dictionaries/interface';
-import { getCommonDictionaries } from 'modules/dictionaries/connector';
-import { ONE_DAY } from 'services/constants/staleTime';
+import { queryCommonDictionaries } from 'modules/dictionaries/api';
 interface UseHome {
   config: HomePageConfig;
   suggestions: ActivitySuggestion[];
@@ -22,13 +20,7 @@ export const useHome = (): UseHome => {
     'ids' in suggestion ? suggestion.ids : [suggestion.type],
   );
 
-  const { data: commonDictionaries } = useQuery<CommonDictionaries, Error>(
-    ['commonDictionaries', language],
-    () => getCommonDictionaries(language),
-    {
-      staleTime: ONE_DAY / 2,
-    },
-  );
+  const commonDictionaries = queryCommonDictionaries(language);
 
   const { data = [] } = useQuery<ActivitySuggestion[] | [], Error>(
     ['activitySuggestions', `Suggestion-${activitySuggestionIds.join('-')}`, language],

--- a/frontend/src/components/pages/home/useHome.ts
+++ b/frontend/src/components/pages/home/useHome.ts
@@ -26,7 +26,7 @@ export const useHome = (): UseHome => {
     ['commonDictionaries', language],
     () => getCommonDictionaries(language),
     {
-      staleTime: ONE_DAY,
+      staleTime: ONE_DAY / 2,
     },
   );
 

--- a/frontend/src/components/pages/home/useHome.ts
+++ b/frontend/src/components/pages/home/useHome.ts
@@ -5,6 +5,9 @@ import { HomePageConfig } from 'modules/home/interface';
 import { adaptSuggestions, getHomePageConfig } from 'modules/home/utils';
 import { useRouter } from 'next/router';
 import { useQuery } from '@tanstack/react-query';
+import { CommonDictionaries } from 'modules/dictionaries/interface';
+import { getCommonDictionaries } from 'modules/dictionaries/connector';
+import { ONE_DAY } from 'services/constants/staleTime';
 interface UseHome {
   config: HomePageConfig;
   suggestions: ActivitySuggestion[];
@@ -19,10 +22,18 @@ export const useHome = (): UseHome => {
     'ids' in suggestion ? suggestion.ids : [suggestion.type],
   );
 
+  const { data: commonDictionaries } = useQuery<CommonDictionaries, Error>(
+    ['commonDictionaries', language],
+    () => getCommonDictionaries(language),
+    {
+      staleTime: ONE_DAY,
+    },
+  );
+
   const { data = [] } = useQuery<ActivitySuggestion[] | [], Error>(
     ['activitySuggestions', `Suggestion-${activitySuggestionIds.join('-')}`, language],
-    () => getActivitySuggestions(suggestions, language),
-    { enabled: suggestions.length > 0 },
+    () => getActivitySuggestions(suggestions, language, commonDictionaries),
+    { enabled: suggestions.length > 0 && commonDictionaries !== undefined },
   );
 
   return { config: homePageConfig, suggestions: data };

--- a/frontend/src/components/pages/search/hooks/useCounter.ts
+++ b/frontend/src/components/pages/search/hooks/useCounter.ts
@@ -1,7 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { ONE_DAY } from 'services/constants/staleTime';
-import { getCommonDictionaries } from 'modules/dictionaries/connector';
-import { CommonDictionaries } from 'modules/dictionaries/interface';
+import { queryCommonDictionaries } from 'modules/dictionaries/api';
 import { getSearchResults } from '../../../../modules/results/connector';
 import { getGlobalConfig } from '../../../../modules/utils/api.config';
 
@@ -17,13 +16,7 @@ interface CountResult {
 }
 
 const useCounter = ({ language }: Args): CountResult => {
-  const { data: commonDictionaries } = useQuery<CommonDictionaries, Error>(
-    ['commonDictionaries', language],
-    () => getCommonDictionaries(language),
-    {
-      staleTime: ONE_DAY / 2,
-    },
-  );
+  const commonDictionaries = queryCommonDictionaries(language);
 
   const result = useQuery(
     ['counter'],

--- a/frontend/src/components/pages/search/hooks/useCounter.ts
+++ b/frontend/src/components/pages/search/hooks/useCounter.ts
@@ -21,7 +21,7 @@ const useCounter = ({ language }: Args): CountResult => {
     ['commonDictionaries', language],
     () => getCommonDictionaries(language),
     {
-      staleTime: ONE_DAY,
+      staleTime: ONE_DAY / 2,
     },
   );
 

--- a/frontend/src/components/pages/search/hooks/useCounter.ts
+++ b/frontend/src/components/pages/search/hooks/useCounter.ts
@@ -1,5 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { ONE_DAY } from 'services/constants/staleTime';
+import { getCommonDictionaries } from 'modules/dictionaries/connector';
+import { CommonDictionaries } from 'modules/dictionaries/interface';
 import { getSearchResults } from '../../../../modules/results/connector';
 import { getGlobalConfig } from '../../../../modules/utils/api.config';
 
@@ -15,6 +17,14 @@ interface CountResult {
 }
 
 const useCounter = ({ language }: Args): CountResult => {
+  const { data: commonDictionaries } = useQuery<CommonDictionaries, Error>(
+    ['commonDictionaries', language],
+    () => getCommonDictionaries(language),
+    {
+      staleTime: ONE_DAY,
+    },
+  );
+
   const result = useQuery(
     ['counter'],
     ({
@@ -34,6 +44,7 @@ const useCounter = ({ language }: Args): CountResult => {
         },
         pageParam,
         language,
+        commonDictionaries,
       ),
     {
       refetchOnReconnect: false,

--- a/frontend/src/components/pages/search/hooks/useTrekResults.ts
+++ b/frontend/src/components/pages/search/hooks/useTrekResults.ts
@@ -72,7 +72,7 @@ export const useTrekResults = (
     ['commonDictionaries', language],
     () => getCommonDictionaries(language),
     {
-      staleTime: ONE_DAY,
+      staleTime: ONE_DAY / 2,
     },
   );
 

--- a/frontend/src/components/pages/search/hooks/useTrekResults.ts
+++ b/frontend/src/components/pages/search/hooks/useTrekResults.ts
@@ -1,13 +1,16 @@
 import { useRouter } from 'next/router';
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import { useEffect, useRef, useState } from 'react';
 
 import { getSearchResults } from 'modules/results/connector';
 import { SearchResults } from 'modules/results/interface';
 import { DateFilter, FilterState } from 'modules/filters/interface';
-import { getGlobalConfig } from '../../../../modules/utils/api.config';
 
+import { CommonDictionaries } from 'modules/dictionaries/interface';
+import { getCommonDictionaries } from 'modules/dictionaries/connector';
+import { ONE_DAY } from 'services/constants/staleTime';
 import { formatInfiniteQuery, parseBboxFilter, parseFilters, parseTextFilter } from '../utils';
+import { getGlobalConfig } from '../../../../modules/utils/api.config';
 
 const formatFiltersUrl = (filtersState: FilterState[]): string[] =>
   filtersState.reduce<string[]>(
@@ -65,6 +68,14 @@ export const useTrekResults = (
 
   const router = useRouter();
 
+  const { data: commonDictionaries } = useQuery<CommonDictionaries, Error>(
+    ['commonDictionaries', language],
+    () => getCommonDictionaries(language),
+    {
+      staleTime: ONE_DAY,
+    },
+  );
+
   const {
     data,
     isLoading,
@@ -96,6 +107,7 @@ export const useTrekResults = (
         { filtersState: parsedFiltersState, textFilterState, bboxState, dateFilter },
         pageParam,
         language,
+        commonDictionaries,
       );
     },
     {

--- a/frontend/src/components/pages/search/hooks/useTrekResults.ts
+++ b/frontend/src/components/pages/search/hooks/useTrekResults.ts
@@ -1,14 +1,12 @@
 import { useRouter } from 'next/router';
-import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import { useEffect, useRef, useState } from 'react';
 
 import { getSearchResults } from 'modules/results/connector';
 import { SearchResults } from 'modules/results/interface';
 import { DateFilter, FilterState } from 'modules/filters/interface';
 
-import { CommonDictionaries } from 'modules/dictionaries/interface';
-import { getCommonDictionaries } from 'modules/dictionaries/connector';
-import { ONE_DAY } from 'services/constants/staleTime';
+import { queryCommonDictionaries } from 'modules/dictionaries/api';
 import { formatInfiniteQuery, parseBboxFilter, parseFilters, parseTextFilter } from '../utils';
 import { getGlobalConfig } from '../../../../modules/utils/api.config';
 
@@ -68,13 +66,7 @@ export const useTrekResults = (
 
   const router = useRouter();
 
-  const { data: commonDictionaries } = useQuery<CommonDictionaries, Error>(
-    ['commonDictionaries', language],
-    () => getCommonDictionaries(language),
-    {
-      staleTime: ONE_DAY / 2,
-    },
-  );
+  const commonDictionaries = queryCommonDictionaries(language);
 
   const {
     data,

--- a/frontend/src/components/pages/site/useOutdoorCourse.tsx
+++ b/frontend/src/components/pages/site/useOutdoorCourse.tsx
@@ -2,10 +2,16 @@ import useSectionsReferences from 'hooks/useSectionsReferences';
 import { isUrlString } from 'modules/utils/string';
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { getOutdoorCourseDetails } from '../../../modules/outdoorCourse/connector';
-import { OutdoorCourseDetails } from '../../../modules/outdoorCourse/interface';
-import { getDetailsConfig } from '../details/config';
+import { useRouter } from 'next/router';
+import { CommonDictionaries } from 'modules/dictionaries/interface';
+import { getCommonDictionaries } from 'modules/dictionaries/connector';
+import { isRessourceMissing } from 'services/routeUtils';
+import { routes } from 'services/routes';
+import { ONE_DAY } from 'services/constants/staleTime';
 import { DetailsSections } from '../details/useDetails';
+import { getDetailsConfig } from '../details/config';
+import { OutdoorCourseDetails } from '../../../modules/outdoorCourse/interface';
+import { getOutdoorCourseDetails } from '../../../modules/outdoorCourse/connector';
 
 export const useOutdoorCourse = (
   outdoorCourseUrl: string | string[] | undefined,
@@ -13,11 +19,33 @@ export const useOutdoorCourse = (
 ) => {
   const id = isUrlString(outdoorCourseUrl) ? outdoorCourseUrl.split('-')[0] : '';
   const path = isUrlString(outdoorCourseUrl) ? decodeURI(outdoorCourseUrl) : '';
+
+  const router = useRouter();
+
+  const { data: commonDictionaries } = useQuery<CommonDictionaries, Error>(
+    ['commonDictionaries', language],
+    () => getCommonDictionaries(language),
+    {
+      onError: async error => {
+        if (isRessourceMissing(error)) {
+          await router.push(routes.HOME);
+        }
+      },
+      staleTime: ONE_DAY,
+    },
+  );
+
   const { data, refetch, isLoading } = useQuery<OutdoorCourseDetails, Error>(
     ['outdoorCourseDetails', id, language],
-    () => getOutdoorCourseDetails(id, language),
+    () => getOutdoorCourseDetails(id, language, commonDictionaries),
     {
-      enabled: isUrlString(outdoorCourseUrl),
+      enabled: isUrlString(outdoorCourseUrl) && commonDictionaries !== undefined,
+      onError: async error => {
+        if (isRessourceMissing(error)) {
+          await router.push(routes.HOME);
+        }
+      },
+      staleTime: ONE_DAY,
     },
   );
 

--- a/frontend/src/components/pages/site/useOutdoorCourse.tsx
+++ b/frontend/src/components/pages/site/useOutdoorCourse.tsx
@@ -31,7 +31,7 @@ export const useOutdoorCourse = (
           await router.push(routes.HOME);
         }
       },
-      staleTime: ONE_DAY,
+      staleTime: ONE_DAY / 2,
     },
   );
 

--- a/frontend/src/components/pages/site/useOutdoorCourse.tsx
+++ b/frontend/src/components/pages/site/useOutdoorCourse.tsx
@@ -3,11 +3,10 @@ import { isUrlString } from 'modules/utils/string';
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useRouter } from 'next/router';
-import { CommonDictionaries } from 'modules/dictionaries/interface';
-import { getCommonDictionaries } from 'modules/dictionaries/connector';
 import { isRessourceMissing } from 'services/routeUtils';
 import { routes } from 'services/routes';
 import { ONE_DAY } from 'services/constants/staleTime';
+import { queryCommonDictionaries } from 'modules/dictionaries/api';
 import { DetailsSections } from '../details/useDetails';
 import { getDetailsConfig } from '../details/config';
 import { OutdoorCourseDetails } from '../../../modules/outdoorCourse/interface';
@@ -22,18 +21,7 @@ export const useOutdoorCourse = (
 
   const router = useRouter();
 
-  const { data: commonDictionaries } = useQuery<CommonDictionaries, Error>(
-    ['commonDictionaries', language],
-    () => getCommonDictionaries(language),
-    {
-      onError: async error => {
-        if (isRessourceMissing(error)) {
-          await router.push(routes.HOME);
-        }
-      },
-      staleTime: ONE_DAY / 2,
-    },
-  );
+  const commonDictionaries = queryCommonDictionaries(language);
 
   const { data, refetch, isLoading } = useQuery<OutdoorCourseDetails, Error>(
     ['outdoorCourseDetails', id, language],

--- a/frontend/src/components/pages/site/useOutdoorSite.tsx
+++ b/frontend/src/components/pages/site/useOutdoorSite.tsx
@@ -3,11 +3,10 @@ import { isUrlString } from 'modules/utils/string';
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { ONE_DAY } from 'services/constants/staleTime';
-import { CommonDictionaries } from 'modules/dictionaries/interface';
-import { getCommonDictionaries } from 'modules/dictionaries/connector';
 import { isRessourceMissing } from 'services/routeUtils';
 import { useRouter } from 'next/router';
 import { routes } from 'services/routes';
+import { queryCommonDictionaries } from 'modules/dictionaries/api';
 import { getOutdoorSiteDetails } from '../../../modules/outdoorSite/connector';
 import { OutdoorSiteDetails } from '../../../modules/outdoorSite/interface';
 import { getDetailsConfig } from '../details/config';
@@ -18,18 +17,7 @@ export const useOutdoorSite = (outdoorSiteUrl: string | string[] | undefined, la
   const path = isUrlString(outdoorSiteUrl) ? decodeURI(outdoorSiteUrl) : '';
   const router = useRouter();
 
-  const { data: commonDictionaries } = useQuery<CommonDictionaries, Error>(
-    ['commonDictionaries', language],
-    () => getCommonDictionaries(language),
-    {
-      onError: async error => {
-        if (isRessourceMissing(error)) {
-          await router.push(routes.HOME);
-        }
-      },
-      staleTime: ONE_DAY / 2,
-    },
-  );
+  const commonDictionaries = queryCommonDictionaries(language);
 
   const { data, refetch, isLoading } = useQuery<OutdoorSiteDetails, Error>(
     ['outdoorSiteDetails', id, language],

--- a/frontend/src/components/pages/site/useOutdoorSite.tsx
+++ b/frontend/src/components/pages/site/useOutdoorSite.tsx
@@ -3,6 +3,11 @@ import { isUrlString } from 'modules/utils/string';
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { ONE_DAY } from 'services/constants/staleTime';
+import { CommonDictionaries } from 'modules/dictionaries/interface';
+import { getCommonDictionaries } from 'modules/dictionaries/connector';
+import { isRessourceMissing } from 'services/routeUtils';
+import { useRouter } from 'next/router';
+import { routes } from 'services/routes';
 import { getOutdoorSiteDetails } from '../../../modules/outdoorSite/connector';
 import { OutdoorSiteDetails } from '../../../modules/outdoorSite/interface';
 import { getDetailsConfig } from '../details/config';
@@ -11,11 +16,31 @@ import { DetailsSections } from '../details/useDetails';
 export const useOutdoorSite = (outdoorSiteUrl: string | string[] | undefined, language: string) => {
   const id = isUrlString(outdoorSiteUrl) ? outdoorSiteUrl.split('-')[0] : '';
   const path = isUrlString(outdoorSiteUrl) ? decodeURI(outdoorSiteUrl) : '';
+  const router = useRouter();
+
+  const { data: commonDictionaries } = useQuery<CommonDictionaries, Error>(
+    ['commonDictionaries', language],
+    () => getCommonDictionaries(language),
+    {
+      onError: async error => {
+        if (isRessourceMissing(error)) {
+          await router.push(routes.HOME);
+        }
+      },
+      staleTime: ONE_DAY,
+    },
+  );
+
   const { data, refetch, isLoading } = useQuery<OutdoorSiteDetails, Error>(
     ['outdoorSiteDetails', id, language],
-    () => getOutdoorSiteDetails(id, language),
+    () => getOutdoorSiteDetails(id, language, commonDictionaries),
     {
-      enabled: isUrlString(outdoorSiteUrl),
+      enabled: isUrlString(outdoorSiteUrl) && commonDictionaries !== undefined,
+      onError: async error => {
+        if (isRessourceMissing(error)) {
+          await router.push(routes.HOME);
+        }
+      },
       staleTime: ONE_DAY,
     },
   );

--- a/frontend/src/components/pages/site/useOutdoorSite.tsx
+++ b/frontend/src/components/pages/site/useOutdoorSite.tsx
@@ -27,7 +27,7 @@ export const useOutdoorSite = (outdoorSiteUrl: string | string[] | undefined, la
           await router.push(routes.HOME);
         }
       },
-      staleTime: ONE_DAY,
+      staleTime: ONE_DAY / 2,
     },
   );
 

--- a/frontend/src/components/pages/touristicContent/useTouristicContent.tsx
+++ b/frontend/src/components/pages/touristicContent/useTouristicContent.tsx
@@ -32,7 +32,7 @@ export const useTouristicContent = (
           await router.push(routes.HOME);
         }
       },
-      staleTime: ONE_DAY,
+      staleTime: ONE_DAY / 2,
     },
   );
 

--- a/frontend/src/components/pages/touristicContent/useTouristicContent.tsx
+++ b/frontend/src/components/pages/touristicContent/useTouristicContent.tsx
@@ -8,8 +8,7 @@ import { useRouter } from 'next/router';
 import { ONE_DAY } from 'services/constants/staleTime';
 import { routes } from 'services/routes';
 import useSectionsReferences from 'hooks/useSectionsReferences';
-import { getCommonDictionaries } from 'modules/dictionaries/connector';
-import { CommonDictionaries } from 'modules/dictionaries/interface';
+import { queryCommonDictionaries } from 'modules/dictionaries/api';
 import { DetailsSections } from '../details/useDetails';
 import { getDetailsConfig } from '../details/config';
 
@@ -23,18 +22,7 @@ export const useTouristicContent = (
   const path = isTouristicContentUrlString ? decodeURI(touristicContentUrl) : '';
   const router = useRouter();
 
-  const { data: commonDictionaries } = useQuery<CommonDictionaries, Error>(
-    ['commonDictionaries', language],
-    () => getCommonDictionaries(language),
-    {
-      onError: async error => {
-        if (isRessourceMissing(error)) {
-          await router.push(routes.HOME);
-        }
-      },
-      staleTime: ONE_DAY / 2,
-    },
-  );
+  const commonDictionaries = queryCommonDictionaries(language);
 
   const { data, refetch, isLoading } = useQuery<TouristicContentDetails, Error>(
     ['touristicContentDetails', id, language],

--- a/frontend/src/components/pages/touristicEvent/useTouristicEvent.tsx
+++ b/frontend/src/components/pages/touristicEvent/useTouristicEvent.tsx
@@ -30,7 +30,7 @@ export const useTouristicEvent = (
           await router.push(routes.HOME);
         }
       },
-      staleTime: ONE_DAY,
+      staleTime: ONE_DAY / 2,
     },
   );
 

--- a/frontend/src/components/pages/touristicEvent/useTouristicEvent.tsx
+++ b/frontend/src/components/pages/touristicEvent/useTouristicEvent.tsx
@@ -6,8 +6,7 @@ import { useRouter } from 'next/router';
 import { ONE_DAY } from 'services/constants/staleTime';
 import { routes } from 'services/routes';
 import useSectionsReferences from 'hooks/useSectionsReferences';
-import { getCommonDictionaries } from 'modules/dictionaries/connector';
-import { CommonDictionaries } from 'modules/dictionaries/interface';
+import { queryCommonDictionaries } from 'modules/dictionaries/api';
 import { getTouristicEventDetails } from '../../../modules/touristicEvent/connector';
 import { TouristicEventDetails } from '../../../modules/touristicEvent/interface';
 import { getDetailsConfig } from '../details/config';
@@ -21,18 +20,7 @@ export const useTouristicEvent = (
   const path = isUrlString(touristicEventUrl) ? decodeURI(touristicEventUrl) : '';
   const router = useRouter();
 
-  const { data: commonDictionaries } = useQuery<CommonDictionaries, Error>(
-    ['commonDictionaries', language],
-    () => getCommonDictionaries(language),
-    {
-      onError: async error => {
-        if (isRessourceMissing(error)) {
-          await router.push(routes.HOME);
-        }
-      },
-      staleTime: ONE_DAY / 2,
-    },
-  );
+  const commonDictionaries = queryCommonDictionaries(language);
 
   const { data, refetch, isLoading } = useQuery<TouristicEventDetails, Error>(
     ['outdoorCourseDetails', id, language],

--- a/frontend/src/modules/activitySuggestions/connector.ts
+++ b/frontend/src/modules/activitySuggestions/connector.ts
@@ -1,7 +1,5 @@
 import { getActivities } from 'modules/activities/connector';
-import { getCities } from 'modules/city/connector';
 import { getDifficulties } from 'modules/filters/difficulties';
-import { getThemes } from 'modules/filters/theme/connector';
 import { getOutdoorPractices } from 'modules/outdoorPractice/connector';
 import { adaptoutdoorSitesResult } from 'modules/outdoorSite/adapter';
 import { fetchOutdoorSiteDetails } from 'modules/outdoorSite/api';
@@ -18,25 +16,24 @@ import { fetchTouristicEventDetails, fetchTouristicEvents } from 'modules/touris
 import { RawTouristicEventDetails } from 'modules/touristicEvent/interface';
 import { getTouristicEventTypes } from 'modules/touristicEventType/connector';
 import { ONE_DAY } from 'services/constants/staleTime';
+import { CommonDictionaries } from 'modules/dictionaries/interface';
 import { Suggestion } from '../home/interface';
 import { ActivitySuggestion } from './interface';
 export const getActivitySuggestions = async (
   suggestions: Suggestion[],
   language: string,
+  commonDictionaries?: CommonDictionaries,
 ): Promise<ActivitySuggestion[]> => {
+  const { cities = {}, themes = {} } = commonDictionaries ?? {};
   const [
     difficulties,
-    themes,
     activities,
-    cityDictionnary,
     touristicContentCategories,
     outdoorPracticeDictionnary,
     touristicEventType,
   ] = await Promise.all([
     getDifficulties(language),
-    getThemes(language),
     getActivities(language),
-    getCities(language),
     getTouristicContentCategories(language),
     getOutdoorPractices(language),
     getTouristicEventTypes(language),
@@ -62,7 +59,7 @@ export const getActivitySuggestions = async (
             difficulties,
             themes,
             activities,
-            cityDictionnary,
+            cityDictionnary: cities,
           }),
         };
       }
@@ -87,7 +84,7 @@ export const getActivitySuggestions = async (
                   ),
                   touristicContentCategories,
                   themeDictionnary: themes,
-                  cityDictionnary,
+                  cityDictionnary: cities,
                 }),
         };
       }
@@ -109,7 +106,7 @@ export const getActivitySuggestions = async (
             ),
             themeDictionnary: themes,
             outdoorPracticeDictionnary,
-            cityDictionnary,
+            cityDictionnary: cities,
           }),
         };
       }
@@ -128,7 +125,7 @@ export const getActivitySuggestions = async (
             ({ properties, ...result }) => ({ ...result, ...properties }), // Because for some reasons touristic events attributes are in properties field
           ),
           themeDictionnary: themes,
-          cityDictionnary,
+          cityDictionnary: cities,
           touristicEventType,
         });
         const resultsWithUnexpiredEvents = eventResult.filter(result => {
@@ -179,7 +176,7 @@ export const getActivitySuggestions = async (
             // And sliced with the desired items
             rawTouristicEvents: orderedUpcomingEventsResults.slice(0, numberOfItemsToDisplay),
             themeDictionnary: themes,
-            cityDictionnary,
+            cityDictionnary: cities,
             touristicEventType,
           }),
         };

--- a/frontend/src/modules/details/adapter.ts
+++ b/frontend/src/modules/details/adapter.ts
@@ -142,7 +142,7 @@ export const adaptResults = ({
         ? rawDetailsProperties.accessibilities.map(accessId => accessibilityDictionnary[accessId])
         : [],
       sources: Array.isArray(rawDetailsProperties.source)
-        ? rawDetailsProperties.source.map(sourceId => sourceDictionnary[sourceId])
+        ? rawDetailsProperties.source.map(sourceId => sourceDictionnary[sourceId]).filter(Boolean)
         : [],
       informationDesks: Array.isArray(rawDetailsProperties.information_desks)
         ? rawDetailsProperties.information_desks

--- a/frontend/src/modules/details/adapter.ts
+++ b/frontend/src/modules/details/adapter.ts
@@ -127,7 +127,9 @@ export const adaptResults = ({
       trekArrival: adaptGeometry2D(coordinates[coordinates.length - 1]),
       departure: rawDetailsProperties.departure,
       arrival: rawDetailsProperties.arrival,
-      cities: rawDetailsProperties.cities.map(id => cityDictionnary[id].name),
+      cities: rawDetailsProperties.cities
+        .map(id => cityDictionnary[id]?.name ?? null)
+        .filter(Boolean),
       cities_raw: rawDetailsProperties.cities,
       touristicContents,
       parkingLocation:

--- a/frontend/src/modules/details/adapter.ts
+++ b/frontend/src/modules/details/adapter.ts
@@ -150,7 +150,7 @@ export const adaptResults = ({
             .filter(Boolean)
         : [],
       labels: Array.isArray(rawDetailsProperties.labels)
-        ? rawDetailsProperties.labels.map(labelId => labelsDictionnary[labelId])
+        ? rawDetailsProperties.labels.map(labelId => labelsDictionnary[labelId]).filter(Boolean)
         : [],
       advice: rawDetailsProperties.advice,
       gear:

--- a/frontend/src/modules/details/adapter.ts
+++ b/frontend/src/modules/details/adapter.ts
@@ -145,7 +145,9 @@ export const adaptResults = ({
         ? rawDetailsProperties.source.map(sourceId => sourceDictionnary[sourceId])
         : [],
       informationDesks: Array.isArray(rawDetailsProperties.information_desks)
-        ? rawDetailsProperties.information_desks.map(deskId => informationDeskDictionnary[deskId])
+        ? rawDetailsProperties.information_desks
+            .map(deskId => informationDeskDictionnary[deskId])
+            .filter(Boolean)
         : [],
       labels: Array.isArray(rawDetailsProperties.labels)
         ? rawDetailsProperties.labels.map(labelId => labelsDictionnary[labelId])

--- a/frontend/src/modules/dictionaries/api.ts
+++ b/frontend/src/modules/dictionaries/api.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+import { ONE_DAY } from 'services/constants/staleTime';
+import { CommonDictionaries } from './interface';
+import { getCommonDictionaries } from './connector';
+
+export const queryCommonDictionaries = (language: string) => {
+  const { data } = useQuery<CommonDictionaries, Error>(
+    ['commonDictionaries', language],
+    () => getCommonDictionaries(language),
+    {
+      staleTime: ONE_DAY / 2,
+    },
+  );
+  return data;
+};

--- a/frontend/src/modules/dictionaries/connector.ts
+++ b/frontend/src/modules/dictionaries/connector.ts
@@ -1,0 +1,30 @@
+import { getCities } from 'modules/city/connector';
+import { getThemes } from 'modules/filters/theme/connector';
+import { getInformationDesks } from 'modules/informationDesk/connector';
+import { getLabels } from 'modules/label/connector';
+import { getSources } from 'modules/source/connector';
+import { CommonDictionaries } from './interface';
+
+export const getCommonDictionaries = async (language: string): Promise<CommonDictionaries> => {
+  let dictionaries;
+  try {
+    const [themes, cities, sources, informationDesk, labels] = await Promise.all([
+      getThemes(language),
+      getCities(language),
+      getSources(language),
+      getInformationDesks(language),
+      getLabels(language),
+    ]);
+    dictionaries = {
+      themes,
+      cities,
+      sources,
+      informationDesk,
+      labels,
+    };
+  } catch (e) {
+    console.error('Error in dictionaries/connector', e);
+    throw e;
+  }
+  return dictionaries;
+};

--- a/frontend/src/modules/dictionaries/interface.ts
+++ b/frontend/src/modules/dictionaries/interface.ts
@@ -1,0 +1,13 @@
+import { CityDictionnary } from 'modules/city/interface';
+import { Choices } from 'modules/filters/interface';
+import { InformationDeskDictionnary } from 'modules/informationDesk/interface';
+import { LabelDictionnary } from 'modules/label/interface';
+import { SourceDictionnary } from 'modules/source/interface';
+
+export type CommonDictionaries = {
+  themes: Choices;
+  cities: CityDictionnary;
+  sources: SourceDictionnary;
+  informationDesk: InformationDeskDictionnary;
+  labels: LabelDictionnary;
+};

--- a/frontend/src/modules/outdoorCourse/adapter.ts
+++ b/frontend/src/modules/outdoorCourse/adapter.ts
@@ -151,7 +151,10 @@ export const adaptOutdoorCourseDetails = ({
     gear: String(rawOutdoorCourseDetails.properties.gear),
     equipment: String(rawOutdoorCourseDetails.properties.equipment),
     pdfUri: rawOutdoorCourseDetails.properties.pdf,
-    cities: rawOutdoorCourseDetails.properties.cities?.map(id => cityDictionnary[id]?.name) ?? [],
+    cities:
+      rawOutdoorCourseDetails.properties.cities
+        ?.map(id => cityDictionnary[id]?.name ?? null)
+        .filter(Boolean) ?? [],
     cities_raw: rawOutdoorCourseDetails.properties.cities,
     ratings:
       rawOutdoorCourseDetails.properties.ratings?.map(r => {

--- a/frontend/src/modules/outdoorSite/adapter.ts
+++ b/frontend/src/modules/outdoorSite/adapter.ts
@@ -145,9 +145,9 @@ export const adaptOutdoorSiteDetails = ({
   source:
     rawOutdoorSiteDetails?.properties?.source?.map(sourceId => sourcesDictionnary[sourceId]) ?? [],
   informationDesks:
-    rawOutdoorSiteDetails?.properties?.information_desks?.map(
-      deskId => informationDesksDictionnary[deskId],
-    ) ?? [],
+    rawOutdoorSiteDetails?.properties?.information_desks
+      ?.map(deskId => informationDesksDictionnary[deskId])
+      .filter(Boolean) ?? [],
   webLinks: rawOutdoorSiteDetails?.properties?.web_links ?? null,
   pois,
   touristicContents,

--- a/frontend/src/modules/outdoorSite/adapter.ts
+++ b/frontend/src/modules/outdoorSite/adapter.ts
@@ -143,7 +143,9 @@ export const adaptOutdoorSiteDetails = ({
   labels:
     rawOutdoorSiteDetails?.properties?.labels?.map(labelId => labelsDictionnary[labelId]) ?? [],
   source:
-    rawOutdoorSiteDetails?.properties?.source?.map(sourceId => sourcesDictionnary[sourceId]) ?? [],
+    rawOutdoorSiteDetails?.properties?.source
+      ?.map(sourceId => sourcesDictionnary[sourceId])
+      .filter(Boolean) ?? [],
   informationDesks:
     rawOutdoorSiteDetails?.properties?.information_desks
       ?.map(deskId => informationDesksDictionnary[deskId])

--- a/frontend/src/modules/outdoorSite/adapter.ts
+++ b/frontend/src/modules/outdoorSite/adapter.ts
@@ -161,7 +161,10 @@ export const adaptOutdoorSiteDetails = ({
   access,
   pdfUri: rawOutdoorSiteDetails?.properties?.pdf || '',
   practice: outdoorPractice[String(rawOutdoorSiteDetails?.properties?.practice)] ?? null,
-  cities: rawOutdoorSiteDetails.properties.cities?.map(id => cityDictionnary[id]?.name) ?? [],
+  cities:
+    rawOutdoorSiteDetails.properties.cities
+      ?.map(id => cityDictionnary[id]?.name ?? null)
+      .filter(Boolean) ?? [],
   cities_raw: rawOutdoorSiteDetails.properties.cities,
   ratings:
     rawOutdoorSiteDetails.properties.ratings?.map(r => {

--- a/frontend/src/modules/outdoorSite/adapter.ts
+++ b/frontend/src/modules/outdoorSite/adapter.ts
@@ -141,7 +141,9 @@ export const adaptOutdoorSiteDetails = ({
     corner2: { x: rawOutdoorSiteDetails.bbox[2], y: rawOutdoorSiteDetails.bbox[3] },
   },
   labels:
-    rawOutdoorSiteDetails?.properties?.labels?.map(labelId => labelsDictionnary[labelId]) ?? [],
+    rawOutdoorSiteDetails?.properties?.labels
+      ?.map(labelId => labelsDictionnary[labelId])
+      .filter(Boolean) ?? [],
   source:
     rawOutdoorSiteDetails?.properties?.source
       ?.map(sourceId => sourcesDictionnary[sourceId])

--- a/frontend/src/modules/outdoorSite/connector.ts
+++ b/frontend/src/modules/outdoorSite/connector.ts
@@ -5,7 +5,6 @@ import { getInfrastructure } from 'modules/infrastructure/connector';
 import { adaptGeometry } from 'modules/utils/geometry';
 import { GeometryObject } from 'modules/interface';
 import { CommonDictionaries } from 'modules/dictionaries/interface';
-import { getCities } from '../city/connector';
 import { getOutdoorCoursesResult } from '../outdoorCourse/connector';
 import { getOutdoorPractices } from '../outdoorPractice/connector';
 import { getOutdoorRating } from '../outdoorRating/connector';
@@ -139,12 +138,13 @@ export const getOutdoorSiteDetails = async (
 export const getOutdoorSitePopupResult = async (
   id: string,
   language: string,
+  commonDictionaries?: CommonDictionaries,
 ): Promise<PopupResult> => {
   const rawOutdoorSitePopupResult = await fetchOutdoorSiteDetails({ language }, id);
 
-  const cityDictionnary = await getCities(language);
+  const { cities = {} } = commonDictionaries ?? {};
 
-  return adaptOutdoorSitePopupResults({ rawOutdoorSitePopupResult, cityDictionnary });
+  return adaptOutdoorSitePopupResults({ rawOutdoorSitePopupResult, cityDictionnary: cities });
 };
 
 export const getOutdoorSiteGeometryResult = async (

--- a/frontend/src/modules/outdoorSite/connector.ts
+++ b/frontend/src/modules/outdoorSite/connector.ts
@@ -94,7 +94,17 @@ export const getOutdoorSiteDetails = async (
       infrastructure,
       sensitiveAreas,
     ] = await Promise.all([
-      getTrekResults(language, { near_outdoorsite: Number(id) }),
+      getTrekResults(
+        language,
+        { near_outdoorsite: Number(id) },
+        {
+          cities,
+          themes,
+          sources,
+          informationDesk,
+          labels,
+        },
+      ),
       getOutdoorPractices(language),
       getOutdoorRating(language),
       getOutdoorRatingScale(language),

--- a/frontend/src/modules/results/connector.ts
+++ b/frontend/src/modules/results/connector.ts
@@ -10,6 +10,7 @@ import { DateFilter } from 'modules/filters/interface';
 import { TouristicContentResult } from 'modules/touristicContent/interface';
 import { getCities } from 'modules/city/connector';
 import { adaptTouristicContentResult } from 'modules/touristicContent/adapter';
+import { CommonDictionaries } from 'modules/dictionaries/interface';
 import { getOutdoorPractices } from '../outdoorPractice/connector';
 import { adaptoutdoorSitesResult } from '../outdoorSite/adapter';
 import { fetchOutdoorSites } from '../outdoorSite/api';
@@ -333,16 +334,21 @@ export const getSearchResults = async (
 export const getTrekResultsById = async (
   trekIds: number[],
   language: string,
+  commonDictionaries?: CommonDictionaries,
 ): Promise<TrekResult[]> => {
   try {
-    if (trekIds === null || trekIds === undefined || trekIds.length === 0) {
+    if (
+      trekIds === null ||
+      trekIds === undefined ||
+      trekIds.length === 0 ||
+      commonDictionaries === undefined
+    ) {
       return [];
     }
-    const [difficulties, themes, activities, cityDictionnary] = await Promise.all([
+    const { themes, cities } = commonDictionaries;
+    const [difficulties, activities] = await Promise.all([
       getDifficulties(language),
-      getThemes(language),
       getActivities(language),
-      getCities(language),
     ]);
     const rawTrekResults = await Promise.all(
       trekIds.map(trekId => fetchTrekResult({ language }, trekId)),
@@ -352,7 +358,7 @@ export const getTrekResultsById = async (
       difficulties,
       themes,
       activities,
-      cityDictionnary,
+      cityDictionnary: cities,
     });
   } catch (e) {
     console.error('Error in results connector', e);

--- a/frontend/src/modules/touristicContent/connector.ts
+++ b/frontend/src/modules/touristicContent/connector.ts
@@ -1,4 +1,3 @@
-import { getCities } from 'modules/city/connector';
 import { GeometryObject } from 'modules/interface';
 import {
   getTouristicContentCategories,
@@ -76,13 +75,12 @@ export const getTouristicContentDetails = async (
 export const getTouristicContentPopupResult = async (
   id: string,
   language: string,
+  commonDictionaries?: CommonDictionaries,
 ): Promise<PopupResult> => {
-  const [rawTouristicContentPopupResult, cityDictionnary] = await Promise.all([
-    fetchTouristicContentPopupResult({ language }, id),
-    getCities(language),
-  ]);
+  const rawTouristicContentPopupResult = await fetchTouristicContentPopupResult({ language }, id);
+  const { cities = {} } = commonDictionaries ?? {};
 
-  return adaptTouristicContentPopupResults(rawTouristicContentPopupResult, cityDictionnary);
+  return adaptTouristicContentPopupResults(rawTouristicContentPopupResult, cities);
 };
 
 export const getTouristicContentGeometryResult = async (

--- a/frontend/src/modules/touristicContent/connector.ts
+++ b/frontend/src/modules/touristicContent/connector.ts
@@ -1,7 +1,5 @@
 import { getCities } from 'modules/city/connector';
-import { getThemes } from 'modules/filters/theme/connector';
 import { GeometryObject } from 'modules/interface';
-import { getSources } from 'modules/source/connector';
 import {
   getTouristicContentCategories,
   getTouristicContentCategory,
@@ -9,6 +7,7 @@ import {
 import { PopupResult } from 'modules/trekResult/interface';
 import { getGlobalConfig } from 'modules/utils/api.config';
 import { adaptGeometry } from 'modules/utils/geometry';
+import { CommonDictionaries } from 'modules/dictionaries/interface';
 import {
   adaptTouristicContent,
   adaptTouristicContentDetails,
@@ -52,15 +51,11 @@ export const getTouristicContents = async (language: string): Promise<TouristicC
 export const getTouristicContentDetails = async (
   id: string,
   language: string,
+  commonDictionaries?: CommonDictionaries,
 ): Promise<TouristicContentDetails> => {
   try {
-    const [rawTouristicContentDetails, sourceDictionnary, cityDictionnary, themeDictionnary] =
-      await Promise.all([
-        fetchTouristicContentDetails({ language }, id),
-        getSources(language),
-        getCities(language),
-        getThemes(language),
-      ]);
+    const { themes = {}, cities = {}, sources = [] } = commonDictionaries ?? {};
+    const rawTouristicContentDetails = await fetchTouristicContentDetails({ language }, id);
     const touristicContentCategory = await getTouristicContentCategory(
       rawTouristicContentDetails.properties.category,
       language,
@@ -68,9 +63,9 @@ export const getTouristicContentDetails = async (
     return adaptTouristicContentDetails({
       rawTCD: rawTouristicContentDetails,
       touristicContentCategory,
-      sourceDictionnary,
-      cityDictionnary,
-      themeDictionnary,
+      sourceDictionnary: sources,
+      cityDictionnary: cities,
+      themeDictionnary: themes,
     });
   } catch (e) {
     console.error('Error in touristicContent connector', e);

--- a/frontend/src/modules/touristicEvent/connector.ts
+++ b/frontend/src/modules/touristicEvent/connector.ts
@@ -1,38 +1,12 @@
 import { GeometryObject } from 'modules/interface';
 import { adaptGeometry } from 'modules/utils/geometry';
 import { CommonDictionaries } from 'modules/dictionaries/interface';
-import { getCities } from '../city/connector';
-import { getThemes } from '../filters/theme/connector';
 import { getTouristicContentsNearTarget } from '../touristicContent/connector';
 import { getTouristicEventTypes } from '../touristicEventType/connector';
 import { PopupResult } from '../trekResult/interface';
-import {
-  adaptTouristicEventDetails,
-  adaptTouristicEventPopupResults,
-  adaptTouristicEvents,
-} from './adapter';
-import { fetchTouristicEventDetails, fetchTouristicEventResult, fetchTouristicEvents } from './api';
-import { TouristicEvent, TouristicEventDetails } from './interface';
-
-export const getTouristicEvents = async (
-  language: string,
-  query = {},
-): Promise<TouristicEvent[]> => {
-  const [rawTouristicEventResult, themeDictionnary, cityDictionnary, touristicEventType] =
-    await Promise.all([
-      fetchTouristicEvents({ ...query, language }),
-      getThemes(language),
-      getCities(language),
-      getTouristicEventTypes(language),
-    ]);
-
-  return adaptTouristicEvents({
-    rawTouristicEvents: rawTouristicEventResult.results,
-    themeDictionnary,
-    cityDictionnary,
-    touristicEventType,
-  });
-};
+import { adaptTouristicEventDetails, adaptTouristicEventPopupResults } from './adapter';
+import { fetchTouristicEventDetails, fetchTouristicEventResult } from './api';
+import { TouristicEventDetails } from './interface';
 
 export const getTouristicEventDetails = async (
   id: string,
@@ -64,12 +38,13 @@ export const getTouristicEventDetails = async (
 export const getTouristicEventPopupResult = async (
   id: string,
   language: string,
+  commonDictionaries?: CommonDictionaries,
 ): Promise<PopupResult> => {
   const rawTouristicEventPopupResult = await fetchTouristicEventDetails({ language }, id);
 
-  const [cityDictionnary] = await Promise.all([getCities(language)]);
+  const { cities = {} } = commonDictionaries ?? {};
 
-  return adaptTouristicEventPopupResults({ rawTouristicEventPopupResult, cityDictionnary });
+  return adaptTouristicEventPopupResults({ rawTouristicEventPopupResult, cityDictionnary: cities });
 };
 
 export const getTouristicEventGeometryResult = async (

--- a/frontend/src/modules/touristicEvent/connector.ts
+++ b/frontend/src/modules/touristicEvent/connector.ts
@@ -1,8 +1,8 @@
 import { GeometryObject } from 'modules/interface';
 import { adaptGeometry } from 'modules/utils/geometry';
+import { CommonDictionaries } from 'modules/dictionaries/interface';
 import { getCities } from '../city/connector';
 import { getThemes } from '../filters/theme/connector';
-import { getSources } from '../source/connector';
 import { getTouristicContentsNearTarget } from '../touristicContent/connector';
 import { getTouristicEventTypes } from '../touristicEventType/connector';
 import { PopupResult } from '../trekResult/interface';
@@ -37,30 +37,22 @@ export const getTouristicEvents = async (
 export const getTouristicEventDetails = async (
   id: string,
   language: string,
+  commonDictionaries?: CommonDictionaries,
 ): Promise<TouristicEventDetails> => {
   try {
-    const [
-      rawTouristicEventDetails,
-      themeDictionnary,
-      cityDictionnary,
-      touristicContents,
-      sourcesDictionnary,
-      touristicEventType,
-    ] = await Promise.all([
+    const { themes = {}, cities = {}, sources = [] } = commonDictionaries ?? {};
+    const [rawTouristicEventDetails, touristicContents, touristicEventType] = await Promise.all([
       fetchTouristicEventDetails({ language }, id),
-      getThemes(language),
-      getCities(language),
       getTouristicContentsNearTarget(Number(id), language, 'near_touristicevent'),
-      getSources(language),
       getTouristicEventTypes(language),
     ]);
 
     return adaptTouristicEventDetails({
       rawTouristicEventDetails,
-      themeDictionnary,
-      cityDictionnary,
+      themeDictionnary: themes,
+      cityDictionnary: cities,
       touristicContents,
-      sourcesDictionnary,
+      sourcesDictionnary: sources,
       touristicEventType,
     });
   } catch (e) {

--- a/frontend/src/pages/event/[touristicEvent].tsx
+++ b/frontend/src/pages/event/[touristicEvent].tsx
@@ -5,6 +5,7 @@ import { getDefaultLanguage } from 'modules/header/utills';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import { routes } from 'services/routes';
 import { redirectIfWrongUrl } from 'modules/utils/url';
+import { getCommonDictionaries } from 'modules/dictionaries/connector';
 import { getTouristicEventDetails } from '../../modules/touristicEvent/connector';
 import { isUrlString } from '../../modules/utils/string';
 import Custom404 from '../404';
@@ -17,8 +18,10 @@ export const getServerSideProps: GetServerSideProps = async context => {
 
   const queryClient = new QueryClient();
   try {
-    const details = await getTouristicEventDetails(id, locale);
+    const commonDictionaries = await getCommonDictionaries(locale);
+    await queryClient.prefetchQuery(['commonDictionaries', locale], () => commonDictionaries);
 
+    const details = await getTouristicEventDetails(id, locale, commonDictionaries);
     await queryClient.prefetchQuery(['touristicEventDetails', id, locale], () => details);
 
     const redirect = redirectIfWrongUrl(

--- a/frontend/src/pages/outdoor-course/[outdoorCourse].tsx
+++ b/frontend/src/pages/outdoor-course/[outdoorCourse].tsx
@@ -5,6 +5,7 @@ import { getDefaultLanguage } from 'modules/header/utills';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import { routes } from 'services/routes';
 import { redirectIfWrongUrl } from 'modules/utils/url';
+import { getCommonDictionaries } from 'modules/dictionaries/connector';
 import { getOutdoorCourseDetails } from '../../modules/outdoorCourse/connector';
 import { isUrlString } from '../../modules/utils/string';
 import Custom404 from '../404';
@@ -18,8 +19,10 @@ export const getServerSideProps: GetServerSideProps = async context => {
   const queryClient = new QueryClient();
 
   try {
-    const details = await getOutdoorCourseDetails(id, locale);
+    const commonDictionaries = await getCommonDictionaries(locale);
+    await queryClient.prefetchQuery(['commonDictionaries', locale], () => commonDictionaries);
 
+    const details = await getOutdoorCourseDetails(id, locale, commonDictionaries);
     await queryClient.prefetchQuery(['outdoorCourseDetails', id, locale], () => details);
 
     const redirect = redirectIfWrongUrl(

--- a/frontend/src/pages/outdoor-site/[outdoorSite].tsx
+++ b/frontend/src/pages/outdoor-site/[outdoorSite].tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 import { getDefaultLanguage } from 'modules/header/utills';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import { routes } from 'services/routes';
+import { getCommonDictionaries } from 'modules/dictionaries/connector';
 import { getOutdoorSiteDetails } from '../../modules/outdoorSite/connector';
 import { isUrlString } from '../../modules/utils/string';
 import { redirectIfWrongUrl } from '../../modules/utils/url';
@@ -16,8 +17,10 @@ export const getServerSideProps: GetServerSideProps = async context => {
   const queryClient = new QueryClient();
 
   try {
-    const details = await getOutdoorSiteDetails(id, locale);
+    const commonDictionaries = await getCommonDictionaries(locale);
+    await queryClient.prefetchQuery(['commonDictionaries', locale], () => commonDictionaries);
 
+    const details = await getOutdoorSiteDetails(id, locale, commonDictionaries);
     await queryClient.prefetchQuery(['outdoorSiteDetails', id, locale], () => details);
 
     const redirect = redirectIfWrongUrl(

--- a/frontend/src/pages/search.tsx
+++ b/frontend/src/pages/search.tsx
@@ -5,6 +5,7 @@ import { getDefaultLanguage } from 'modules/header/utills';
 import { getSearchResults } from 'modules/results/connector';
 import { GetServerSideProps, NextPage } from 'next';
 import { dehydrate, DehydratedState, QueryClient } from '@tanstack/react-query';
+import { getCommonDictionaries } from 'modules/dictionaries/connector';
 import { getGlobalConfig } from '../modules/utils/api.config';
 import Custom404 from './404';
 
@@ -29,6 +30,9 @@ export const getServerSideProps: GetServerSideProps = async context => {
       beginDate: context.query.beginDate ?? '',
       endDate: context.query.endDate ?? '',
     };
+
+    const commonDictionaries = await getCommonDictionaries(locale);
+    await queryClient.prefetchQuery(['commonDictionaries', locale], () => commonDictionaries);
 
     await queryClient.prefetchInfiniteQuery(
       [
@@ -55,6 +59,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
             touristicEvents: getGlobalConfig().enableTouristicEvents ? page : null,
           },
           locale,
+          commonDictionaries,
         ),
     );
   } catch (error) {

--- a/frontend/src/pages/service/[touristicContent].tsx
+++ b/frontend/src/pages/service/[touristicContent].tsx
@@ -4,6 +4,7 @@ import { TouristicContentUI } from 'components/pages/touristicContent';
 import { getDefaultLanguage } from 'modules/header/utills';
 import { dehydrate, QueryClient } from '@tanstack/react-query';
 import { routes } from 'services/routes';
+import { getCommonDictionaries } from 'modules/dictionaries/connector';
 import { getTouristicContentDetails } from '../../modules/touristicContent/connector';
 import { isUrlString } from '../../modules/utils/string';
 import { redirectIfWrongUrl } from '../../modules/utils/url';
@@ -18,8 +19,10 @@ export const getServerSideProps: GetServerSideProps = async context => {
   const queryClient = new QueryClient();
 
   try {
-    const details = await getTouristicContentDetails(id, locale);
+    const commonDictionaries = await getCommonDictionaries(locale);
+    await queryClient.prefetchQuery(['commonDictionaries', locale], () => commonDictionaries);
 
+    const details = await getTouristicContentDetails(id, locale, commonDictionaries);
     await queryClient.prefetchQuery(['touristicContentDetails', id, locale], () => details);
 
     const redirect = redirectIfWrongUrl(

--- a/frontend/src/pages/trek/[slug].tsx
+++ b/frontend/src/pages/trek/[slug].tsx
@@ -7,6 +7,7 @@ import { getDetails, getTrekFamily } from 'modules/details/connector';
 import { isUrlString } from 'modules/utils/string';
 import { getDefaultLanguage } from 'modules/header/utills';
 import { routes } from 'services/routes';
+import { getCommonDictionaries } from 'modules/dictionaries/connector';
 import { redirectIfWrongUrl } from '../../modules/utils/url';
 import Custom404 from '../404';
 
@@ -18,7 +19,10 @@ export const getServerSideProps: GetServerSideProps = async context => {
   const queryClient = new QueryClient();
 
   try {
-    const details = await getDetails(id, locale);
+    const commonDictionaries = await getCommonDictionaries(locale);
+    await queryClient.prefetchQuery(['commonDictionaries', locale], () => commonDictionaries);
+
+    const details = await getDetails(id, locale, commonDictionaries);
 
     await queryClient.prefetchQuery(['details', id, locale], () => details);
     await queryClient.prefetchQuery(['trekFamily', parentIdString, locale], () =>


### PR DESCRIPTION
Put common dictionaries (themes, cities, sources, informationDesk, labels)  in the server cache and use it for search/details/suggestions pages
