### PR TITLE
Fix colorization of the map filter button

### DIFF
--- a/frontend/src/components/Map/SearchMap/index.tsx
+++ b/frontend/src/components/Map/SearchMap/index.tsx
@@ -18,7 +18,6 @@ export type PropsType = {
   hideMap?: () => void;
   hasZoomControl?: boolean;
   openFilterMenu?: () => void;
-  hasFilters?: boolean;
   arrivalLocation?: { x: number; y: number };
   departureLocation?: { x: number; y: number };
   parkingLocation?: { x: number; y: number };
@@ -41,7 +40,7 @@ const SearchMap: React.FC<PropsType> = props => {
       {props.onMove && <MoveHandler onMove={props.onMove} />}
       <TileLayerManager />
       <BackButton icon={<ArrowLeft size={24} />} onClick={hideMap} />
-      <FilterButton openFilterMenu={props.openFilterMenu} hasFilters={props.hasFilters} />
+      <FilterButton openFilterMenu={props.openFilterMenu} />
       <ResetView />
       <ScaleControl />
       <SearchMapChildrens {...props} />

--- a/frontend/src/components/Map/components/FilterButton/index.tsx
+++ b/frontend/src/components/Map/components/FilterButton/index.tsx
@@ -1,28 +1,35 @@
 import { Filter } from 'components/Icons/Filter';
 import { ControlPosition } from 'leaflet';
+import { cn } from 'services/utils/cn';
+import { useRouter } from 'next/router';
+import { FormattedMessage } from 'react-intl';
 import Control from '../CustomControl';
 
 interface Props {
   openFilterMenu?: () => void;
-  hasFilters?: boolean;
   position?: ControlPosition;
 }
 
 export const FilterButton: React.FC<Props> = ({
   openFilterMenu = () => null,
-  hasFilters = false,
   position = 'topright',
 }) => {
+  const { query = {} } = useRouter();
+  const hasFilters = Object.keys(query).length > 0;
   return (
     <Control position={position}>
       <button
         type="button"
         onClick={openFilterMenu}
-        className={`rounded-full p-2 shadow-md bg-white flex justify-center items-center text-greyDarkColored desktop:hidden ${
-          hasFilters ? 'bg-primary1' : ''
-        }`}
+        className={cn(
+          'rounded-full p-2 shadow-md  flex justify-center items-center text-greyDarkColored desktop:hidden',
+          hasFilters ? 'bg-primary1' : 'bg-white',
+        )}
       >
         <Filter size={24} className={hasFilters ? 'text-white' : 'text-primary1'} />
+        <span className="sr-only">
+          <FormattedMessage id="search.filter" />
+        </span>
       </button>
     </Control>
   );

--- a/frontend/src/components/pages/search/Search.tsx
+++ b/frontend/src/components/pages/search/Search.tsx
@@ -280,7 +280,6 @@ export const SearchUI: React.FC<Props> = ({ language }) => {
           <SearchMapDynamicComponent
             hideMap={hideMobileMap}
             openFilterMenu={displayMenu}
-            hasFilters={numberSelected > 0}
             shouldUseClusters
             shouldUsePopups
           />


### PR DESCRIPTION
The map filter changes color when certain filters are selected or none, this was not working correctly as the map component is only rendered once.

Two fixes:
- Re-render the component and set the toggle color dynamically
- Fixed the className conflict defining the button background-color

One improvement:
- Define an invisible label for the button (for a11y purposes).