### PR TITLE
Upgrade leaflet locate control

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -56,7 +56,7 @@
     "leaflet": "^1.7.1",
     "leaflet-boundary-canvas": "^1.0.0",
     "leaflet-rastercoords": "^1.0.5",
-    "leaflet.locatecontrol": "0.74.0",
+    "leaflet.locatecontrol": "^0.81.1",
     "leaflet.offline": "^3.0.1",
     "next": "^13.1.6",
     "next-compose-plugins": "^2.2.1",

--- a/frontend/src/components/Map/DetailsMap/DetailsMap.tsx
+++ b/frontend/src/components/Map/DetailsMap/DetailsMap.tsx
@@ -47,6 +47,7 @@ import FullscreenControl from '../components/FullScreenControl';
 import ViewPointHD from '../components/ViewPointHD';
 import { CRSPixel } from '../components/ViewPointHD/CRSPixel';
 import { AnnotationList } from '../components/ViewPointHD/AnnotationList';
+import LocateControl from '../components/LocateControl';
 
 export interface GeometryListProps {
   geometry:
@@ -314,6 +315,7 @@ export const DetailsMap: React.FC<PropsType> = props => {
               viewPointVisibility={viewPointVisibility}
               setMapId={props.setMapId}
             />
+            <LocateControl />
             {props.displayAltimetricProfile === true && props.trekGeoJSON && (
               <AltimetricProfile id="altimetric-profile" trekGeoJSON={props.trekGeoJSON} />
             )}

--- a/frontend/src/components/Map/DetailsMap/DetailsMap.tsx
+++ b/frontend/src/components/Map/DetailsMap/DetailsMap.tsx
@@ -146,7 +146,7 @@ export const DetailsMap: React.FC<PropsType> = props => {
 
   const mapToDisplay = props.viewPoints?.find(({ id }) => id === props.mapId) ?? 'default';
 
-  const { map, setMapInstance } = useTileLayer(props.trekId, bounds, mapToDisplay);
+  const { map, setMapInstance } = useTileLayer(props.trekId, bounds);
 
   useEffect(() => {
     if (map && center) {

--- a/frontend/src/components/Map/SearchMap/index.tsx
+++ b/frontend/src/components/Map/SearchMap/index.tsx
@@ -13,6 +13,7 @@ import { FilterButton } from '../components/FilterButton';
 import { ResetView } from '../components/ResetView';
 import TileLayerManager from '../components/TileLayerManager';
 import FullscreenControl from '../components/FullScreenControl';
+import LocateControl from '../components/LocateControl';
 
 export type PropsType = {
   segments?: { x: number; y: number }[];
@@ -45,6 +46,7 @@ const SearchMap: React.FC<PropsType> = props => {
       {props.hasZoomControl === true && <FullscreenControl />}
       <ResetView />
       <ScaleControl />
+      <LocateControl />
       <SearchMapChildrens {...props} />
     </MapContainer>
   );

--- a/frontend/src/components/Map/components/LocateControl/index.tsx
+++ b/frontend/src/components/Map/components/LocateControl/index.tsx
@@ -1,0 +1,41 @@
+import { useEffect } from 'react';
+import { useMap } from 'react-leaflet';
+import { useIntl } from 'react-intl';
+
+import 'leaflet.locatecontrol';
+import 'leaflet.locatecontrol/dist/L.Control.Locate.min.css';
+import L from 'leaflet';
+
+const LocateControl = ({ position = 'bottomright' }) => {
+  const map = useMap();
+  const intl = useIntl();
+
+  useEffect(() => {
+    if (!map) {
+      return;
+    }
+
+    // @ts-expect-error no type available in this plugin
+    const locateControl = L.control.locate({
+      locateOptions: {
+        enableHighAccuracy: true,
+      },
+      icon: 'gg-track',
+      strings: {
+        title: intl.formatMessage({ id: 'search.map.seeMe' }),
+      },
+      position,
+    });
+
+    locateControl.addTo(map);
+
+    return () => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      map.removeControl(locateControl);
+    };
+  }, [intl, map, position]);
+
+  return null;
+};
+
+export default LocateControl;

--- a/frontend/src/hooks/useTileLayer.ts
+++ b/frontend/src/hooks/useTileLayer.ts
@@ -1,46 +1,23 @@
-import L, { LatLngBoundsExpression } from 'leaflet';
+import { LatLngBoundsExpression } from 'leaflet';
 import { Map } from 'leaflet';
 import { useState } from 'react';
-import { useIntl } from 'react-intl';
 
-require('leaflet.locatecontrol');
-import 'leaflet.locatecontrol/dist/L.Control.Locate.min.css';
 import injectOfflineMode from 'services/offline/injectOfflineMode';
-import { ViewPoint } from 'modules/viewPoint/interface';
 
 export const useTileLayer = (
   id?: number,
   center?: LatLngBoundsExpression | null,
-  mapToDisplay: ViewPoint | 'default' = 'default',
 ): {
   map: Map | null;
   setMapInstance: (newMap: Map) => void;
 } => {
   const [map, setMap] = useState<Map | null>(null);
 
-  const intl = useIntl();
-
   const setMapInstance = (newMap: Map) => {
     setMap(newMap);
 
     if (id !== undefined && center) {
       injectOfflineMode(newMap, id, center);
-    }
-
-    if (mapToDisplay === 'default') {
-      L.control
-        // @ts-expect-error no type available in this plugin
-        .locate({
-          locateOptions: {
-            enableHighAccuracy: true,
-          },
-          icon: 'gg-track',
-          strings: {
-            title: intl.formatMessage({ id: 'search.map.seeMe' }),
-          },
-          position: 'bottomright',
-        })
-        .addTo(newMap);
     }
   };
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -8366,10 +8366,10 @@ leaflet.fullscreen@2.4.0:
   resolved "https://registry.yarnpkg.com/leaflet.fullscreen/-/leaflet.fullscreen-2.4.0.tgz#8503c69b6f6afe6f54594c9cdd5e4f131cfa97b4"
   integrity sha512-41O0ikdUR0bVC0QfoFN3W5S+9yoeHqL74i0QQafa/W79+ij/G7IRZwpfwPuxoNwpydoUJ/9Mq/6Hp7WZOnkWzQ==
 
-leaflet.locatecontrol@0.74.0:
-  version "0.74.0"
-  resolved "https://registry.yarnpkg.com/leaflet.locatecontrol/-/leaflet.locatecontrol-0.74.0.tgz#a62153a0de5e05ef7efd73df7247a23060330fd7"
-  integrity sha512-Rs4u2ZH9SeEB4IBLhBT3yPWaN81CtFq4XWT6gTCZeqVOImMJKpwqkVn9FKxge9Z5JFBRJHFFquYEdwR3mxgHxg==
+leaflet.locatecontrol@^0.81.1:
+  version "0.81.1"
+  resolved "https://registry.yarnpkg.com/leaflet.locatecontrol/-/leaflet.locatecontrol-0.81.1.tgz#8aec3124ef5cdda3476fd9013315789b4e301a45"
+  integrity sha512-ZtsdScGufPw330X3UIaGGjnfQ1NrhLySnlruWufIMnfzsHgQPz0+mSxsCQMVh7QgOBoefCGb/lioSejiaNx1EQ==
 
 leaflet.markercluster@^1.4.1:
   version "1.4.1"


### PR DESCRIPTION
- Bump leaflet.locatecontrol from 0.74.0 to 0.81.1
- Refacto to use the leaflet locate.control in a more “react” way.