### PR TITLE
Fix display of outdoorSite courses

### DIFF
--- a/frontend/src/components/pages/site/OutdoorSiteUI.tsx
+++ b/frontend/src/components/pages/site/OutdoorSiteUI.tsx
@@ -262,7 +262,7 @@ const OutdoorSiteUIWithoutContext: React.FC<Props> = ({ outdoorSiteUrl, language
 
                     if (
                       section.name === 'courses' &&
-                      Number(outdoorSiteContent.children?.length) > 0
+                      Number(outdoorSiteContent.courses?.length) > 0
                     ) {
                       return (
                         <section


### PR DESCRIPTION
The condition for displaying outdoorSite courses was incorrect: it checks the number of children (i.e. the children site of the current outdoorSite) instead of the outdoor courses related.

Regression since https://github.com/GeotrekCE/Geotrek-rando-v3/releases/tag/v3.15.0
