### PR TITLE
Define "Source Sans 3" as main font instead of "Assistant"

### DIFF
--- a/docs/customization/customization-themestyles.md
+++ b/docs/customization/customization-themestyles.md
@@ -46,6 +46,18 @@ You can override CSS in `customization/theme/style.css` file. To help overriding
 
 In addition, some classes prefixed with `custo-*` are gradually being added to facilitate style overrides for components.
 
+The font used is `Source sans 3`. If you wish to replace it, you must modify the
+dedicated `--font-main` variable in the custom properties.  
+For example, if you want to use the `arial` typeface, put the following code in
+`customization/theme/style.css`.
+
+```css
+:root {
+  --font-main: arial;
+  font-size-adjust: 0.5; /* Arial is bigger than Source sans 3 */
+}
+```
+
 !!! note
     
     **Explanations and differents styling for the main menu**

--- a/frontend/src/components/pages/_app/Root.tsx
+++ b/frontend/src/components/pages/_app/Root.tsx
@@ -1,6 +1,6 @@
 import getNextConfig from 'next/config';
 import Head from 'next/head';
-import { Assistant } from 'next/font/google';
+import { Source_Sans_3 } from 'next/font/google';
 import { IntlProvider } from 'react-intl';
 import { getGlobalConfig } from 'modules/utils/api.config';
 import { getDefaultLanguage } from 'modules/header/utills';
@@ -17,7 +17,7 @@ const {
   publicRuntimeConfig: { locales },
 } = getNextConfig();
 
-const assistant = Assistant({
+const font = Source_Sans_3({
   weight: ['400', '600', '700'],
   subsets: ['latin'],
   display: 'swap',
@@ -64,7 +64,7 @@ export const Root: React.FC<React.PropsWithChildren> = props => {
 
         <style>{`
           :root {
-            --font-assistant: ${assistant.style.fontFamily};
+            --font-main: ${font.style.fontFamily};
           }
         `}</style>
       </Head>

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -9,7 +9,7 @@ module.exports = {
     },
     fontFamily: {
       main: [
-        'var(--font-assistant)',
+        'var(--font-main)',
         '-apple-system',
         'BlinkMacSystemFont',
         'Segoe UI',


### PR DESCRIPTION
Assistant shows some issues with "j" and "Ç" letters for example (see https://github.com/GeotrekCE/Geotrek-rando-v3/issues/406)
And the both fonts looks very similar 
![image](https://github.com/user-attachments/assets/89b7ac8c-6c5d-46a8-9cb2-df3dc1b55f9d)
(on the left: Assistant ; on the right: Source sans 3)