### PR TITLE
Avoid app crashes if `/customization/html/details` folder is missing

### DIFF
--- a/frontend/src/services/getConfig.js
+++ b/frontend/src/services/getConfig.js
@@ -2,8 +2,17 @@ const fs = require('fs');
 const deepmerge = require('deepmerge');
 const { getLocales } = require('./getLocales');
 
+function isPathExists(path) {
+  try {
+    fs.accessSync(path, fs.R_OK);
+    return true;
+  } catch (err) {
+    return false;
+  }
+}
+
 function getFiles(dir, files = []) {
-  if (!fs.existsSync(dir)) {
+  if (!isPathExists(dir)) {
     return files;
   }
   const fileList = fs.readdirSync(dir);
@@ -19,7 +28,7 @@ function getFiles(dir, files = []) {
 }
 
 const getContent = (path, parse) => {
-  if (fs.existsSync(path)) {
+  if (isPathExists(path)) {
     const content = fs.readFileSync(path).toString();
     return parse ? JSON.parse(content) : content;
   }

--- a/frontend/src/services/getConfig.js
+++ b/frontend/src/services/getConfig.js
@@ -3,6 +3,9 @@ const deepmerge = require('deepmerge');
 const { getLocales } = require('./getLocales');
 
 function getFiles(dir, files = []) {
+  if (!fs.existsSync(dir)) {
+    return files;
+  }
   const fileList = fs.readdirSync(dir);
   for (const file of fileList) {
     const name = `${dir}/${file}`;


### PR DESCRIPTION
Since 3.16.0, the app crashes on runtime if the  `/customization/html/details` folder is missing
