### PR TITLE
Build "Show More" menu items only if there are enough

### DIFF
--- a/frontend/src/components/InlineMenu/Menu.tsx
+++ b/frontend/src/components/InlineMenu/Menu.tsx
@@ -24,7 +24,10 @@ export const Menu: React.FC<MenuProps> = ({
 }) => {
   const intl = useIntl();
   const items = useMemo(() => {
-    if (menuItems.some(({ children = [] }) => children.length)) {
+    if (
+      menuItems.length < primaryItemsNumber ||
+      menuItems.some(({ children = [] }) => children.length)
+    ) {
       return menuItems;
     }
     // If there are no children, we use "primaryItemsNumber" to split menu with "See More" button


### PR DESCRIPTION
The “show more” menu button is added when there are no hierarchical items in menuItems. It takes the `primaryItemsNumber` parameters defined in `header.json` to divide the menu.

But when the list of items is less than `primaryItemsNumber` value, the show more button appears without any sub-items.

