### PR TITLE
Define googleSiteVerificationToken settings to null in default config

### DIFF
--- a/frontend/config/global.json
+++ b/frontend/config/global.json
@@ -11,7 +11,7 @@
   "reservationPartner": null,
   "reservationProject": null,
   "googleAnalyticsId": null,
-  "googleSiteVerificationToken": "eKAyxwaXAobFWQcJen0mnZ8T3CpLoN45JysXeNkRf38",
+  "googleSiteVerificationToken": null,
   "baseUrl": "http://127.0.0.1:3000",
   "fallbackImageUri": "https://upload.wikimedia.org/wikipedia/fr/d/df/Logo_ecrins.png",
   "touristicContentLabelImageUri": "https://upload.wikimedia.org/wikipedia/fr/d/df/Logo_ecrins.png",


### PR DESCRIPTION
This shouldn't be set in the default configuration; I have absolutely no idea what this value corresponds to.
Maybe we can deprecate this setting and define this kind of `<meta>` tag in the `scriptsHeader.html`