### PR TITLE
Display Files from attachments to donwload in details pages

### DIFF
--- a/frontend/config/details.json
+++ b/frontend/config/details.json
@@ -1,7 +1,7 @@
 {
   "sections": {
     "trek": [
-      { 
+      {
         "name": "presentation",
         "display": true,
         "anchor": true,
@@ -13,79 +13,79 @@
         "anchor": false,
         "order": 15
       },
-      { 
+      {
         "name": "itinerancySteps",
         "display": true,
         "anchor": true,
         "order": 20
       },
-      { 
+      {
         "name": "poi",
         "display": true,
         "anchor": true,
         "order": 30
       },
-      { 
+      {
         "name": "description",
         "display": true,
         "anchor": true,
         "order": 40
       },
-      { 
+      {
         "name": "forecastWidget",
         "display": true,
         "anchor": false,
         "order": 50
       },
-      { 
+      {
         "name": "altimetricProfile",
         "display": true,
         "anchor": false,
         "order": 60
       },
-      { 
+      {
         "name": "sensitiveAreas",
         "display": true,
         "anchor": true,
         "order": 70
       },
-      { 
+      {
         "name": "practicalInformations",
         "display": true,
         "anchor": true,
         "order": 80
       },
-      { 
+      {
         "name": "accessibility",
         "display": true,
         "anchor": true,
         "order": 90
       },
-      { 
+      {
         "name": "more",
         "display": true,
         "anchor": false,
         "order": 100
       },
-      { 
+      {
         "name": "source",
         "display": true,
         "anchor": false,
         "order": 110
       },
-      { 
+      {
         "name": "report",
         "display": true,
         "anchor": true,
         "order": 120
       },
-      { 
+      {
         "name": "touristicContent",
         "display": true,
         "anchor": true,
         "order": 130
       },
-      { 
+      {
         "name": "reservationWidget",
         "display": true,
         "anchor": true,
@@ -93,84 +93,7 @@
       }
     ],
     "touristicContent": [
-      { 
-        "name": "presentation",
-        "display": true,
-        "anchor": true,
-        "order": 10
-      },
-      { 
-        "name": "practicalInformations",
-        "display": true,
-        "anchor": true,
-        "order": 20
-      },
-      { 
-        "name": "accessibility",
-        "display": true,
-        "anchor": false,
-        "order": 30
-      },      
-      { 
-        "name": "contact",
-        "display": true,
-        "anchor": false,
-        "order": 40
-      },
-      { 
-        "name": "forecastWidget",
-        "display": true,
-        "anchor": false,
-        "order": 50
-      },
-      { 
-        "name": "source",
-        "display": true,
-        "anchor": false,
-        "order": 60
-      }
-      
-    ],
-    "touristicEvent": [
-      { 
-        "name": "presentation",
-        "display": true,
-        "anchor": true,
-        "order": 10
-      },
-      { 
-        "name": "description",
-        "display": true,
-        "anchor": true,
-        "order": 20
-      },
-      { 
-        "name": "practicalInformations",
-        "display": true,
-        "anchor": true,
-        "order": 30
-      },
-      { 
-        "name": "forecastWidget",
-        "display": true,
-        "anchor": false,
-        "order": 40
-      },
-      { 
-        "name": "source",
-        "display": true,
-        "anchor": false,
-        "order": 50
-      },
-      { 
-        "name": "touristicContent",
-        "display": true,
-        "anchor": false,
-        "order": 60
-      }
-    ],
-    "outdoorSite": [
-      { 
+      {
         "name": "presentation",
         "display": true,
         "anchor": true,
@@ -182,67 +105,155 @@
         "anchor": false,
         "order": 15
       },
-      { 
+      {
+        "name": "practicalInformations",
+        "display": true,
+        "anchor": true,
+        "order": 20
+      },
+      {
+        "name": "accessibility",
+        "display": true,
+        "anchor": false,
+        "order": 30
+      },
+      {
+        "name": "contact",
+        "display": true,
+        "anchor": false,
+        "order": 40
+      },
+      {
+        "name": "forecastWidget",
+        "display": true,
+        "anchor": false,
+        "order": 50
+      },
+      {
+        "name": "source",
+        "display": true,
+        "anchor": false,
+        "order": 60
+      }
+    ],
+    "touristicEvent": [
+      {
+        "name": "presentation",
+        "display": true,
+        "anchor": true,
+        "order": 10
+      },
+      {
+        "name": "medias",
+        "display": true,
+        "anchor": false,
+        "order": 15
+      },
+      {
+        "name": "description",
+        "display": true,
+        "anchor": true,
+        "order": 20
+      },
+      {
+        "name": "practicalInformations",
+        "display": true,
+        "anchor": true,
+        "order": 30
+      },
+      {
+        "name": "forecastWidget",
+        "display": true,
+        "anchor": false,
+        "order": 40
+      },
+      {
+        "name": "source",
+        "display": true,
+        "anchor": false,
+        "order": 50
+      },
+      {
+        "name": "touristicContent",
+        "display": true,
+        "anchor": false,
+        "order": 60
+      }
+    ],
+    "outdoorSite": [
+      {
+        "name": "presentation",
+        "display": true,
+        "anchor": true,
+        "order": 10
+      },
+      {
+        "name": "medias",
+        "display": true,
+        "anchor": false,
+        "order": 15
+      },
+      {
         "name": "poi",
         "display": true,
         "anchor": true,
         "order": 20
       },
-      { 
+      {
         "name": "description",
         "display": true,
         "anchor": true,
         "order": 30
       },
-      { 
+      {
         "name": "subsites",
         "display": true,
         "anchor": true,
         "order": 40
       },
-      { 
+      {
         "name": "courses",
         "display": true,
         "anchor": true,
         "order": 50
       },
-      { 
+      {
         "name": "sensitiveAreas",
         "display": true,
         "anchor": false,
         "order": 60
       },
-      { 
+      {
         "name": "practicalInformations",
         "display": true,
         "anchor": true,
         "order": 70
       },
-      { 
+      {
         "name": "access",
         "display": true,
         "anchor": true,
         "order": 80
       },
-      { 
+      {
         "name": "forecastWidget",
         "display": true,
         "anchor": false,
         "order": 90
       },
-      { 
+      {
         "name": "source",
         "display": true,
         "anchor": false,
         "order": 100
       },
-      { 
+      {
         "name": "more",
         "display": true,
         "anchor": false,
         "order": 110
       },
-      { 
+      {
         "name": "touristicContent",
         "display": true,
         "anchor": false,
@@ -250,55 +261,55 @@
       }
     ],
     "outdoorCourse": [
-      { 
+      {
         "name": "presentation",
         "display": true,
         "anchor": true,
         "order": 10
       },
-      { 
+      {
         "name": "description",
         "display": true,
         "anchor": false,
         "order": 20
       },
-      { 
+      {
         "name": "gear",
         "display": true,
         "anchor": false,
         "order": 30
       },
-      { 
+      {
         "name": "equipment",
         "display": true,
         "anchor": false,
         "order": 40
       },
-      { 
+      {
         "name": "poi",
         "display": true,
         "anchor": true,
         "order": 50
       },
-      { 
+      {
         "name": "sensitiveAreas",
         "display": true,
         "anchor": false,
         "order": 60
       },
-      { 
+      {
         "name": "practicalInformations",
         "display": true,
         "anchor": false,
         "order": 70
       },
-      { 
+      {
         "name": "touristicContent",
         "display": true,
         "anchor": false,
         "order": 80
       },
-      { 
+      {
         "name": "forecastWidget",
         "display": true,
         "anchor": false,

--- a/frontend/config/details.json
+++ b/frontend/config/details.json
@@ -10,7 +10,7 @@
       {
         "name": "medias",
         "display": true,
-        "anchor": false,
+        "anchor": true,
         "order": 15
       },
       {
@@ -102,7 +102,7 @@
       {
         "name": "medias",
         "display": true,
-        "anchor": false,
+        "anchor": true,
         "order": 15
       },
       {
@@ -146,7 +146,7 @@
       {
         "name": "medias",
         "display": true,
-        "anchor": false,
+        "anchor": true,
         "order": 15
       },
       {
@@ -190,7 +190,7 @@
       {
         "name": "medias",
         "display": true,
-        "anchor": false,
+        "anchor": true,
         "order": 15
       },
       {

--- a/frontend/src/components/Icons/Download/index.tsx
+++ b/frontend/src/components/Icons/Download/index.tsx
@@ -3,9 +3,8 @@ import { GenericIconProps } from '../types';
 
 export const Download: React.FC<GenericIconProps> = ({
   color = 'currentColor',
-  opacity,
-  className,
   size,
+  ...props
 }) => {
   return (
     <svg
@@ -14,8 +13,7 @@ export const Download: React.FC<GenericIconProps> = ({
       viewBox="0 0 30 30"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
-      className={className}
-      opacity={opacity}
+      {...props}
     >
       <path
         d="M26.077 19.001v4.923a2.462 2.462 0 01-2.462 2.462H6.385a2.462 2.462 0 01-2.462-2.462v-4.923M8.846 12.847l6.153 6.154 6.154-6.154M15 19.001V4.231"

--- a/frontend/src/components/Icons/Minus/index.tsx
+++ b/frontend/src/components/Icons/Minus/index.tsx
@@ -1,13 +1,7 @@
 import React from 'react';
 import { GenericIconProps } from '../types';
 
-export const Minus: React.FC<GenericIconProps> = ({
-  color = 'currentColor',
-  opacity,
-  className,
-  size,
-  ...props
-}) => {
+export const Minus: React.FC<GenericIconProps> = ({ color = 'currentColor', size, ...props }) => {
   return (
     <svg
       width={size}
@@ -15,8 +9,6 @@ export const Minus: React.FC<GenericIconProps> = ({
       viewBox="0 0 24 24"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
-      className={className}
-      opacity={opacity}
       {...props}
     >
       <path

--- a/frontend/src/components/Icons/Paperclip/index.tsx
+++ b/frontend/src/components/Icons/Paperclip/index.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { GenericIconProps } from '../types';
+
+export const Paperclip: React.FC<GenericIconProps> = ({
+  color = 'currentColor',
+  size,
+  ...props
+}) => {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      stroke={color}
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
+      <path d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l8.57-8.57A4 4 0 1 1 18 8.84l-8.59 8.57a2 2 0 0 1-2.83-2.83l8.49-8.48" />
+    </svg>
+  );
+};

--- a/frontend/src/components/Icons/Plus/index.tsx
+++ b/frontend/src/components/Icons/Plus/index.tsx
@@ -1,13 +1,7 @@
 import React from 'react';
 import { GenericIconProps } from '../types';
 
-export const Plus: React.FC<GenericIconProps> = ({
-  color = 'currentColor',
-  opacity,
-  className,
-  size,
-  ...props
-}) => {
+export const Plus: React.FC<GenericIconProps> = ({ color = 'currentColor', size, ...props }) => {
   return (
     <svg
       width={size}
@@ -15,8 +9,6 @@ export const Plus: React.FC<GenericIconProps> = ({
       viewBox="0 0 24 24"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
-      className={className}
-      opacity={opacity}
       {...props}
     >
       <path

--- a/frontend/src/components/Icons/ViewPoint/index.tsx
+++ b/frontend/src/components/Icons/ViewPoint/index.tsx
@@ -3,18 +3,16 @@ import { GenericIconProps } from '../types';
 
 export const ViewPoint: React.FC<GenericIconProps> = ({
   color = 'currentColor',
-  opacity,
-  className,
   size = 24,
+  ...props
 }) => {
   return (
     <svg
       width={size}
-      className={className}
-      opacity={opacity}
       viewBox="0 0 32 40"
       height={size}
       xmlns="http://www.w3.org/2000/svg"
+      {...props}
     >
       <path
         fill={color}

--- a/frontend/src/components/pages/details/Details.tsx
+++ b/frontend/src/components/pages/details/Details.tsx
@@ -51,7 +51,7 @@ import { DetailsSensitiveArea } from './components/DetailsSensitiveArea';
 import { useOnScreenSection } from './hooks/useHighlightedSection';
 import { DetailsGear } from './components/DetailsGear';
 import { useDetailsSections } from './useDetailsSections';
-import { DetailsMedias } from './components/DetailsMedias';
+import { DetailsViewPoints } from './components/DetailsViewPoints';
 
 interface Props {
   slug: string | string[] | undefined;
@@ -220,7 +220,7 @@ export const DetailsUIWithoutContext: React.FC<Props> = ({ slug, parentId, langu
                           id={`details_${section.name}_ref`}
                         >
                           <DetailsSection htmlId="details_medias" className={marginDetailsChild}>
-                            <DetailsMedias
+                            <DetailsViewPoints
                               viewPoints={details.viewPoints}
                               handleViewPointClick={handleViewPointClick}
                             />

--- a/frontend/src/components/pages/details/Details.tsx
+++ b/frontend/src/components/pages/details/Details.tsx
@@ -52,6 +52,7 @@ import { useOnScreenSection } from './hooks/useHighlightedSection';
 import { DetailsGear } from './components/DetailsGear';
 import { useDetailsSections } from './useDetailsSections';
 import { DetailsViewPoints } from './components/DetailsViewPoints';
+import { DetailsFiles } from './components/DetailsFiles';
 
 interface Props {
   slug: string | string[] | undefined;
@@ -209,9 +210,9 @@ export const DetailsUIWithoutContext: React.FC<Props> = ({ slug, parentId, langu
                       );
                     }
                     if (
-                      hasNavigator &&
                       section.name === 'medias' &&
-                      details.viewPoints.length > 0
+                      ((hasNavigator && details.viewPoints.length > 0) ||
+                        details.filesFromAttachments.length > 0)
                     ) {
                       return (
                         <section
@@ -220,10 +221,13 @@ export const DetailsUIWithoutContext: React.FC<Props> = ({ slug, parentId, langu
                           id={`details_${section.name}_ref`}
                         >
                           <DetailsSection htmlId="details_medias" className={marginDetailsChild}>
-                            <DetailsViewPoints
-                              viewPoints={details.viewPoints}
-                              handleViewPointClick={handleViewPointClick}
-                            />
+                            <DetailsFiles files={details.filesFromAttachments} />
+                            {hasNavigator && (
+                              <DetailsViewPoints
+                                viewPoints={details.viewPoints}
+                                handleViewPointClick={handleViewPointClick}
+                              />
+                            )}
                           </DetailsSection>
                         </section>
                       );
@@ -274,6 +278,7 @@ export const DetailsUIWithoutContext: React.FC<Props> = ({ slug, parentId, langu
                               iconUri: poi.type.pictogramUri,
                               iconName: poi.type.label,
                               viewPoints: poi.viewPoints,
+                              filesFromAttachments: poi.filesFromAttachments,
                             }))}
                             type="POI"
                             handleViewPointClick={handleViewPointClick}

--- a/frontend/src/components/pages/details/components/DetailsCard/DetailsCard.tsx
+++ b/frontend/src/components/pages/details/components/DetailsCard/DetailsCard.tsx
@@ -1,3 +1,4 @@
+import { useId } from 'react';
 import { CardIcon } from 'components/CardIcon';
 import { Link } from 'components/Link';
 import { Modal } from 'components/Modal';
@@ -12,6 +13,8 @@ import { cn } from 'services/utils/cn';
 import { Arrow } from 'components/Icons/Arrow';
 import { ViewPoint } from 'modules/viewPoint/interface';
 import { FileFromAttachment, ImageFromAttachment } from 'modules/interface';
+import { ViewPoint as ViewPointIcon } from 'components/Icons/ViewPoint';
+import { Paperclip } from 'components/Icons/Paperclip';
 import { useDetailsCard } from './useDetailsCard';
 import { DetailsViewPoints } from '../DetailsViewPoints';
 import { DetailsFiles } from '../DetailsFiles';
@@ -46,11 +49,13 @@ export const DetailsCard: React.FC<DetailsCardProps> = ({
   redirectionUrl,
   type,
   handleViewPointClick,
-  filesFromAttachments,
-  viewPoints,
+  filesFromAttachments = [],
+  viewPoints = [],
 }) => {
   const hasMedia = Boolean(viewPoints?.length);
-  const { truncateState, toggleTruncateState, detailsCardRef } = useDetailsCard(hasMedia);
+  const { truncateState, toggleTruncateState, detailsCardRef, setTruncateState } =
+    useDetailsCard(hasMedia);
+
   const descriptionStyled =
     truncateState === 'TRUNCATE' ? (
       <HtmlText className="custo-result-card-description line-clamp-2 desktop:line-clamp-5 text-greyDarkColored">
@@ -65,10 +70,17 @@ export const DetailsCard: React.FC<DetailsCardProps> = ({
   const { setHoveredCardId } = useListAndMapContext();
 
   const hasNavigator = useHasMounted(typeof navigator !== 'undefined' && navigator.onLine);
+
+  const hasViewPoints = hasNavigator && viewPoints.length > 0;
+  const hasFiles = filesFromAttachments.length > 0;
+
+  const viewPointsId = useId();
+  const filesId = useId();
+
   return (
     <li
       className={cn(
-        `custo-result-card relative border border-solid border-greySoft rounded-card
+        `custo-result-card relative border border-solid border-greySoft rounded-lg
   flex-none desktop:w-auto mx-1 desktop:mb-6 overflow-hidden
   hover:border-blackSemiTransparent transition-all duration-500`,
         className,
@@ -77,6 +89,7 @@ export const DetailsCard: React.FC<DetailsCardProps> = ({
       <div
         className={cn(
           `
+      relative
       overflow-hidden desktop:w-auto
       h-fit desktop:flex-row
       transition-all duration-500`,
@@ -90,6 +103,44 @@ export const DetailsCard: React.FC<DetailsCardProps> = ({
           setHoveredCardId(null);
         }}
       >
+        {(hasFiles || hasViewPoints) && (
+          <ul className="hidden desktop:flex absolute -top-1 right-0">
+            {hasFiles && (
+              <li>
+                <a
+                  className="block -mr-1p p-2 border border-solid border-blackSemiTransparent hover:bg-greySoft focus:bg-greySoft transition rounded-bl-lg"
+                  href={`#${filesId}`}
+                  onClick={() => setTruncateState('FULL')}
+                >
+                  <Paperclip size={20} aria-hidden />
+                  <span className="sr-only">
+                    <FormattedMessage
+                      id="attachments.title"
+                      values={{ count: filesFromAttachments.length }}
+                    />
+                  </span>
+                </a>
+              </li>
+            )}
+            {hasViewPoints && (
+              <li>
+                <a
+                  className={cn(
+                    'block -mr-1p p-2 border border-solid border-blackSemiTransparent hover:bg-greySoft focus:bg-greySoft transition',
+                    !hasFiles && 'rounded-bl-lg',
+                  )}
+                  href={`#${viewPointsId}`}
+                  onClick={() => setTruncateState('FULL')}
+                >
+                  <ViewPointIcon size={20} aria-hidden />
+                  <span className="sr-only">
+                    <FormattedMessage id="viewPoint.title" />
+                  </span>
+                </a>
+              </li>
+            )}
+          </ul>
+        )}
         <div className="flex shrink-0 h-40 desktop:float-left desktop:min-h-55 desktop:h-full desktop:w-2/5 pr-2 desktop:pr-6">
           <div className="w-full">
             <Modal className="h-full">
@@ -130,15 +181,25 @@ export const DetailsCard: React.FC<DetailsCardProps> = ({
           {Boolean(description) && (
             <>
               <OptionalLink redirectionUrl={redirectionUrl}>{descriptionStyled}</OptionalLink>
-              {hasNavigator && Number(viewPoints?.length) > 0 && truncateState !== 'TRUNCATE' && (
+              {(hasViewPoints || hasFiles) && truncateState !== 'TRUNCATE' && (
                 <div className="clear-both flex flex-col gap-4 desktop:min-w-[420px] overflow-hidden desktop:-mx-6 py-6">
-                  <DetailsFiles files={filesFromAttachments} titleTag="h3" asAccordion />
-                  <DetailsViewPoints
-                    viewPoints={viewPoints ?? []}
-                    handleViewPointClick={handleViewPointClick}
+                  <DetailsFiles
+                    className="scroll-mt-20 desktop:scroll-mt-40"
+                    id={filesId}
+                    files={filesFromAttachments}
                     titleTag="h3"
                     asAccordion
                   />
+                  {hasNavigator && (
+                    <DetailsViewPoints
+                      className="scroll-mt-20 desktop:scroll-mt-40"
+                      id={viewPointsId}
+                      viewPoints={viewPoints}
+                      handleViewPointClick={handleViewPointClick}
+                      titleTag="h3"
+                      asAccordion
+                    />
+                  )}
                 </div>
               )}
               {truncateState !== 'NONE' && (

--- a/frontend/src/components/pages/details/components/DetailsCard/DetailsCard.tsx
+++ b/frontend/src/components/pages/details/components/DetailsCard/DetailsCard.tsx
@@ -13,7 +13,7 @@ import { Arrow } from 'components/Icons/Arrow';
 import { ViewPoint } from 'modules/viewPoint/interface';
 import { ImageFromAttachment } from 'modules/interface';
 import { useDetailsCard } from './useDetailsCard';
-import { DetailsMedias } from '../DetailsMedias';
+import { DetailsViewPoints } from '../DetailsViewPoints';
 
 export interface DetailsCardProps {
   id: string;
@@ -129,7 +129,7 @@ export const DetailsCard: React.FC<DetailsCardProps> = ({
               <OptionalLink redirectionUrl={redirectionUrl}>{descriptionStyled}</OptionalLink>
               {hasNavigator && Number(viewPoints?.length) > 0 && truncateState !== 'TRUNCATE' && (
                 <div className="clear-both desktop:clear-none desktop:min-w-[420px] overflow-hidden py-6">
-                  <DetailsMedias
+                  <DetailsViewPoints
                     viewPoints={viewPoints ?? []}
                     handleViewPointClick={handleViewPointClick}
                     titleTag="h3"

--- a/frontend/src/components/pages/details/components/DetailsCard/DetailsCard.tsx
+++ b/frontend/src/components/pages/details/components/DetailsCard/DetailsCard.tsx
@@ -11,9 +11,10 @@ import { FormattedMessage } from 'react-intl';
 import { cn } from 'services/utils/cn';
 import { Arrow } from 'components/Icons/Arrow';
 import { ViewPoint } from 'modules/viewPoint/interface';
-import { ImageFromAttachment } from 'modules/interface';
+import { FileFromAttachment, ImageFromAttachment } from 'modules/interface';
 import { useDetailsCard } from './useDetailsCard';
 import { DetailsViewPoints } from '../DetailsViewPoints';
+import { DetailsFiles } from '../DetailsFiles';
 
 export interface DetailsCardProps {
   id: string;
@@ -27,6 +28,7 @@ export interface DetailsCardProps {
   className?: string;
   redirectionUrl?: string;
   type?: string;
+  filesFromAttachments?: FileFromAttachment[];
   viewPoints?: ViewPoint[];
   handleViewPointClick?: (id: string) => void;
 }
@@ -44,6 +46,7 @@ export const DetailsCard: React.FC<DetailsCardProps> = ({
   redirectionUrl,
   type,
   handleViewPointClick,
+  filesFromAttachments,
   viewPoints,
 }) => {
   const hasMedia = Boolean(viewPoints?.length);
@@ -128,7 +131,8 @@ export const DetailsCard: React.FC<DetailsCardProps> = ({
             <>
               <OptionalLink redirectionUrl={redirectionUrl}>{descriptionStyled}</OptionalLink>
               {hasNavigator && Number(viewPoints?.length) > 0 && truncateState !== 'TRUNCATE' && (
-                <div className="clear-both desktop:clear-none desktop:min-w-[420px] overflow-hidden py-6">
+                <div className="clear-both flex flex-col gap-4 desktop:gap-6 desktop:min-w-[420px] overflow-hidden py-6">
+                  <DetailsFiles files={filesFromAttachments} titleTag="h3" asAccordion />
                   <DetailsViewPoints
                     viewPoints={viewPoints ?? []}
                     handleViewPointClick={handleViewPointClick}

--- a/frontend/src/components/pages/details/components/DetailsCard/DetailsCard.tsx
+++ b/frontend/src/components/pages/details/components/DetailsCard/DetailsCard.tsx
@@ -131,7 +131,7 @@ export const DetailsCard: React.FC<DetailsCardProps> = ({
             <>
               <OptionalLink redirectionUrl={redirectionUrl}>{descriptionStyled}</OptionalLink>
               {hasNavigator && Number(viewPoints?.length) > 0 && truncateState !== 'TRUNCATE' && (
-                <div className="clear-both flex flex-col gap-4 desktop:gap-6 desktop:min-w-[420px] overflow-hidden py-6">
+                <div className="clear-both flex flex-col gap-4 desktop:min-w-[420px] overflow-hidden desktop:-mx-6 py-6">
                   <DetailsFiles files={filesFromAttachments} titleTag="h3" asAccordion />
                   <DetailsViewPoints
                     viewPoints={viewPoints ?? []}

--- a/frontend/src/components/pages/details/components/DetailsCard/__tests__/__snapshots__/DetailsCard.test.tsx.snap
+++ b/frontend/src/components/pages/details/components/DetailsCard/__tests__/__snapshots__/DetailsCard.test.tsx.snap
@@ -6,10 +6,10 @@ Object {
   "baseElement": <body>
     <div>
       <li
-        class="custo-result-card relative border border-solid border-greySoft rounded-card flex-none desktop:w-auto mx-1 desktop:mb-6 overflow-hidden hover:border-blackSemiTransparent transition-all duration-500"
+        class="custo-result-card relative border border-solid border-greySoft rounded-lg flex-none desktop:w-auto mx-1 desktop:mb-6 overflow-hidden hover:border-blackSemiTransparent transition-all duration-500"
       >
         <div
-          class="overflow-hidden desktop:w-auto h-fit desktop:flex-row transition-all duration-500 desktop:h-55"
+          class="relative overflow-hidden desktop:w-auto h-fit desktop:flex-row transition-all duration-500 desktop:h-55"
         >
           <div
             class="flex shrink-0 h-40 desktop:float-left desktop:min-h-55 desktop:h-full desktop:w-2/5 pr-2 desktop:pr-6"
@@ -30,7 +30,7 @@ Object {
                       class="relative h-coverDetailsMobile desktop:h-coverDetailsDesktop"
                     >
                       <figure
-                        aria-labelledby=":r2:"
+                        aria-labelledby=":r4:"
                         class="relative "
                         id="details_cover_image"
                         role="figure"
@@ -38,12 +38,12 @@ Object {
                         <img
                           alt="Lorem ipsum"
                           class="overflow-hidden size-full object-cover object-center"
-                          id=":r3:"
+                          id=":r5:"
                           loading="lazy"
                           src="https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_400.jpg"
                         />
                         <figcaption
-                          id=":r2:"
+                          id=":r4:"
                         >
                           <span
                             class="w-full h-12 desktop:h-40
@@ -59,7 +59,7 @@ Object {
                             </span>
                           </span>
                           <button
-                            aria-describedby=":r3:"
+                            aria-describedby=":r5:"
                             class="absolute inset-0 size-full"
                             type="button"
                           >
@@ -108,10 +108,10 @@ Object {
     </div>
     <div>
       <li
-        class="custo-result-card relative border border-solid border-greySoft rounded-card flex-none desktop:w-auto mx-1 desktop:mb-6 overflow-hidden hover:border-blackSemiTransparent transition-all duration-500"
+        class="custo-result-card relative border border-solid border-greySoft rounded-lg flex-none desktop:w-auto mx-1 desktop:mb-6 overflow-hidden hover:border-blackSemiTransparent transition-all duration-500"
       >
         <div
-          class="overflow-hidden desktop:w-auto h-fit desktop:flex-row transition-all duration-500 desktop:h-55"
+          class="relative overflow-hidden desktop:w-auto h-fit desktop:flex-row transition-all duration-500 desktop:h-55"
         >
           <div
             class="flex shrink-0 h-40 desktop:float-left desktop:min-h-55 desktop:h-full desktop:w-2/5 pr-2 desktop:pr-6"
@@ -159,7 +159,7 @@ Object {
                           >
                             <div>
                               <figure
-                                aria-labelledby=":r8:"
+                                aria-labelledby=":rc:"
                                 class="relative "
                                 id="details_cover_image"
                                 role="figure"
@@ -167,12 +167,12 @@ Object {
                                 <img
                                   alt="Lorem ipsum"
                                   class="overflow-hidden size-full object-cover object-center"
-                                  id=":r9:"
+                                  id=":rd:"
                                   loading="lazy"
                                   src="https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_400.jpg"
                                 />
                                 <figcaption
-                                  id=":r8:"
+                                  id=":rc:"
                                 >
                                   <span
                                     class="w-full h-12 desktop:h-40
@@ -188,7 +188,7 @@ Object {
                                     </span>
                                   </span>
                                   <button
-                                    aria-describedby=":r9:"
+                                    aria-describedby=":rd:"
                                     class="absolute inset-0 size-full"
                                     type="button"
                                   >
@@ -218,7 +218,7 @@ Object {
                           >
                             <div>
                               <figure
-                                aria-labelledby=":ra:"
+                                aria-labelledby=":re:"
                                 class="relative "
                                 id="details_cover_image"
                                 role="figure"
@@ -226,12 +226,12 @@ Object {
                                 <img
                                   alt="Lorem ipsum"
                                   class="overflow-hidden size-full object-cover object-center"
-                                  id=":rb:"
+                                  id=":rf:"
                                   loading="lazy"
                                   src="https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_400.jpg"
                                 />
                                 <figcaption
-                                  id=":ra:"
+                                  id=":re:"
                                 >
                                   <span
                                     class="w-full h-12 desktop:h-40
@@ -247,7 +247,7 @@ Object {
                                     </span>
                                   </span>
                                   <button
-                                    aria-describedby=":rb:"
+                                    aria-describedby=":rf:"
                                     class="absolute inset-0 size-full"
                                     type="button"
                                   >
@@ -332,10 +332,10 @@ Object {
   </body>,
   "container": <div>
     <li
-      class="custo-result-card relative border border-solid border-greySoft rounded-card flex-none desktop:w-auto mx-1 desktop:mb-6 overflow-hidden hover:border-blackSemiTransparent transition-all duration-500"
+      class="custo-result-card relative border border-solid border-greySoft rounded-lg flex-none desktop:w-auto mx-1 desktop:mb-6 overflow-hidden hover:border-blackSemiTransparent transition-all duration-500"
     >
       <div
-        class="overflow-hidden desktop:w-auto h-fit desktop:flex-row transition-all duration-500 desktop:h-55"
+        class="relative overflow-hidden desktop:w-auto h-fit desktop:flex-row transition-all duration-500 desktop:h-55"
       >
         <div
           class="flex shrink-0 h-40 desktop:float-left desktop:min-h-55 desktop:h-full desktop:w-2/5 pr-2 desktop:pr-6"
@@ -356,7 +356,7 @@ Object {
                     class="relative h-coverDetailsMobile desktop:h-coverDetailsDesktop"
                   >
                     <figure
-                      aria-labelledby=":r2:"
+                      aria-labelledby=":r4:"
                       class="relative "
                       id="details_cover_image"
                       role="figure"
@@ -364,12 +364,12 @@ Object {
                       <img
                         alt="Lorem ipsum"
                         class="overflow-hidden size-full object-cover object-center"
-                        id=":r3:"
+                        id=":r5:"
                         loading="lazy"
                         src="https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_400.jpg"
                       />
                       <figcaption
-                        id=":r2:"
+                        id=":r4:"
                       >
                         <span
                           class="w-full h-12 desktop:h-40
@@ -385,7 +385,7 @@ Object {
                           </span>
                         </span>
                         <button
-                          aria-describedby=":r3:"
+                          aria-describedby=":r5:"
                           class="absolute inset-0 size-full"
                           type="button"
                         >
@@ -492,10 +492,10 @@ Object {
   "baseElement": <body>
     <div>
       <li
-        class="custo-result-card relative border border-solid border-greySoft rounded-card flex-none desktop:w-auto mx-1 desktop:mb-6 overflow-hidden hover:border-blackSemiTransparent transition-all duration-500"
+        class="custo-result-card relative border border-solid border-greySoft rounded-lg flex-none desktop:w-auto mx-1 desktop:mb-6 overflow-hidden hover:border-blackSemiTransparent transition-all duration-500"
       >
         <div
-          class="overflow-hidden desktop:w-auto h-fit desktop:flex-row transition-all duration-500 desktop:h-55"
+          class="relative overflow-hidden desktop:w-auto h-fit desktop:flex-row transition-all duration-500 desktop:h-55"
         >
           <div
             class="flex shrink-0 h-40 desktop:float-left desktop:min-h-55 desktop:h-full desktop:w-2/5 pr-2 desktop:pr-6"
@@ -516,7 +516,7 @@ Object {
                       class="relative h-coverDetailsMobile desktop:h-coverDetailsDesktop"
                     >
                       <figure
-                        aria-labelledby=":r2:"
+                        aria-labelledby=":r4:"
                         class="relative "
                         id="details_cover_image"
                         role="figure"
@@ -524,12 +524,12 @@ Object {
                         <img
                           alt="Lorem ipsum"
                           class="overflow-hidden size-full object-cover object-center"
-                          id=":r3:"
+                          id=":r5:"
                           loading="lazy"
                           src="https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_400.jpg"
                         />
                         <figcaption
-                          id=":r2:"
+                          id=":r4:"
                         >
                           <span
                             class="w-full h-12 desktop:h-40
@@ -545,7 +545,7 @@ Object {
                             </span>
                           </span>
                           <button
-                            aria-describedby=":r3:"
+                            aria-describedby=":r5:"
                             class="absolute inset-0 size-full"
                             type="button"
                           >
@@ -594,10 +594,10 @@ Object {
     </div>
     <div>
       <li
-        class="custo-result-card relative border border-solid border-greySoft rounded-card flex-none desktop:w-auto mx-1 desktop:mb-6 overflow-hidden hover:border-blackSemiTransparent transition-all duration-500"
+        class="custo-result-card relative border border-solid border-greySoft rounded-lg flex-none desktop:w-auto mx-1 desktop:mb-6 overflow-hidden hover:border-blackSemiTransparent transition-all duration-500"
       >
         <div
-          class="overflow-hidden desktop:w-auto h-fit desktop:flex-row transition-all duration-500 desktop:h-55"
+          class="relative overflow-hidden desktop:w-auto h-fit desktop:flex-row transition-all duration-500 desktop:h-55"
         >
           <div
             class="flex shrink-0 h-40 desktop:float-left desktop:min-h-55 desktop:h-full desktop:w-2/5 pr-2 desktop:pr-6"
@@ -645,7 +645,7 @@ Object {
                           >
                             <div>
                               <figure
-                                aria-labelledby=":r8:"
+                                aria-labelledby=":rc:"
                                 class="relative "
                                 id="details_cover_image"
                                 role="figure"
@@ -653,12 +653,12 @@ Object {
                                 <img
                                   alt="Lorem ipsum"
                                   class="overflow-hidden size-full object-cover object-center"
-                                  id=":r9:"
+                                  id=":rd:"
                                   loading="lazy"
                                   src="https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_400.jpg"
                                 />
                                 <figcaption
-                                  id=":r8:"
+                                  id=":rc:"
                                 >
                                   <span
                                     class="w-full h-12 desktop:h-40
@@ -674,7 +674,7 @@ Object {
                                     </span>
                                   </span>
                                   <button
-                                    aria-describedby=":r9:"
+                                    aria-describedby=":rd:"
                                     class="absolute inset-0 size-full"
                                     type="button"
                                   >
@@ -704,7 +704,7 @@ Object {
                           >
                             <div>
                               <figure
-                                aria-labelledby=":ra:"
+                                aria-labelledby=":re:"
                                 class="relative "
                                 id="details_cover_image"
                                 role="figure"
@@ -712,12 +712,12 @@ Object {
                                 <img
                                   alt="Lorem ipsum"
                                   class="overflow-hidden size-full object-cover object-center"
-                                  id=":rb:"
+                                  id=":rf:"
                                   loading="lazy"
                                   src="https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_400.jpg"
                                 />
                                 <figcaption
-                                  id=":ra:"
+                                  id=":re:"
                                 >
                                   <span
                                     class="w-full h-12 desktop:h-40
@@ -733,7 +733,7 @@ Object {
                                     </span>
                                   </span>
                                   <button
-                                    aria-describedby=":rb:"
+                                    aria-describedby=":rf:"
                                     class="absolute inset-0 size-full"
                                     type="button"
                                   >
@@ -818,10 +818,10 @@ Object {
   </body>,
   "container": <div>
     <li
-      class="custo-result-card relative border border-solid border-greySoft rounded-card flex-none desktop:w-auto mx-1 desktop:mb-6 overflow-hidden hover:border-blackSemiTransparent transition-all duration-500"
+      class="custo-result-card relative border border-solid border-greySoft rounded-lg flex-none desktop:w-auto mx-1 desktop:mb-6 overflow-hidden hover:border-blackSemiTransparent transition-all duration-500"
     >
       <div
-        class="overflow-hidden desktop:w-auto h-fit desktop:flex-row transition-all duration-500 desktop:h-55"
+        class="relative overflow-hidden desktop:w-auto h-fit desktop:flex-row transition-all duration-500 desktop:h-55"
       >
         <div
           class="flex shrink-0 h-40 desktop:float-left desktop:min-h-55 desktop:h-full desktop:w-2/5 pr-2 desktop:pr-6"
@@ -869,7 +869,7 @@ Object {
                         >
                           <div>
                             <figure
-                              aria-labelledby=":r8:"
+                              aria-labelledby=":rc:"
                               class="relative "
                               id="details_cover_image"
                               role="figure"
@@ -877,12 +877,12 @@ Object {
                               <img
                                 alt="Lorem ipsum"
                                 class="overflow-hidden size-full object-cover object-center"
-                                id=":r9:"
+                                id=":rd:"
                                 loading="lazy"
                                 src="https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_400.jpg"
                               />
                               <figcaption
-                                id=":r8:"
+                                id=":rc:"
                               >
                                 <span
                                   class="w-full h-12 desktop:h-40
@@ -898,7 +898,7 @@ Object {
                                   </span>
                                 </span>
                                 <button
-                                  aria-describedby=":r9:"
+                                  aria-describedby=":rd:"
                                   class="absolute inset-0 size-full"
                                   type="button"
                                 >
@@ -928,7 +928,7 @@ Object {
                         >
                           <div>
                             <figure
-                              aria-labelledby=":ra:"
+                              aria-labelledby=":re:"
                               class="relative "
                               id="details_cover_image"
                               role="figure"
@@ -936,12 +936,12 @@ Object {
                               <img
                                 alt="Lorem ipsum"
                                 class="overflow-hidden size-full object-cover object-center"
-                                id=":rb:"
+                                id=":rf:"
                                 loading="lazy"
                                 src="https://cdn.pixabay.com/photo/2017/06/29/18/40/background-2455710_400.jpg"
                               />
                               <figcaption
-                                id=":ra:"
+                                id=":re:"
                               >
                                 <span
                                   class="w-full h-12 desktop:h-40
@@ -957,7 +957,7 @@ Object {
                                   </span>
                                 </span>
                                 <button
-                                  aria-describedby=":rb:"
+                                  aria-describedby=":rf:"
                                   class="absolute inset-0 size-full"
                                   type="button"
                                 >

--- a/frontend/src/components/pages/details/components/DetailsCard/useDetailsCard.tsx
+++ b/frontend/src/components/pages/details/components/DetailsCard/useDetailsCard.tsx
@@ -70,5 +70,5 @@ export const useDetailsCard = (hasMedia = false) => {
     };
   }, [debouncedResize]);
 
-  return { truncateState, toggleTruncateState, detailsCardRef };
+  return { truncateState, toggleTruncateState, setTruncateState, detailsCardRef };
 };

--- a/frontend/src/components/pages/details/components/DetailsCardSection/DetailsCardSection.tsx
+++ b/frontend/src/components/pages/details/components/DetailsCardSection/DetailsCardSection.tsx
@@ -62,6 +62,7 @@ export const DetailsCardSection: React.FC<DetailsCardSectionProps> = ({
             type={type}
             handleViewPointClick={handleViewPointClick}
             viewPoints={card.viewPoints}
+            filesFromAttachments={card.filesFromAttachments}
           />
         ))}
       </ScrollContainer>

--- a/frontend/src/components/pages/details/components/DetailsCardSection/DetailsCardSection.tsx
+++ b/frontend/src/components/pages/details/components/DetailsCardSection/DetailsCardSection.tsx
@@ -53,7 +53,7 @@ export const DetailsCardSection: React.FC<DetailsCardSectionProps> = ({
             iconUri={card.iconUri}
             iconName={card.iconName}
             place={card.place}
-            className="w-60"
+            className="w-70"
             redirectionUrl={
               generateUrlFunction && card.id !== undefined
                 ? generateUrlFunction(card.id, card.name)

--- a/frontend/src/components/pages/details/components/DetailsFiles/DetailsFiles.tsx
+++ b/frontend/src/components/pages/details/components/DetailsFiles/DetailsFiles.tsx
@@ -24,14 +24,14 @@ export const DetailsFiles: React.FC<DetailsDetailsFilesProps> = ({
   const SubTitleTag = TitleTag === 'h2' ? 'h3' : 'h4';
 
   const id = useId();
-  const [isOpen, setOpen] = useState(true);
+  const [isOpen, setOpen] = useState(!asAccordion);
 
   if (files.length === 0) {
     return null;
   }
 
   return (
-    <div className={cn(className, asAccordion && 'p-4 bg-neutral-100')}>
+    <div className={cn(className, asAccordion && 'p-2 desktop:p-6 bg-neutral-100')}>
       <TitleTag
         className={cn(
           'relative flex items-center justify-start gap-1 font-bold',
@@ -71,6 +71,7 @@ export const DetailsFiles: React.FC<DetailsDetailsFilesProps> = ({
         className={cn(
           'flex desktop:flex-col gap-4 border border text-Mobile-C1 desktop:text-P1 mt-4 pb-5 desktop:pb-0 overflow-x-auto overflow-y-hidden desktop:overflow-visible scroll-smooth snap-x',
           !isOpen && 'hidden',
+          asAccordion && 'mt-4',
         )}
       >
         {files.map((file, index) => {
@@ -80,19 +81,21 @@ export const DetailsFiles: React.FC<DetailsDetailsFilesProps> = ({
           return (
             <li
               key={index}
-              className="shrink-0 relative desktop:flex w-60 desktop:w-auto border-l desktop:border-l-0 desktop:border-t first:border-0 border-solid border-greySoft pl-5 desktop:pl-0 desktop:pt-5"
+              className={cn(
+                'shrink-0 relative p-4 desktop:flex w-50 desktop:w-auto border rounded-lg border-solid border-greySoft bg-white',
+              )}
             >
               <div className="flex flex-col gap-4 desktop:flex-row items-center justify-between w-full">
                 <div>
-                  <SubTitleTag className="flex flex-wrap gap-4 justify-center">
+                  <SubTitleTag className="flex flex-col gap-1 justify-center desktop:justify-start">
+                    <span className="text-P2 mb-1 text-greyDarkColored hidden desktop:block">
+                      {file.fileType}
+                    </span>
                     {file.fileName && (
                       <span className="text-Mobile-C1 desktop:text-H4 text-primary1 font-bold break-all">
                         {file.fileName}
                       </span>
                     )}
-                    <span className="py-1 px-2 rounded-full  bg-primary2 text-sm desktop:text-base">
-                      {file.fileType}
-                    </span>
                   </SubTitleTag>
                   {legend.length > 0 && (
                     <p className="mt-4 text-greyDarkColored text-sm">

--- a/frontend/src/components/pages/details/components/DetailsFiles/DetailsFiles.tsx
+++ b/frontend/src/components/pages/details/components/DetailsFiles/DetailsFiles.tsx
@@ -6,7 +6,7 @@ import { FileFromAttachment } from 'modules/interface';
 import { cn } from 'services/utils/cn';
 import { Minus } from 'components/Icons/Minus';
 import { Plus } from 'components/Icons/Plus';
-import { Download } from 'components/Icons/Download';
+import { Paperclip } from 'components/Icons/Paperclip';
 
 interface DetailsDetailsFilesProps {
   className?: string;
@@ -38,7 +38,7 @@ export const DetailsFiles: React.FC<DetailsDetailsFilesProps> = ({
           TitleTag === 'h2' ? 'text-Mobile-H1 desktop:text-H2' : 'text-Mobile-C1 desktop:text-H4',
         )}
       >
-        <Download size={30} aria-hidden />
+        <Paperclip size={30} aria-hidden />
         <FormattedMessage id="attachments.title" values={{ count: files.length }} />
         {asAccordion && (
           <button

--- a/frontend/src/components/pages/details/components/DetailsFiles/DetailsFiles.tsx
+++ b/frontend/src/components/pages/details/components/DetailsFiles/DetailsFiles.tsx
@@ -9,6 +9,7 @@ import { Plus } from 'components/Icons/Plus';
 import { Paperclip } from 'components/Icons/Paperclip';
 
 interface DetailsDetailsFilesProps {
+  id?: string;
   className?: string;
   files?: FileFromAttachment[];
   asAccordion?: boolean;
@@ -20,6 +21,7 @@ export const DetailsFiles: React.FC<DetailsDetailsFilesProps> = ({
   files = [],
   asAccordion = false,
   titleTag: TitleTag = 'h2',
+  ...props
 }) => {
   const SubTitleTag = TitleTag === 'h2' ? 'h3' : 'h4';
 
@@ -31,7 +33,7 @@ export const DetailsFiles: React.FC<DetailsDetailsFilesProps> = ({
   }
 
   return (
-    <div className={cn(className, asAccordion && 'p-2 desktop:p-6 bg-neutral-100')}>
+    <div className={cn(className, asAccordion && 'p-2 desktop:p-6 bg-neutral-100')} {...props}>
       <TitleTag
         className={cn(
           'relative flex items-center justify-start gap-1 font-bold',

--- a/frontend/src/components/pages/details/components/DetailsFiles/DetailsFiles.tsx
+++ b/frontend/src/components/pages/details/components/DetailsFiles/DetailsFiles.tsx
@@ -1,0 +1,132 @@
+import { useId, useState } from 'react';
+import { FormattedMessage } from 'react-intl';
+import Link from 'next/link';
+
+import { FileFromAttachment } from 'modules/interface';
+import { cn } from 'services/utils/cn';
+import { Minus } from 'components/Icons/Minus';
+import { Plus } from 'components/Icons/Plus';
+import { Download } from 'components/Icons/Download';
+
+interface DetailsDetailsFilesProps {
+  className?: string;
+  files?: FileFromAttachment[];
+  asAccordion?: boolean;
+  titleTag?: 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+}
+
+export const DetailsFiles: React.FC<DetailsDetailsFilesProps> = ({
+  className,
+  files = [],
+  asAccordion = false,
+  titleTag: TitleTag = 'h2',
+}) => {
+  const SubTitleTag = TitleTag === 'h2' ? 'h3' : 'h4';
+
+  const id = useId();
+  const [isOpen, setOpen] = useState(true);
+
+  if (files.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={cn(className, asAccordion && 'p-4 bg-neutral-100')}>
+      <TitleTag
+        className={cn(
+          'relative flex items-center justify-start gap-1 font-bold',
+          TitleTag === 'h2' ? 'text-Mobile-H1 desktop:text-H2' : 'text-Mobile-C1 desktop:text-H4',
+        )}
+      >
+        <Download size={30} aria-hidden />
+        <FormattedMessage id="attachments.title" values={{ count: files.length }} />
+        {asAccordion && (
+          <button
+            type="button"
+            aria-expanded={isOpen ? 'true' : 'false'}
+            aria-controls={id}
+            className="ml-auto before:content-[''] before:absolute before:inset-0"
+            onClick={() => setOpen(prevOpen => !prevOpen)}
+          >
+            {isOpen ? (
+              <>
+                <span className="sr-only">
+                  <FormattedMessage id="accordion.close" />
+                </span>
+                <Minus size={24} aria-hidden />
+              </>
+            ) : (
+              <>
+                <span className="sr-only">
+                  <FormattedMessage id="accordion.open" />
+                </span>
+                <Plus size={24} aria-hidden />
+              </>
+            )}
+          </button>
+        )}
+      </TitleTag>
+      <ul
+        id={id}
+        className={cn(
+          'flex desktop:flex-col gap-4 border border text-Mobile-C1 desktop:text-P1 mt-4 pb-5 desktop:pb-0 overflow-x-auto overflow-y-hidden desktop:overflow-visible scroll-smooth snap-x',
+          !isOpen && 'hidden',
+        )}
+      >
+        {files.map((file, index) => {
+          const legend = [file.legend, file.author].filter(Boolean).join(' - ');
+          const fileExtension = file.url.split('.').pop();
+
+          return (
+            <li
+              key={index}
+              className="shrink-0 relative desktop:flex w-60 desktop:w-auto border-l desktop:border-l-0 desktop:border-t first:border-0 border-solid border-greySoft pl-5 desktop:pl-0 desktop:pt-5"
+            >
+              <div className="flex flex-col gap-4 desktop:flex-row items-center justify-between w-full">
+                <div>
+                  <SubTitleTag className="flex flex-wrap gap-4 justify-center">
+                    {file.fileName && (
+                      <span className="text-Mobile-C1 desktop:text-H4 text-primary1 font-bold break-all">
+                        {file.fileName}
+                      </span>
+                    )}
+                    <span className="py-1 px-2 rounded-full  bg-primary2 text-sm desktop:text-base">
+                      {file.fileType}
+                    </span>
+                  </SubTitleTag>
+                  {legend.length > 0 && (
+                    <p className="mt-4 text-greyDarkColored text-sm">
+                      <FormattedMessage id="attachments.credit" /> {legend}
+                    </p>
+                  )}
+                </div>
+                <Link
+                  href={file.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  download
+                  className={cn(`
+                    flex justify-center items-center gap-2
+                    p-2
+                    rounded-xl desktop:rounded-full shadow-sm
+                    text-greyDarkColored hover:bg-primary2 focus:bg-primary2 bg-white transition
+                    before:content-[''] before:absolute before:inset-0
+                    `)}
+                >
+                  <span>
+                    <FormattedMessage id="attachments.download" />
+                  </span>
+                  {fileExtension && (
+                    <span className="py-1 px-2 rounded-full bg-greyDarkColored text-white text-sm desktop:text-base">
+                      {fileExtension}
+                    </span>
+                  )}
+                </Link>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+};

--- a/frontend/src/components/pages/details/components/DetailsFiles/index.ts
+++ b/frontend/src/components/pages/details/components/DetailsFiles/index.ts
@@ -1,0 +1,1 @@
+export { DetailsFiles } from './DetailsFiles';

--- a/frontend/src/components/pages/details/components/DetailsMedias/DetailsMedias.tsx
+++ b/frontend/src/components/pages/details/components/DetailsMedias/DetailsMedias.tsx
@@ -51,7 +51,7 @@ export const DetailsMedias: React.FC<DetailsMediasProps> = ({
           TitleTag === 'h2' ? 'text-Mobile-H1 desktop:text-H2' : 'text-Mobile-C1 desktop:text-H4',
         )}
       >
-        <ViewPointIcon size={40} />
+        <ViewPointIcon size={40} aria-hidden />
         <FormattedMessage id="viewPoint.title" />
         {asAccordion && (
           <button
@@ -64,14 +64,14 @@ export const DetailsMedias: React.FC<DetailsMediasProps> = ({
             {isOpen ? (
               <>
                 <span className="sr-only">
-                  <FormattedMessage id="accordion.close" />
+                  <FormattedMessage id="accordion.close" aria-hidden />
                 </span>
                 <Minus size={24} />
               </>
             ) : (
               <>
                 <span className="sr-only">
-                  <FormattedMessage id="accordion.open" />
+                  <FormattedMessage id="accordion.open" aria-hidden />
                 </span>
                 <Plus size={24} />
               </>
@@ -136,7 +136,7 @@ export const DetailsMedias: React.FC<DetailsMediasProps> = ({
                   <span className="text-greyDarkColored">
                     <FormattedMessage id="viewPoint.displayPicture" />
                   </span>
-                  <ArrowRight />
+                  <ArrowRight aria-hidden />
                 </button>
               </div>
             </li>

--- a/frontend/src/components/pages/details/components/DetailsMedias/index.ts
+++ b/frontend/src/components/pages/details/components/DetailsMedias/index.ts
@@ -1,1 +1,0 @@
-export { DetailsMedias } from './DetailsMedias';

--- a/frontend/src/components/pages/details/components/DetailsSection/DetailsSection.tsx
+++ b/frontend/src/components/pages/details/components/DetailsSection/DetailsSection.tsx
@@ -20,6 +20,7 @@ export const DetailsSection: React.FC<DetailsSectionProps> = ({
       <div
         id="details_section"
         className={cn(`flex flex-col
+          gap-3 desktop:gap-4
           pt-6 desktop:pt-12
           pb-3 desktop:pb-6
           mb-3 desktop:mb-6
@@ -33,7 +34,7 @@ export const DetailsSection: React.FC<DetailsSectionProps> = ({
         )}
         <div
           id="details_sectionContent"
-          className="mt-3 desktop:mt-4
+          className="flex flex-col gap-6
           text-Mobile-C1 desktop:text-P1"
         >
           {children}

--- a/frontend/src/components/pages/details/components/DetailsViewPoints/DetailsViewPoints.tsx
+++ b/frontend/src/components/pages/details/components/DetailsViewPoints/DetailsViewPoints.tsx
@@ -34,7 +34,7 @@ export const DetailsViewPoints: React.FC<DetailsViewPointsProps> = ({
   );
 
   const id = useId();
-  const [isOpen, setOpen] = useState(true);
+  const [isOpen, setOpen] = useState(!asAccordion);
 
   const { setHoveredCardId } = useListAndMapContext();
 
@@ -43,7 +43,7 @@ export const DetailsViewPoints: React.FC<DetailsViewPointsProps> = ({
   }
 
   return (
-    <div className={cn(className, asAccordion && 'p-4 bg-neutral-100')}>
+    <div className={cn(className, asAccordion && 'p-2 p-2 desktop:p-6 bg-neutral-100')}>
       <TitleTag
         className={cn(
           'relative flex items-center justify-stretch gap-1 font-bold',
@@ -78,13 +78,19 @@ export const DetailsViewPoints: React.FC<DetailsViewPointsProps> = ({
           </button>
         )}
       </TitleTag>
-      <p className={cn('text-lg desktop:mt-6', !isOpen && 'hidden')}>
+      <p
+        className={cn(
+          'text-lg desktop:mt-6',
+          asAccordion && 'hidden desktop:block',
+          !isOpen && 'hidden desktop:hidden',
+        )}
+      >
         <FormattedMessage id="viewPoint.description" />
       </p>
       <ul
         id={id}
         className={cn(
-          'flex desktop:flex-col gap-4 bg-white text-Mobile-C1 desktop:text-P1 mt-4 pb-5 desktop:pb-0 overflow-x-auto desktop:overflow-x-hidden overflow-y-hidden desktop:overflow-y-auto scroll-smooth snap-x',
+          'flex desktop:flex-col gap-4 text-Mobile-C1 desktop:text-P1 mt-4 pb-5 desktop:pb-0 overflow-x-auto desktop:overflow-x-hidden overflow-y-hidden desktop:overflow-y-auto scroll-smooth snap-x',
           !isOpen && 'hidden',
         )}
       >
@@ -93,7 +99,7 @@ export const DetailsViewPoints: React.FC<DetailsViewPointsProps> = ({
           return (
             <li
               key={viewPoint.id}
-              className="shrink-0 relative desktop:flex items-stretch border border-solid border-greySoft hover:border-blackSemiTransparent transition rounded-xl overflow-hidden row w-60 desktop:w-auto"
+              className="shrink-0 relative desktop:flex items-stretch border border-solid border-greySoft hover:border-blackSemiTransparent transition rounded-xl overflow-hidden row w-60 desktop:w-full bg-white"
               onMouseEnter={() => {
                 !asAccordion && setHoveredCardId(`DETAILS-VIEWPOINT-${viewPoint.id}`);
               }}

--- a/frontend/src/components/pages/details/components/DetailsViewPoints/DetailsViewPoints.tsx
+++ b/frontend/src/components/pages/details/components/DetailsViewPoints/DetailsViewPoints.tsx
@@ -9,7 +9,7 @@ import { Plus } from 'components/Icons/Plus';
 import { useListAndMapContext } from 'modules/map/ListAndMapContext';
 import { ViewPoint as ViewPointIcon } from 'components/Icons/ViewPoint';
 
-interface DetailsMediasProps {
+interface DetailsViewPointsProps {
   className?: string;
   viewPoints: ViewPoint[];
   handleViewPointClick?: (key: string) => void;
@@ -17,7 +17,7 @@ interface DetailsMediasProps {
   titleTag?: 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 }
 
-export const DetailsMedias: React.FC<DetailsMediasProps> = ({
+export const DetailsViewPoints: React.FC<DetailsViewPointsProps> = ({
   className,
   viewPoints,
   handleViewPointClick,
@@ -41,7 +41,6 @@ export const DetailsMedias: React.FC<DetailsMediasProps> = ({
   if (viewPoints.length === 0) {
     return null;
   }
-
 
   return (
     <div className={className}>

--- a/frontend/src/components/pages/details/components/DetailsViewPoints/DetailsViewPoints.tsx
+++ b/frontend/src/components/pages/details/components/DetailsViewPoints/DetailsViewPoints.tsx
@@ -10,6 +10,7 @@ import { useListAndMapContext } from 'modules/map/ListAndMapContext';
 import { ViewPoint as ViewPointIcon } from 'components/Icons/ViewPoint';
 
 interface DetailsViewPointsProps {
+  id?: string;
   className?: string;
   viewPoints: ViewPoint[];
   handleViewPointClick?: (key: string) => void;
@@ -23,6 +24,7 @@ export const DetailsViewPoints: React.FC<DetailsViewPointsProps> = ({
   handleViewPointClick,
   asAccordion = false,
   titleTag: TitleTag = 'h2',
+  ...props
 }) => {
   const SubTitleTag = TitleTag === 'h2' ? 'h3' : 'h4';
 
@@ -43,7 +45,7 @@ export const DetailsViewPoints: React.FC<DetailsViewPointsProps> = ({
   }
 
   return (
-    <div className={cn(className, asAccordion && 'p-2 p-2 desktop:p-6 bg-neutral-100')}>
+    <div className={cn(className, asAccordion && 'p-2 p-2 desktop:p-6 bg-neutral-100')} {...props}>
       <TitleTag
         className={cn(
           'relative flex items-center justify-stretch gap-1 font-bold',

--- a/frontend/src/components/pages/details/components/DetailsViewPoints/DetailsViewPoints.tsx
+++ b/frontend/src/components/pages/details/components/DetailsViewPoints/DetailsViewPoints.tsx
@@ -43,10 +43,10 @@ export const DetailsViewPoints: React.FC<DetailsViewPointsProps> = ({
   }
 
   return (
-    <div className={className}>
+    <div className={cn(className, asAccordion && 'p-4 bg-neutral-100')}>
       <TitleTag
         className={cn(
-          'relative flex items-center justify-start gap-1 font-bold',
+          'relative flex items-center justify-stretch gap-1 font-bold',
           TitleTag === 'h2' ? 'text-Mobile-H1 desktop:text-H2' : 'text-Mobile-C1 desktop:text-H4',
         )}
       >
@@ -57,34 +57,34 @@ export const DetailsViewPoints: React.FC<DetailsViewPointsProps> = ({
             type="button"
             aria-expanded={isOpen ? 'true' : 'false'}
             aria-controls={id}
-            className="flex gap-1 items-center text-base before:content-[''] before:absolute before:inset-0"
+            className="ml-auto before:content-[''] before:absolute before:inset-0"
             onClick={() => setOpen(prevOpen => !prevOpen)}
           >
             {isOpen ? (
               <>
                 <span className="sr-only">
-                  <FormattedMessage id="accordion.close" aria-hidden />
+                  <FormattedMessage id="accordion.close" />
                 </span>
-                <Minus size={24} />
+                <Minus size={24} aria-hidden />
               </>
             ) : (
               <>
                 <span className="sr-only">
-                  <FormattedMessage id="accordion.open" aria-hidden />
+                  <FormattedMessage id="accordion.open" />
                 </span>
-                <Plus size={24} />
+                <Plus size={24} aria-hidden />
               </>
             )}
           </button>
         )}
       </TitleTag>
-      <p className="text-lg desktop:mt-6">
+      <p className={cn('text-lg desktop:mt-6', !isOpen && 'hidden')}>
         <FormattedMessage id="viewPoint.description" />
       </p>
       <ul
         id={id}
         className={cn(
-          'flex desktop:flex-col gap-4 text-Mobile-C1 desktop:text-P1 mt-4 pb-5 desktop:pb-0 overflow-x-auto desktop:overflow-x-hidden overflow-y-hidden desktop:overflow-y-auto scroll-smooth snap-x',
+          'flex desktop:flex-col gap-4 bg-white text-Mobile-C1 desktop:text-P1 mt-4 pb-5 desktop:pb-0 overflow-x-auto desktop:overflow-x-hidden overflow-y-hidden desktop:overflow-y-auto scroll-smooth snap-x',
           !isOpen && 'hidden',
         )}
       >

--- a/frontend/src/components/pages/details/components/DetailsViewPoints/index.ts
+++ b/frontend/src/components/pages/details/components/DetailsViewPoints/index.ts
@@ -1,0 +1,1 @@
+export { DetailsViewPoints } from './DetailsViewPoints';

--- a/frontend/src/components/pages/site/OutdoorSiteUI.tsx
+++ b/frontend/src/components/pages/site/OutdoorSiteUI.tsx
@@ -43,6 +43,7 @@ import { DetailsSensitiveArea } from '../details/components/DetailsSensitiveArea
 import { DetailsAndMapProvider } from '../details/DetailsAndMapContext';
 import { useDetailsSections } from '../details/useDetailsSections';
 import { DetailsViewPoints } from '../details/components/DetailsViewPoints';
+import { DetailsFiles } from '../details/components/DetailsFiles';
 
 interface Props {
   outdoorSiteUrl: string | string[] | undefined;
@@ -200,9 +201,9 @@ const OutdoorSiteUIWithoutContext: React.FC<Props> = ({ outdoorSiteUrl, language
                       );
                     }
                     if (
-                      hasNavigator &&
                       section.name === 'medias' &&
-                      outdoorSiteContent.viewPoints.length > 0
+                      ((hasNavigator && outdoorSiteContent.viewPoints.length > 0) ||
+                        outdoorSiteContent.filesFromAttachments.length > 0)
                     ) {
                       return (
                         <section
@@ -211,10 +212,13 @@ const OutdoorSiteUIWithoutContext: React.FC<Props> = ({ outdoorSiteUrl, language
                           id={`details_${section.name}_ref`}
                         >
                           <DetailsSection htmlId="details_medias" className={marginDetailsChild}>
-                            <DetailsViewPoints
-                              viewPoints={outdoorSiteContent.viewPoints}
-                              handleViewPointClick={handleViewPointClick}
-                            />
+                            <DetailsFiles files={outdoorSiteContent.filesFromAttachments} />
+                            {hasNavigator && (
+                              <DetailsViewPoints
+                                viewPoints={outdoorSiteContent.viewPoints}
+                                handleViewPointClick={handleViewPointClick}
+                              />
+                            )}
                           </DetailsSection>
                         </section>
                       );
@@ -245,6 +249,7 @@ const OutdoorSiteUIWithoutContext: React.FC<Props> = ({ outdoorSiteUrl, language
                               iconUri: poi.type.pictogramUri,
                               iconName: poi.type.label,
                               viewPoints: poi.viewPoints,
+                              filesFromAttachments: poi.filesFromAttachments,
                             }))}
                             type="POI"
                             handleViewPointClick={handleViewPointClick}

--- a/frontend/src/components/pages/site/OutdoorSiteUI.tsx
+++ b/frontend/src/components/pages/site/OutdoorSiteUI.tsx
@@ -42,7 +42,7 @@ import { DetailsCoverCarousel } from '../details/components/DetailsCoverCarousel
 import { DetailsSensitiveArea } from '../details/components/DetailsSensitiveArea';
 import { DetailsAndMapProvider } from '../details/DetailsAndMapContext';
 import { useDetailsSections } from '../details/useDetailsSections';
-import { DetailsMedias } from '../details/components/DetailsMedias';
+import { DetailsViewPoints } from '../details/components/DetailsViewPoints';
 
 interface Props {
   outdoorSiteUrl: string | string[] | undefined;
@@ -211,7 +211,7 @@ const OutdoorSiteUIWithoutContext: React.FC<Props> = ({ outdoorSiteUrl, language
                           id={`details_${section.name}_ref`}
                         >
                           <DetailsSection htmlId="details_medias" className={marginDetailsChild}>
-                            <DetailsMedias
+                            <DetailsViewPoints
                               viewPoints={outdoorSiteContent.viewPoints}
                               handleViewPointClick={handleViewPointClick}
                             />

--- a/frontend/src/components/pages/touristicContent/TouristicContentUI.tsx
+++ b/frontend/src/components/pages/touristicContent/TouristicContentUI.tsx
@@ -22,6 +22,7 @@ import { DetailsHeaderMobile, marginDetailsChild } from '../details/Details';
 import { HtmlText, templatesVariablesAreDefinedAndUsed } from '../details/utils';
 import { DetailsHeader } from '../details/components/DetailsHeader';
 import { useDetailsSections } from '../details/useDetailsSections';
+import { DetailsFiles } from '../details/components/DetailsFiles';
 
 interface TouristicContentUIProps {
   touristicContentUrl: string | string[] | undefined;
@@ -153,6 +154,24 @@ export const TouristicContentUI: React.FC<TouristicContentUIProps> = ({
                       </section>
                     );
                   }
+
+                  if (
+                    section.name === 'medias' &&
+                    touristicContent.filesFromAttachments.length > 0
+                  ) {
+                    return (
+                      <section
+                        key={section.name}
+                        ref={sectionRef[section.name]}
+                        id={`details_${section.name}_ref`}
+                      >
+                        <DetailsSection htmlId="details_medias" className={marginDetailsChild}>
+                          <DetailsFiles files={touristicContent.filesFromAttachments} />
+                        </DetailsSection>
+                      </section>
+                    );
+                  }
+
                   if (section.name === 'practicalInformations' && touristicContent.practicalInfo) {
                     return (
                       <section

--- a/frontend/src/components/pages/touristicEvent/TouristicEventUI.tsx
+++ b/frontend/src/components/pages/touristicEvent/TouristicEventUI.tsx
@@ -31,6 +31,7 @@ import { ErrorFallback } from '../search/components/ErrorFallback';
 import { DetailsTopIcons } from '../details/components/DetailsTopIcons';
 import { DetailsCoverCarousel } from '../details/components/DetailsCoverCarousel';
 import { useDetailsSections } from '../details/useDetailsSections';
+import { DetailsFiles } from '../details/components/DetailsFiles';
 
 interface Props {
   touristicEventUrl: string | string[] | undefined;
@@ -186,6 +187,24 @@ export const TouristicEventUIWithoutContext: React.FC<Props> = ({
                         </section>
                       );
                     }
+
+                    if (
+                      section.name === 'medias' &&
+                      touristicEventContent.filesFromAttachments.length > 0
+                    ) {
+                      return (
+                        <section
+                          key={section.name}
+                          ref={sectionRef[section.name]}
+                          id={`details_${section.name}_ref`}
+                        >
+                          <DetailsSection htmlId="details_medias" className={marginDetailsChild}>
+                            <DetailsFiles files={touristicEventContent.filesFromAttachments} />
+                          </DetailsSection>
+                        </section>
+                      );
+                    }
+
                     if (section.name === 'description' && touristicEventContent.description) {
                       return (
                         <section

--- a/frontend/src/modules/details/adapter.ts
+++ b/frontend/src/modules/details/adapter.ts
@@ -23,7 +23,10 @@ import { Service } from 'modules/service/interface';
 import { InfrastructureDictionary } from 'modules/infrastructure/interface';
 import { SourceDictionnary } from 'modules/source/interface';
 import { TouristicContent } from 'modules/touristicContent/interface';
-import { getLargeImagesOrThumbnailsFromAttachments } from 'modules/utils/adapter';
+import {
+  geFilesFromAttachments,
+  getLargeImagesOrThumbnailsFromAttachments,
+} from 'modules/utils/adapter';
 import {
   adaptGeometry2D,
   extractFirstPointOfGeometry,
@@ -101,6 +104,7 @@ export const adaptResults = ({
       title: rawDetailsProperties.name,
       place: cityDictionnary[rawDetailsProperties.departure_city]?.name ?? '',
       imgs: getLargeImagesOrThumbnailsFromAttachments(rawDetailsProperties.attachments, false),
+      filesFromAttachments: geFilesFromAttachments(rawDetailsProperties.attachments),
       practice: activity,
       transport: rawDetailsProperties.public_transport,
       access: rawDetailsProperties.access,

--- a/frontend/src/modules/details/interface.ts
+++ b/frontend/src/modules/details/interface.ts
@@ -5,6 +5,7 @@ import { Network } from 'modules/networks/interface';
 import { Poi } from 'modules/poi/interface';
 import {
   Coordinate2D,
+  FileFromAttachment,
   ImageFromAttachment,
   RawAttachment,
   RawCoordinate2D,
@@ -159,6 +160,7 @@ export interface Details extends DetailsHtml {
   title: string;
   place?: string;
   imgs: ImageFromAttachment[];
+  filesFromAttachments: FileFromAttachment[];
   tags: string[];
   informations: DetailsInformation;
   pois: Poi[];

--- a/frontend/src/modules/details/mocks/mocks.ts
+++ b/frontend/src/modules/details/mocks/mocks.ts
@@ -24,6 +24,10 @@ export const rawDetailsProperties: RawDetailsProperties = {
       title: '',
       url: 'https://www.youtube.com/watch?v=Jm3anSjly0Y',
       type: 'video',
+      filetype: {
+        id: 1,
+        type: 'Topoguide',
+      },
     },
     {
       author: 'admin',
@@ -34,6 +38,10 @@ export const rawDetailsProperties: RawDetailsProperties = {
       title: "Lac_de_l'Eychauda_Parc_National_des_Ecrins",
       url: 'https://geotrekdemo.ecrins-parcnational.fr/media/paperclip/trekking_trek/2/lac_de_leychauda_parc_national_des_ecrins.jpg',
       type: 'image',
+      filetype: {
+        id: 1,
+        type: 'Topoguide',
+      },
     },
     {
       author: 'admin',
@@ -44,6 +52,10 @@ export const rawDetailsProperties: RawDetailsProperties = {
       title: 'Marmotte_Parc_National_des_Ecrins',
       url: 'https://geotrekdemo.ecrins-parcnational.fr/media/paperclip/trekking_trek/2/marmotte_parc_national_des_ecrins.jpg',
       type: 'image',
+      filetype: {
+        id: 1,
+        type: 'Topoguide',
+      },
     },
     {
       author: 'Dominique Vincent - PNE',
@@ -54,6 +66,10 @@ export const rawDetailsProperties: RawDetailsProperties = {
       title: 'le-depart-du-hameau-de-molines',
       url: 'https://geotrekdemo.ecrins-parcnational.fr/media/paperclip/trekking_trek/2/le-depart-du-hameau-de-molines.JPG',
       type: 'image',
+      filetype: {
+        id: 1,
+        type: 'Topoguide',
+      },
     },
     {
       author: 'Dominique Vincent - PNE',
@@ -64,6 +80,10 @@ export const rawDetailsProperties: RawDetailsProperties = {
       title: 'arrivee-au-col-de-font-froide',
       url: 'https://geotrekdemo.ecrins-parcnational.fr/media/paperclip/trekking_trek/2/arrivee-au-col-de-font-froide.JPG',
       type: 'image',
+      filetype: {
+        id: 1,
+        type: 'Topoguide',
+      },
     },
     {
       author: 'Dominique Vincent - PNE',
@@ -74,6 +94,10 @@ export const rawDetailsProperties: RawDetailsProperties = {
       title: 'en-chemin-vers-le-col-de-font-froide',
       url: 'https://geotrekdemo.ecrins-parcnational.fr/media/paperclip/trekking_trek/2/en-chemin-vers-le-col-de-font-froide.JPG',
       type: 'image',
+      filetype: {
+        id: 1,
+        type: 'Topoguide',
+      },
     },
     {
       author: 'Dominique Vincent - PNE',
@@ -84,6 +108,10 @@ export const rawDetailsProperties: RawDetailsProperties = {
       title: 'signaletique-du-sentier-menant-au-col-de-font-froide',
       url: 'https://geotrekdemo.ecrins-parcnational.fr/media/paperclip/trekking_trek/2/signaletique-du-sentier-menant-au-col-de-font-froide.JPG',
       type: 'image',
+      filetype: {
+        id: 1,
+        type: 'Topoguide',
+      },
     },
     {
       author: 'Dominique Vincent - PNE',
@@ -94,6 +122,10 @@ export const rawDetailsProperties: RawDetailsProperties = {
       title: 'randonneur-au-col-de-font-froide',
       url: 'https://geotrekdemo.ecrins-parcnational.fr/media/paperclip/trekking_trek/2/randonneur-au-col-de-font-froide.JPG',
       type: 'image',
+      filetype: {
+        id: 1,
+        type: 'Topoguide',
+      },
     },
   ],
   departure_city: '05090',

--- a/frontend/src/modules/infrastructure/mocks/index.ts
+++ b/frontend/src/modules/infrastructure/mocks/index.ts
@@ -18,6 +18,10 @@ export const mockInfrastructureResponse = (): APIResponseForList<RawInfrastructu
           title: 'lagopede-alpin-en-tenue-dete',
           url: 'https://geotrekdemo.ecrins-parcnational.fr/media/paperclip/trekking_poi/442/lagopede-alpin-en-tenue-dete.jpg',
           type: 'image',
+          filetype: {
+            id: 1,
+            type: 'Topoguide',
+          },
         },
         {
           author: 'Damien Combrisson - PNE',
@@ -28,6 +32,10 @@ export const mockInfrastructureResponse = (): APIResponseForList<RawInfrastructu
           title: 'lagopede-alpin-en-plumage-dhiver',
           url: 'https://geotrekdemo.ecrins-parcnational.fr/media/paperclip/trekking_poi/442/lagopede-alpin-en-plumage-dhiver.jpg',
           type: 'image',
+          filetype: {
+            id: 1,
+            type: 'Topoguide',
+          },
         },
       ],
       id: 1,

--- a/frontend/src/modules/interface.ts
+++ b/frontend/src/modules/interface.ts
@@ -141,10 +141,17 @@ export interface RawAttachment {
   };
 }
 
-export interface ImageFromAttachment {
+interface Attachment {
   author: string;
   legend: string;
   url: string;
+}
+
+export interface ImageFromAttachment extends Attachment {}
+
+export interface FileFromAttachment extends Attachment {
+  fileName: string;
+  fileType: string;
 }
 
 export interface LineStringGeometry {

--- a/frontend/src/modules/interface.ts
+++ b/frontend/src/modules/interface.ts
@@ -135,6 +135,10 @@ export interface RawAttachment {
   title: string;
   url: string;
   type: string;
+  filetype: {
+    id: number;
+    type: string;
+  };
 }
 
 export interface ImageFromAttachment {

--- a/frontend/src/modules/outdoorSite/adapter.ts
+++ b/frontend/src/modules/outdoorSite/adapter.ts
@@ -2,7 +2,11 @@ import { SensitiveArea } from 'modules/sensitiveArea/interface';
 import { SignageDictionary } from 'modules/signage/interface';
 import { Service } from 'modules/service/interface';
 import { InfrastructureDictionary } from 'modules/infrastructure/interface';
-import { getLargeImagesOrThumbnailsFromAttachments, getThumbnail } from 'modules/utils/adapter';
+import {
+  geFilesFromAttachments,
+  getLargeImagesOrThumbnailsFromAttachments,
+  getThumbnail,
+} from 'modules/utils/adapter';
 import { adaptGeometry } from 'modules/utils/geometry';
 import { ViewPoint } from 'modules/viewPoint/interface';
 import { CityDictionnary } from '../city/interface';
@@ -44,6 +48,7 @@ export const adaptOutdoorSites = ({
       id: rawOutdoorSite.id,
       name: rawOutdoorSite.name,
       images: getLargeImagesOrThumbnailsFromAttachments(rawOutdoorSite.attachments, false),
+      filesFromAttachments: geFilesFromAttachments(rawOutdoorSite.attachments),
       geometry: adaptGeometry(rawOutdoorSite.geometry),
       themes: rawOutdoorSite?.themes?.map(themeId => themeDictionnary[themeId]?.label) ?? [],
       category: outdoorPracticeDictionnary[rawOutdoorSite.practice] ?? null,

--- a/frontend/src/modules/outdoorSite/interface.ts
+++ b/frontend/src/modules/outdoorSite/interface.ts
@@ -1,6 +1,7 @@
 import { Bbox, WebLink } from 'modules/details/interface';
 import { InfrastructureDictionary } from 'modules/infrastructure/interface';
 import {
+  FileFromAttachment,
   GeometryCollection,
   ImageFromAttachment,
   LineStringGeometry,
@@ -81,6 +82,7 @@ export interface OutdoorSite {
   id: string;
   name: string;
   images: ImageFromAttachment[];
+  filesFromAttachments: FileFromAttachment[];
   geometry:
     | PolygonGeometry
     | MultiPolygonGeometry

--- a/frontend/src/modules/poi/adapter.ts
+++ b/frontend/src/modules/poi/adapter.ts
@@ -1,5 +1,8 @@
 import { PoiTypeDictionnary } from 'modules/poiType/interface';
-import { getLargeImagesOrThumbnailsFromAttachments } from 'modules/utils/adapter';
+import {
+  geFilesFromAttachments,
+  getLargeImagesOrThumbnailsFromAttachments,
+} from 'modules/utils/adapter';
 import { adaptViewPoints } from 'modules/viewPoint/adapter';
 import { Poi, RawPoi } from './interface';
 
@@ -21,6 +24,7 @@ export const adaptPoi = ({
         description: rawPoi.description,
         thumbnails: getLargeImagesOrThumbnailsFromAttachments(rawPoi.attachments, true),
         images: getLargeImagesOrThumbnailsFromAttachments(rawPoi.attachments, false),
+        filesFromAttachments: geFilesFromAttachments(rawPoi.attachments),
         type: poiTypes[rawPoi.type],
         geometry: {
           x: rawPoi.geometry.coordinates[0],

--- a/frontend/src/modules/poi/interface.ts
+++ b/frontend/src/modules/poi/interface.ts
@@ -1,5 +1,6 @@
 import {
   Coordinate3D,
+  FileFromAttachment,
   ImageFromAttachment,
   RawAttachment,
   RawPointGeometry3D,
@@ -23,6 +24,7 @@ export interface Poi {
   description?: string;
   thumbnails: ImageFromAttachment[];
   images: ImageFromAttachment[];
+  filesFromAttachments: FileFromAttachment[];
   type: PoiType;
   geometry: Coordinate3D;
   viewPoints?: ViewPoint[];

--- a/frontend/src/modules/poi/mocks/index.ts
+++ b/frontend/src/modules/poi/mocks/index.ts
@@ -23,6 +23,10 @@ export const mockPois = (): APIResponseForList<RawPoi> => ({
           title: 'lagopede-alpin-en-tenue-dete',
           url: 'https://geotrekdemo.ecrins-parcnational.fr/media/paperclip/trekking_poi/442/lagopede-alpin-en-tenue-dete.jpg',
           type: 'image',
+          filetype: {
+            id: 1,
+            type: 'Topoguide',
+          },
         },
         {
           author: 'Damien Combrisson - PNE',
@@ -33,6 +37,10 @@ export const mockPois = (): APIResponseForList<RawPoi> => ({
           title: 'lagopede-alpin-en-plumage-dhiver',
           url: 'https://geotrekdemo.ecrins-parcnational.fr/media/paperclip/trekking_poi/442/lagopede-alpin-en-plumage-dhiver.jpg',
           type: 'image',
+          filetype: {
+            id: 1,
+            type: 'Topoguide',
+          },
         },
       ],
       type: 3,

--- a/frontend/src/modules/results/mocks/index.ts
+++ b/frontend/src/modules/results/mocks/index.ts
@@ -31,6 +31,10 @@ export const mockResultsResponse = (): APIResponseForList<RawTrekResult> => ({
           title: '',
           url: 'https://geotrekdemo.ecrins-parcnational.fr/media/paperclip/trekking_trek/2/le-depart-du-hameau-de-molines.JPG',
           type: 'image',
+          filetype: {
+            id: 1,
+            type: 'Topoguide',
+          },
         },
       ],
     },

--- a/frontend/src/modules/signage/mocks/index.ts
+++ b/frontend/src/modules/signage/mocks/index.ts
@@ -18,6 +18,10 @@ export const mockSignageResponse = (): APIResponseForList<RawSignage> => ({
           title: 'lagopede-alpin-en-tenue-dete',
           url: 'https://geotrekdemo.ecrins-parcnational.fr/media/paperclip/trekking_poi/442/lagopede-alpin-en-tenue-dete.jpg',
           type: 'image',
+          filetype: {
+            id: 1,
+            type: 'Topoguide',
+          },
         },
         {
           author: 'Damien Combrisson - PNE',
@@ -28,6 +32,10 @@ export const mockSignageResponse = (): APIResponseForList<RawSignage> => ({
           title: 'lagopede-alpin-en-plumage-dhiver',
           url: 'https://geotrekdemo.ecrins-parcnational.fr/media/paperclip/trekking_poi/442/lagopede-alpin-en-plumage-dhiver.jpg',
           type: 'image',
+          filetype: {
+            id: 1,
+            type: 'Topoguide',
+          },
         },
       ],
       id: 1,

--- a/frontend/src/modules/touristicContent/adapter.ts
+++ b/frontend/src/modules/touristicContent/adapter.ts
@@ -6,7 +6,11 @@ import {
   TouristicContentCategoryDictionnary,
 } from 'modules/touristicContentCategory/interface';
 import { PopupResult } from 'modules/trekResult/interface';
-import { getLargeImagesOrThumbnailsFromAttachments, getThumbnail } from 'modules/utils/adapter';
+import {
+  geFilesFromAttachments,
+  getLargeImagesOrThumbnailsFromAttachments,
+  getThumbnail,
+} from 'modules/utils/adapter';
 import { getGlobalConfig } from 'modules/utils/api.config';
 import { adaptGeometry } from 'modules/utils/geometry';
 import {
@@ -110,6 +114,7 @@ export const adaptTouristicContentDetails = ({
   category: touristicContentCategory,
   geometry: rawTCD.geometry ? adaptGeometry(rawTCD.geometry) : null,
   images: getLargeImagesOrThumbnailsFromAttachments(rawTCD.properties.attachments, false),
+  filesFromAttachments: geFilesFromAttachments(rawTCD.properties.attachments),
   description: rawTCD.properties.description,
   sources: Array.isArray(rawTCD.properties.source)
     ? rawTCD.properties.source

--- a/frontend/src/modules/touristicContent/interface.ts
+++ b/frontend/src/modules/touristicContent/interface.ts
@@ -1,5 +1,6 @@
 import { Bbox } from 'modules/details/interface';
 import {
+  FileFromAttachment,
   GeometryCollection,
   ImageFromAttachment,
   LineStringGeometry,
@@ -96,6 +97,7 @@ export interface TouristicContentResult extends ResultCard {
 
 export interface TouristicContentDetails extends TouristicContent {
   images: ImageFromAttachment[];
+  filesFromAttachments: FileFromAttachment[];
   description: string;
   sources: Source[];
   contact: string;

--- a/frontend/src/modules/touristicContent/mocks/index.ts
+++ b/frontend/src/modules/touristicContent/mocks/index.ts
@@ -21,6 +21,10 @@ export const mockTouristicContentResponse =
             title: '',
             url: 'https://geotrekdemo.ecrins-parcnational.fr/media/paperclip/tourism_touristiccontent/257/4948000.jpg',
             type: 'image',
+            filetype: {
+              id: 1,
+              type: 'Topoguide',
+            },
           },
           {
             author: '',
@@ -31,6 +35,10 @@ export const mockTouristicContentResponse =
             title: '',
             url: 'https://geotrekdemo.ecrins-parcnational.fr/media/paperclip/tourism_touristiccontent/257/4948001.jpg',
             type: 'image',
+            filetype: {
+              id: 1,
+              type: 'Topoguide',
+            },
           },
           {
             author: '',
@@ -41,6 +49,10 @@ export const mockTouristicContentResponse =
             title: '',
             url: 'https://geotrekdemo.ecrins-parcnational.fr/media/paperclip/tourism_touristiccontent/257/4947999.jpg',
             type: 'image',
+            filetype: {
+              id: 1,
+              type: 'Topoguide',
+            },
           },
         ],
         approved: false,

--- a/frontend/src/modules/touristicEvent/adapter.ts
+++ b/frontend/src/modules/touristicEvent/adapter.ts
@@ -1,4 +1,8 @@
-import { getLargeImagesOrThumbnailsFromAttachments, getThumbnail } from 'modules/utils/adapter';
+import {
+  geFilesFromAttachments,
+  getLargeImagesOrThumbnailsFromAttachments,
+  getThumbnail,
+} from 'modules/utils/adapter';
 import { adaptGeometry } from 'modules/utils/geometry';
 import { CityDictionnary } from '../city/interface';
 import { Choices } from '../filters/interface';
@@ -34,6 +38,7 @@ export const adaptTouristicEvents = ({
       id: rawTouristicEvent.id,
       name: rawTouristicEvent.name,
       images: getLargeImagesOrThumbnailsFromAttachments(rawTouristicEvent.attachments, false),
+      filesFromAttachments: geFilesFromAttachments(rawTouristicEvent.attachments),
       geometry: adaptGeometry(rawTouristicEvent.geometry),
       themes: rawTouristicEvent?.themes?.map(themeId => themeDictionnary[themeId]?.label) ?? [],
       place: cityDictionnary?.[rawTouristicEvent?.cities?.[0]]?.name ?? '',

--- a/frontend/src/modules/touristicEvent/interface.ts
+++ b/frontend/src/modules/touristicEvent/interface.ts
@@ -1,5 +1,6 @@
 import { Bbox } from 'modules/details/interface';
 import {
+  FileFromAttachment,
   GeometryCollection,
   ImageFromAttachment,
   LineStringGeometry,
@@ -77,6 +78,7 @@ export interface TouristicEvent {
   id: string;
   name: string;
   images: ImageFromAttachment[];
+  filesFromAttachments: FileFromAttachment[];
   geometry:
     | PolygonGeometry
     | MultiPolygonGeometry

--- a/frontend/src/modules/utils/adapter.ts
+++ b/frontend/src/modules/utils/adapter.ts
@@ -33,6 +33,24 @@ export const getLargeImagesOrThumbnailsFromAttachments = (
   return attachments.length > 0 ? attachments : [fallbackAttachment];
 };
 
+export const geFilesFromAttachments = (rawAttachments: RawAttachment[]) => {
+  const attachments = rawAttachments
+    .filter(rawAttachment => {
+      const lastPartOfUrl = rawAttachment.url?.split('/').pop();
+      // Files without extensions are false positive images (GTA version < 2.97.0)
+      const hasExtension = lastPartOfUrl?.includes('.');
+      return rawAttachment.type === 'file' && hasExtension;
+    })
+    .map(rawAttachment => ({
+      url: rawAttachment.url,
+      legend: rawAttachment.legend,
+      author: rawAttachment.author,
+      fileName: rawAttachment.title,
+      fileType: rawAttachment.filetype?.type ?? null,
+    }));
+  return attachments;
+};
+
 export function concatResults<T>(rawResults: APIResponseForList<T>[]): T[] {
   return rawResults.reduce<T[]>(
     (concatenatedResults, currentResult) => [...concatenatedResults, ...currentResult.results],

--- a/frontend/src/translations/ca.json
+++ b/frontend/src/translations/ca.json
@@ -253,6 +253,11 @@
     "credit": "Crèdit fotogràfic :",
     "displayPicture": "Navega per la foto"
   },
+  "attachments": {
+    "title": "{count, plural, =0 {Adjunt} one {Adjunt} other {Adjunts}}",
+    "credit": "Crèdit:",
+    "download": "Descarregar"
+  },
   "Wind": {
     "N": "Nord",
     "S": "Sud",

--- a/frontend/src/translations/de.json
+++ b/frontend/src/translations/de.json
@@ -253,6 +253,11 @@
     "credit": "Fotogutschrift:",
     "displayPicture": "Foto durchsuchen"
   },
+  "attachments": {
+    "title": "{count, plural, =0 {Anlage} one {Anlage} other {Anhänge}}",
+    "credit": "Kredit:",
+    "download": "Herunterladen"
+  },
   "Wind": {
     "N": "Norden",
     "S": "Süden",

--- a/frontend/src/translations/en.json
+++ b/frontend/src/translations/en.json
@@ -260,6 +260,11 @@
     "credit": "Picture credit:",
     "displayPicture": "Display picture"
   },
+  "attachments": {
+    "title": "{count, plural, =0 {Attachment} one {Attachment} other {Attachments}}",
+    "credit": "Credit:",
+    "download": "Download"
+  },
   "Wind": {
     "N": "North",
     "S": "South",

--- a/frontend/src/translations/es.json
+++ b/frontend/src/translations/es.json
@@ -253,6 +253,11 @@
     "credit": "Crédito de la foto:",
     "displayPicture": "Examinar foto"
   },
+  "attachments": {
+    "title": "{count, plural, =0 {Archivo adjunto} one {Archivo adjunto} other {Archivos adjuntos}}",
+    "credit": "Créditos:",
+    "download": "Descargar"
+  },
   "Wind": {
     "N": "Norte",
     "S": "Sur",

--- a/frontend/src/translations/fr.json
+++ b/frontend/src/translations/fr.json
@@ -260,6 +260,11 @@
     "credit": "Crédit image :",
     "displayPicture": "Afficher l'image"
   },
+  "attachments": {
+    "title": "{count, plural, =0 {Document associé} one {Document associé} other {Documents associés}}",
+    "credit": "Crédit :",
+    "download": "Télécharger"
+  },
   "Wind": {
     "N": "Nord",
     "S": "Sud",

--- a/frontend/src/translations/it.json
+++ b/frontend/src/translations/it.json
@@ -263,6 +263,11 @@
     "credit": "Credito foto:",
     "displayPicture": "Sfoglia foto"
   },
+  "attachments": {
+    "title": "{count, plural, =0 {Allegato} one {Allegato} other {Allegati}}",
+    "credit": "Credito:",
+    "download": "Scarica"
+  },
   "Wind": {
     "N": "Nord",
     "S": "Sud",

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -107,7 +107,6 @@ module.exports = {
       },
       borderRadius: {
         button: '8px',
-        card: '16px',
         chip: '20px',
         large: '10px',
         medium: '4px',


### PR DESCRIPTION
- Display Files from attachments for Trek, OutdoorSite, TouristicContent, and POIs objects in Trek, OutdoorSite, TouristicContent details page.
- Put them in the "Medias" section (with ViewPointsHD)
- Define default media anchor display settings to true