### PR TITLE
Add a config to display or not secondary layers by default

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -181,6 +181,7 @@ NB: For "report" and "reservationWidget" sections with `anchors` set to `true`, 
   - `searchMapCenter`: Array of two numbers `[latitude, longitude]` defining the map center point in the search view,
   - `searchMapZoom`: Default value is `10`. It defines the zoom level in the search view. **Warning**: It is important that the `searchMapZoom` value is included in the zoom value range of the basemap (`minZoom` and `maxZoom`), otherwise it may generate an error.
   - `maximumZoomLevel`: Default value is `17`. The default maximum zoom level if the maxZoom option is not defined in map layer (see below)
+  - `displaySecondaryLayersByDefault`: Default value is `true`. Display or not display secondary layers (signages, infractructures and services) at page load on detail pages.
 
   You can also update the map layers. Three types of map layers are available: classic, satellite and offline. Each of them is structured as follows:
 

--- a/frontend/config/map.json
+++ b/frontend/config/map.json
@@ -25,5 +25,6 @@
     }
   },
   "zoomAvailableOffline": [13, 14, 15],
-  "mobileMapPanelDefaultOpened": false
+  "mobileMapPanelDefaultOpened": false,
+  "displaySecondaryLayersByDefault": true
 }

--- a/frontend/src/components/Map/DetailsMap/useDetailsMap.tsx
+++ b/frontend/src/components/Map/DetailsMap/useDetailsMap.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { getMapConfig } from '../config';
 
 export type Visibility = 'DISPLAYED' | 'HIDDEN' | null;
 
@@ -6,6 +7,9 @@ const toggleVisibility = (currentVisibility: Visibility) =>
   currentVisibility === 'DISPLAYED' ? 'HIDDEN' : 'DISPLAYED';
 
 export const useDetailsMap = () => {
+  const { displaySecondaryLayersByDefault } = getMapConfig();
+  const displaySecondaryLayers = displaySecondaryLayersByDefault ? 'DISPLAYED' : 'HIDDEN';
+
   const [trekChildrenMobileVisibility, setTrekChildrenVisibility] = useState<Visibility>('HIDDEN');
   const [poiMobileVisibility, setPoiVisibility] = useState<Visibility>('HIDDEN');
   const [referencePointsMobileVisibility, setReferencePointsVisibility] =
@@ -18,9 +22,10 @@ export const useDetailsMap = () => {
 
   const [coursesVisibility, setCoursesVisibility] = useState<Visibility>('HIDDEN');
   const [experiencesVisibility, setExperiencesVisibility] = useState<Visibility>('HIDDEN');
-  const [signageVisibility, setSignageVisibility] = useState<Visibility>('HIDDEN');
-  const [serviceVisibility, setServiceVisibility] = useState<Visibility>('HIDDEN');
-  const [infrastructureVisibility, setInfrastructureVisibility] = useState<Visibility>('HIDDEN');
+  const [signageVisibility, setSignageVisibility] = useState<Visibility>(displaySecondaryLayers);
+  const [serviceVisibility, setServiceVisibility] = useState<Visibility>(displaySecondaryLayers);
+  const [infrastructureVisibility, setInfrastructureVisibility] =
+    useState<Visibility>(displaySecondaryLayers);
   const [viewPointVisibility, setViewPointVisibility] = useState<Visibility>('HIDDEN');
   const [annotationViewpointVisibility, setAnnotationViewpointVisibility] =
     useState<Visibility>('DISPLAYED');

--- a/frontend/src/components/Map/interface.ts
+++ b/frontend/src/components/Map/interface.ts
@@ -14,4 +14,5 @@ export interface MapConfig {
   mapOfflineLayer: TileLayer;
   zoomAvailableOffline?: number[];
   mobileMapPanelDefaultOpened: boolean;
+  displaySecondaryLayersByDefault: boolean;
 }


### PR DESCRIPTION
- [x] Ticket : [ Fiches détails - Pouvoir afficher les couches secondaires par défaut sur les cartes (Infos, signalétique, aménagements) #997](https://github.com/GeotrekCE/Geotrek-rando-v3/issues/997)
