### PR TITLE
Define reservation id to null if it's an empty string

### DIFF
--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -37,8 +37,6 @@
     "@typescript-eslint/no-inferrable-types": "error",
     "@typescript-eslint/prefer-for-of": "error",
     "@typescript-eslint/unified-signatures": "error",
-    "@typescript-eslint/prefer-nullish-coalescing": "error",
-    "@typescript-eslint/strict-boolean-expressions": "warn",
     "@typescript-eslint/ban-ts-comment": "warn",
     "@typescript-eslint/no-unsafe-assignment": "off",
     "@typescript-eslint/no-unsafe-call": "off",

--- a/frontend/src/modules/details/adapter.ts
+++ b/frontend/src/modules/details/adapter.ts
@@ -175,7 +175,7 @@ export const adaptResults = ({
       altimetricProfileUrl: rawDetailsProperties.altimetric_profile,
       length2d: rawDetailsProperties.length_2d,
       reservation,
-      reservation_id: rawDetailsProperties.reservation_id ?? null,
+      reservation_id: rawDetailsProperties.reservation_id || null,
       ratings:
         rawDetailsProperties.ratings?.map(r => {
           return {


### PR DESCRIPTION
The app doen't handle the revervation_id equals to an empty string, this PR corrects it. 