### PR TITLE
Clean search params

### DIFF
--- a/frontend/src/components/pages/search/components/useFilters.ts
+++ b/frontend/src/components/pages/search/components/useFilters.ts
@@ -63,7 +63,9 @@ export const useFilter = () => {
         if (filterState.id === filterId) {
           return {
             ...filterState,
-            selectedOptions: options.sort((a, b) => a.value.localeCompare(b.value)),
+            selectedOptions: options.sort((a, b) =>
+              a.value.localeCompare(b.value, undefined, { numeric: true }),
+            ),
           };
         }
         return filterState;

--- a/frontend/src/components/pages/search/hooks/useTrekResults.ts
+++ b/frontend/src/components/pages/search/hooks/useTrekResults.ts
@@ -27,14 +27,14 @@ const computeUrl = (
   textFilter: string | null,
   dateFilter: DateFilter | null,
 ) => {
-  const urlParams =
-    textFilter !== null
-      ? [...formatFiltersUrl(filtersState), `text=${textFilter}`]
-      : formatFiltersUrl(filtersState);
+  const urlParams = formatFiltersUrl(filtersState);
 
-  dateFilter && dateFilter.beginDate !== '' && urlParams.push(`beginDate=${dateFilter?.beginDate}`);
-  dateFilter && dateFilter.endDate !== '' && urlParams.push(`endDate=${dateFilter?.endDate}`);
-  const formattedUrl = `search?${urlParams.join('&')}`;
+  textFilter && urlParams.push(`text=${textFilter}`);
+  dateFilter?.beginDate && urlParams.push(`beginDate=${dateFilter.beginDate}`);
+  dateFilter?.endDate && urlParams.push(`endDate=${dateFilter.endDate}`);
+
+  const params = urlParams.join('&');
+  const formattedUrl = `search${params && '?'}${params}`;
 
   return formattedUrl;
 };
@@ -134,7 +134,7 @@ export const useTrekResults = (
       void router.push(url, undefined, { shallow: true });
       void refetch();
     }
-  }, [filtersState, textFilterState, dateFilter, refetch]);
+  }, [filtersState, textFilterState, dateFilter, refetch, router]);
 
   return {
     searchResults: formatInfiniteQuery(data),

--- a/frontend/src/pages/search.tsx
+++ b/frontend/src/pages/search.tsx
@@ -17,7 +17,7 @@ export const getServerSideProps: GetServerSideProps = async context => {
   const queryClient = new QueryClient();
   const { initialFiltersStateWithSelectedOptions } = await getInitialFilters(locale, context.query);
   const parsedInitialFiltersState = parseFilters(initialFiltersStateWithSelectedOptions);
-  const initialTextFilter = context.query.text?.toString() ?? null;
+  const initialTextFilter = context.query.text?.toString() ?? '';
   const page = Number(context.query.page ?? 1);
 
   try {


### PR DESCRIPTION
Clean searchParams URL when removing all filters for :
  - removing the extra `?` character from `/search?`
  - cleaning empty params like `/search?text=`
  
Better ID sort display in searchParams:
- Before `/search?outdoorPractice=1,10,12,4,7,8`
- After `/search?outdoorPractice=1,4,7,8,10,12,`
