### PR TITLE
Serve Assistant font locally

### DIFF
--- a/frontend/src/components/pages/_app/Root.tsx
+++ b/frontend/src/components/pages/_app/Root.tsx
@@ -1,5 +1,6 @@
 import getNextConfig from 'next/config';
 import Head from 'next/head';
+import { Assistant } from 'next/font/google';
 import { IntlProvider } from 'react-intl';
 import { getGlobalConfig } from 'modules/utils/api.config';
 import { getDefaultLanguage } from 'modules/header/utills';
@@ -15,6 +16,12 @@ interface Messages {
 const {
   publicRuntimeConfig: { locales },
 } = getNextConfig();
+
+const assistant = Assistant({
+  weight: ['400', '600', '700'],
+  subsets: ['latin'],
+  display: 'swap',
+});
 
 export const Root: React.FC<React.PropsWithChildren> = props => {
   const router = useRouter();
@@ -54,6 +61,12 @@ export const Root: React.FC<React.PropsWithChildren> = props => {
           name="viewport"
           content="minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no, user-scalable=no, viewport-fit=cover"
         />
+
+        <style>{`
+          :root {
+            --font-assistant: ${assistant.style.fontFamily};
+          }
+        `}</style>
       </Head>
       {props.children}
     </IntlProvider>

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -5,7 +5,6 @@ import { HydrationBoundary, QueryClient, QueryClientProvider } from '@tanstack/r
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { ONE_MINUTE } from 'services/constants/staleTime';
 import '../styles/global.css';
-import '../public/fonts.css';
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
 import 'orejime/dist/orejime.css';

--- a/frontend/src/public/fonts.css
+++ b/frontend/src/public/fonts.css
@@ -1,1 +1,0 @@
-@import url('https://fonts.googleapis.com/css?family=Assistant:100,200,300,400,500,600,700,800,900&display=swap');

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -8,7 +8,17 @@ module.exports = {
       desktop: '1024px',
     },
     fontFamily: {
-      main: `'Assistant', 'Helvetica', 'Arial', sans-serif`,
+      main: [
+        'var(--font-assistant)',
+        '-apple-system',
+        'BlinkMacSystemFont',
+        'Segoe UI',
+        'Roboto',
+        'Helvetica Neue',
+        'ubuntu',
+        'Arial',
+        'sans-serif',
+      ],
       code: 'Monospace',
     },
     boxShadow: {


### PR DESCRIPTION
- Serve Assistant font locally instead of calling from https://fonts.googleapis.com/
- Improve font stack fallback
- Curiously fix https://github.com/GeotrekCE/Geotrek-rando-v3/issues/406
