### PR TITLE
Reduce images gray haze on menuItems and flatpage children cards

### DIFF
--- a/frontend/src/components/Header/BurgerMenuSection/BurgerMenuSection.tsx
+++ b/frontend/src/components/Header/BurgerMenuSection/BurgerMenuSection.tsx
@@ -102,7 +102,7 @@ const MobileMenuItem = ({
         className={cn(
           'flex hover:text-primary3 focus:text-primary3 transition',
           hasThumbnail &&
-            "relative rounded-xl overflow-hidden group after:absolute after:inset-0 after:content-[''] after:bg-black/25",
+            "relative rounded-xl overflow-hidden group after:absolute after:content-[''] after:right-0 after:bottom-0 after:left-0 after:h-1/2 after:bg-gradient-to-t after:from-blackSemiTransparent after:via-blackSemiTransparent",
         )}
         onClick={handleCloseMenu}
       >

--- a/frontend/src/components/InlineMenu/Menu.tsx
+++ b/frontend/src/components/InlineMenu/Menu.tsx
@@ -124,7 +124,7 @@ export const Menu: React.FC<MenuProps> = ({
                         key={item.id}
                         item={item}
                         className={
-                          "relative rounded-xl overflow-hidden group after:absolute after:inset-0 after:content-[''] after:bg-black/25"
+                          "relative rounded-xl overflow-hidden group after:absolute after:content-[''] after:right-0 after:bottom-0 after:left-0 after:h-1/2 after:bg-gradient-to-t after:from-blackSemiTransparent after:via-blackSemiTransparent"
                         }
                       >
                         <Image

--- a/frontend/src/components/pages/flatPage/FlatPage.tsx
+++ b/frontend/src/components/pages/flatPage/FlatPage.tsx
@@ -153,7 +153,7 @@ export const FlatPageUI: React.FC<FlatPageUIProps> = ({ flatPageUrl }) => {
                   {flatPage.children.map(child => (
                     <li key={child.id}>
                       <a
-                        className="relative block aspect-square rounded-xl overflow-hidden group after:absolute bg-gradient-to-t from-blackSemiTransparent via-to-transparent to-transparent after:inset-0 after:content-[''] after:bg-black/25"
+                        className="relative block aspect-square rounded-xl overflow-hidden group after:absolute after:content-[''] after:right-0 after:bottom-0 after:left-0 after:h-1/2 after:bg-gradient-to-t after:from-blackSemiTransparent after:via-blackSemiTransparent"
                         href={generateFlatPageUrl(child.id, child.title)}
                       >
                         <Image


### PR DESCRIPTION
## Image from menuItems

Before:
![image](https://github.com/GeotrekCE/Geotrek-rando-v3/assets/1926041/1f522642-a2a5-4c28-88b4-1cc5939d1e1f)



After: 
![image](https://github.com/GeotrekCE/Geotrek-rando-v3/assets/1926041/45df0d2e-99aa-471b-9aa8-24b689f192d3)


## Image from flatPage children cards

Before:
![image](https://github.com/GeotrekCE/Geotrek-rando-v3/assets/1926041/b6ee86b9-006f-4f64-8845-f8b8fc07a41c)


After: 
![image](https://github.com/GeotrekCE/Geotrek-rando-v3/assets/1926041/23c735dc-7c79-4b2d-b5fc-218bc27c7e95)

