### PR TITLE
Avoid to stringify potentially nullable props

### DIFF
--- a/frontend/src/components/Map/Markers/TrekMarker.tsx
+++ b/frontend/src/components/Map/Markers/TrekMarker.tsx
@@ -27,11 +27,11 @@ const getTop = (ratio: number) => {
   return 'top-2';
 };
 
-const ActivityMarker: React.FC<{ pictogramUrl?: string; zoomRatio: number; color: string }> = ({
-  pictogramUrl,
-  zoomRatio,
-  color,
-}) => {
+const ActivityMarker: React.FC<{
+  pictogramUrl?: string | null;
+  zoomRatio: number;
+  color: string;
+}> = ({ pictogramUrl, zoomRatio, color }) => {
   const icon =
     Boolean(pictogramUrl) && pictogramUrl?.[0] === '<'
       ? `data:image/svg+xml;utf8,${pictogramUrl}`

--- a/frontend/src/modules/mapResults/adapter.ts
+++ b/frontend/src/modules/mapResults/adapter.ts
@@ -88,7 +88,7 @@ export const adaptTouristicEventsMapResults = ({
           ? {
               id: 0,
               label: String(touristicEventTypes[rawMapResult.type].label),
-              pictogramUri: String(touristicEventTypes[rawMapResult.type].pictogramUri),
+              pictogramUri: touristicEventTypes[rawMapResult.type].pictogramUri,
             }
           : undefined,
       type: 'TOURISTIC_EVENT',

--- a/frontend/src/pages/offline/index.tsx
+++ b/frontend/src/pages/offline/index.tsx
@@ -59,7 +59,7 @@ const OfflinePage: NextPage = () => {
                 {
                   label: 'difficulty',
                   value: result.informations.difficulty?.label ?? '',
-                  pictogramUri: String(result.informations.difficulty?.pictogramUri ?? ''),
+                  pictogramUri: result.informations.difficulty?.pictogramUri ?? '',
                 },
                 {
                   label: 'duration',


### PR DESCRIPTION
Sometimes `pictogramUri` returns `null`.
In this situation, applying `String(null)` returns the value `'null'` which is not falsy. 

Thx @Bo-Duke for the help!
