### PR TITLE
Avoid saving tiles from data.geopf.fr to cache storage

### DIFF
--- a/frontend/cache.js
+++ b/frontend/cache.js
@@ -36,6 +36,7 @@ module.exports = [
         && !url.host.includes('openstreetmap')
         && !url.host.includes('stamen-tiles')
         && !url.host.includes('wxs.ign.fr')
+        && !url.host.includes('data.geopf.fr')
         && request.destination === 'image'
     },
     handler: 'NetworkFirst',


### PR DESCRIPTION
Prepare the migration of IGN's tile server, scheduled for the end of the year
Ref https://github.com/GeotrekCE/Geotrek-rando-v3/issues/604#issuecomment-1751646992 