### PR TITLE
Prevent HP video from displaying full-screen on IOS devices

### DIFF
--- a/frontend/src/components/pages/home/components/BannerWithAsset/BannerWithAsset.tsx
+++ b/frontend/src/components/pages/home/components/BannerWithAsset/BannerWithAsset.tsx
@@ -49,6 +49,7 @@ export const BannerWithAsset: React.FC<BannerSectionProps> = ({
           autoPlay
           muted
           loop
+          playsInline
           src={videoUrl}
           className="object-cover object-center overflow-hidden h-bannerSectionMobile desktop:h-bannerSectionDesktop w-full"
           data-testid="video"

--- a/frontend/src/components/pages/home/components/BannerWithAsset/__tests__/__snapshots__/BannerWithAsset.test.tsx.snap
+++ b/frontend/src/components/pages/home/components/BannerWithAsset/__tests__/__snapshots__/BannerWithAsset.test.tsx.snap
@@ -445,6 +445,7 @@ Object {
           data-testid="video"
           id="banner-video"
           loop=""
+          playsinline=""
           src="test.mp4"
         />
         <div
@@ -470,6 +471,7 @@ Object {
         data-testid="video"
         id="banner-video"
         loop=""
+        playsinline=""
         src="test.mp4"
       />
       <div


### PR DESCRIPTION
ref https://github.com/GeotrekCE/Geotrek-rando-v3/issues/1178
