### PR TITLE
Display viewPoint HD layer selector only if there are related viewPoints

### DIFF
--- a/frontend/src/components/Map/DetailsMap/DetailsMap.tsx
+++ b/frontend/src/components/Map/DetailsMap/DetailsMap.tsx
@@ -257,7 +257,7 @@ export const DetailsMap: React.FC<PropsType> = props => {
                 props.service && props.service.length > 0 ? serviceVisibility : null
               }
               infrastructureVisibility={props.infrastructure ? infrastructureVisibility : null}
-              viewPointVisibility={props.viewPoints ? viewPointVisibility : null}
+              viewPointVisibility={props.viewPoints?.length ? viewPointVisibility : null}
               toggleTrekChildrenVisibility={toggleTrekChildrenVisibility}
               togglePoiVisibility={togglePoiVisibility}
               toggleReferencePointsVisibility={toggleReferencePointsVisibility}


### PR DESCRIPTION
The viewPoint control layer is always displayed even if there is no HD viewpoint related to the detail page.

## Screenshots
![image](https://github.com/GeotrekCE/Geotrek-rando-v3/assets/1926041/e75b5f5f-d3c2-4cf4-9dd1-ac90ac17e6c7)

With this PR, it's only displayed if there are viewpoints