### PR TITLE
Call resizeObserver polyfill for useResizeObserver hook

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "@20tab/react-leaflet-resetview": "^1.1.0",
     "@hcaptcha/react-hcaptcha": "^1.4.4",
+    "@juggle/resize-observer": "^3.4.0",
     "@makina-corpus/rando3d": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.1",
     "@raruto/leaflet-elevation": "1.9.0",

--- a/frontend/src/hooks/useSize.ts
+++ b/frontend/src/hooks/useSize.ts
@@ -1,5 +1,6 @@
 import { MutableRefObject, RefObject, useState } from 'react';
 import useResizeObserver from '@react-hook/resize-observer';
+import { ResizeObserver } from '@juggle/resize-observer';
 import useIsomorphicLayoutEffect from './useIsomorphicLayoutEffect';
 
 const useSize = (target: MutableRefObject<HTMLElement | null | undefined>) => {
@@ -9,7 +10,9 @@ const useSize = (target: MutableRefObject<HTMLElement | null | undefined>) => {
     setSize(target.current?.getBoundingClientRect() ?? null);
   }, [target]);
 
-  useResizeObserver(target as RefObject<HTMLElement>, entry => setSize(entry.contentRect ?? null));
+  useResizeObserver(target as RefObject<HTMLElement>, entry => setSize(entry.contentRect ?? null), {
+    polyfill: ResizeObserver,
+  });
   return size;
 };
 

--- a/frontend/src/hooks/useSize.ts
+++ b/frontend/src/hooks/useSize.ts
@@ -1,6 +1,6 @@
 import { MutableRefObject, RefObject, useState } from 'react';
 import useResizeObserver from '@react-hook/resize-observer';
-import { ResizeObserver } from '@juggle/resize-observer';
+import { ResizeObserver as ResizeObserverPolyfill } from '@juggle/resize-observer';
 import useIsomorphicLayoutEffect from './useIsomorphicLayoutEffect';
 
 const useSize = (target: MutableRefObject<HTMLElement | null | undefined>) => {
@@ -11,7 +11,7 @@ const useSize = (target: MutableRefObject<HTMLElement | null | undefined>) => {
   }, [target]);
 
   useResizeObserver(target as RefObject<HTMLElement>, entry => setSize(entry.contentRect ?? null), {
-    polyfill: ResizeObserver,
+    polyfill: ResizeObserverPolyfill,
   });
   return size;
 };

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2279,6 +2279,11 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@juggle/resize-observer@^3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.4.0.tgz#08d6c5e20cf7e4cc02fd181c4b0c225cd31dbb60"
+  integrity sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==
+
 "@makina-corpus/rando3d@^1.3.3":
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@makina-corpus/rando3d/-/rando3d-1.3.3.tgz#9cf8edc8908a65d963735dc63b976aa99ac53751"
@@ -11127,7 +11132,7 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -11153,15 +11158,6 @@ string-width@^4.2.2:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
-
-string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -11276,7 +11272,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -11289,13 +11285,6 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
-
-strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -12673,7 +12662,7 @@ workbox-window@6.5.4, workbox-window@^6.5.4:
     "@types/trusted-types" "^2.0.2"
     workbox-core "6.5.4"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -12686,15 +12675,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
In the [previous PR](https://github.com/GeotrekCE/Geotrek-rando-v3/pull/1312), we upgraded `@react-hook/resize-observer` package.

Its latest version removed a `resize-observer` polyfill and we need it to run the application. 
