### PR TITLE
Fix geometry color of sensitiveAreas

### DIFF
--- a/frontend/src/components/Map/DetailsMap/SensitiveAreas.tsx
+++ b/frontend/src/components/Map/DetailsMap/SensitiveAreas.tsx
@@ -36,11 +36,13 @@ export const SensitiveAreas: React.FC<PropsType> = ({ contents }) => {
     return null;
   }
 
-  return (
-    <>
-      {polygons.map(({ positions, color }, i) => {
-        return <Polygon color={color} key={`sensitiveArea${i}`} positions={positions} weight={3} />;
-      })}
-    </>
-  );
+  return polygons.map(({ positions, color }) => (
+    <Polygon
+      className={`bg-${color}`}
+      color="currentColor"
+      key={color}
+      positions={positions}
+      weight={3}
+    />
+  ));
 };


### PR DESCRIPTION
Define rights colors in the map of geometries related to senstivieAreas

Regression since [3.22.0](https://github.com/GeotrekCE/Geotrek-rando-v3/releases/tag/v3.22.0)