### PR TITLE
Fix dynamic acceptance/refusal of GA cookies

### DIFF
--- a/docs/customization-scripts-GDPR.md
+++ b/docs/customization-scripts-GDPR.md
@@ -111,14 +111,17 @@ To avoid this, one solution is to check the user's acceptance in the cookies.
 >
   // Send visit on each dynamic page change
   window.next.router.events.on('routeChangeComplete', function(url) {
++   (function(allowsGTMCookies) {
++     // Tell Google if it can use the service
++     window['ga-disable-<GOOGLE_ANALYTICS_ID>'] = !allowsGTMCookies;
++      if (allowsGTMCookies) {
+        window.dataLayer.push({
+          event: "pageview",
+          page: url,
+        })
++     }
 +   // Check the user's acceptance of "google-tag-manager" in the cookies
-+   if (JSON.parse(new URLSearchParams(document.cookie.replaceAll('; ', '&')).get('orejime') ?? null)?.["google-tag-manager"] !== true) {
-+       return;
-+   }
-    window.dataLayer.push({
-      event: "pageview",
-      page: url,
-    })
++   })(JSON.parse(new URLSearchParams(document.cookie.replaceAll('; ', '&')).get('orejime') ?? null)?.["google-tag-manager"]);
   });
 </script>
 ```

--- a/frontend/src/components/Layout/useExternalScripts.tsx
+++ b/frontend/src/components/Layout/useExternalScripts.tsx
@@ -116,7 +116,7 @@ export const useExternalsScripts = (executeOnLoad = false) => {
     // @ts-ignore the lib is not typed
     const Orejime = await import('orejime');
     const { show } = Orejime.init(orejimeConfig(consentList, locale, privacyPolicyLink));
-    if (!executeOnLoad || !document.cookie.includes('orejime=')) {
+    if (!executeOnLoad) {
       show();
     }
   }

--- a/frontend/src/components/Layout/useExternalScripts.tsx
+++ b/frontend/src/components/Layout/useExternalScripts.tsx
@@ -77,13 +77,15 @@ export const useExternalsScripts = (executeOnLoad = false) => {
     gtag('config', '${googleAnalyticsId}');
 
     window.next.router.events.on('routeChangeComplete', function(url) {
-      if (JSON.parse(new URLSearchParams(document.cookie.replaceAll('; ', '&')).get('orejime') ?? null)?.["google-tag-manager"] !== true) {
-        return;
-      }
-      window.dataLayer.push({
-        event: "pageview",
-        page: url,
-      })
+      (function(allowsGTMCookies) {
+        window['ga-disable-${googleAnalyticsId}'] = !allowsGTMCookies;
+        if (allowsGTMCookies) {
+          window.dataLayer.push({
+            event: "pageview",
+            page: url,
+          })
+        }
+      })(JSON.parse(new URLSearchParams(document.cookie.replaceAll('; ', '&')).get('orejime') ?? null)?.["google-tag-manager"]);
     });
   </script>
   `


### PR DESCRIPTION
- Fix dynamic acceptance/refusal of GA cookies  when user changes consent without hard reloading browser.
- Display only the GDPR notice if the user has not yet given explicit consent (instead of Modal + Notice)
